### PR TITLE
Add health diagnostics to endpoints and transports

### DIFF
--- a/packages/rpc_dart/CHANGELOG.md
+++ b/packages/rpc_dart/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.3.0
+
+- Added health() and reconnect() APIs for endpoints and transports.
+- Added health diagnostics for RpcInMemoryTransport and RpcTransportRouter.
+- Updated documentation with health monitoring examples.
+
 # Changelog
 
 ## 2.2.2

--- a/packages/rpc_dart/README.md
+++ b/packages/rpc_dart/README.md
@@ -25,6 +25,7 @@
 - RpcInMemoryTransport with zero-copy support for in-process object transfer.
 - Data transfer modes: zeroCopy, codec, auto (recommended).
 - RpcContext carries trace id and headers.
+- Endpoint and transport diagnostics via `health()` and `reconnect()` APIs.
 - Built-in primitive wrappers: RpcString, RpcInt, RpcDouble, RpcBool, RpcList.
 - Pure Dart, no external dependencies.
 - Easy testing with InMemory transport and mocks.
@@ -105,6 +106,21 @@ void main() async {
   await callerEndpoint.close();
   await responderEndpoint.close();
 }
+```
+
+### Health monitoring
+
+RPC endpoints expose aggregated diagnostics that combine endpoint state and
+transport status. Use `health()` to retrieve a snapshot and `reconnect()` to
+delegate recovery to the underlying transport:
+
+```dart
+final report = await callerEndpoint.health();
+if (!report.isHealthy) {
+  print('Transport issue: ${report.transportStatus?.message}');
+}
+
+await callerEndpoint.reconnect();
 ```
 
 #### Data transfer modes

--- a/packages/rpc_dart/benchmark/benchmark.dart
+++ b/packages/rpc_dart/benchmark/benchmark.dart
@@ -178,18 +178,22 @@ class ProgressIndicator {
     final filled = (percentage * barWidth / 100).round();
     final bar = '█' * filled + '░' * (barWidth - filled);
 
-    stdout.write('\r   [$bar] $percentage% | '
-        '$_current/$total | '
-        '${rate.toStringAsFixed(1)} ops/s | '
-        'ETA: ${eta.toStringAsFixed(1)}s     ');
+    stdout.write(
+      '\r   [$bar] $percentage% | '
+      '$_current/$total | '
+      '${rate.toStringAsFixed(1)} ops/s | '
+      'ETA: ${eta.toStringAsFixed(1)}s     ',
+    );
   }
 
   void complete() {
     _stopwatch.stop();
     final rate = total / (_stopwatch.elapsedMilliseconds / 1000);
-    stdout.write('\r   ✅ $operation completed: $total operations in '
-        '${_stopwatch.elapsedMilliseconds / 1000}s '
-        '(${rate.toStringAsFixed(1)} ops/s)\n');
+    stdout.write(
+      '\r   ✅ $operation completed: $total operations in '
+      '${_stopwatch.elapsedMilliseconds / 1000}s '
+      '(${rate.toStringAsFixed(1)} ops/s)\n',
+    );
   }
 }
 
@@ -262,27 +266,37 @@ class TestDataGenerator {
           'entity': {
             'id': _random.nextInt(100000),
             'type': 'enterprise_entity',
-            'attributes': Map.fromEntries(List.generate(
-                20, (i) => MapEntry('attr_$i', _random.nextDouble() * 1000))),
+            'attributes': Map.fromEntries(
+              List.generate(
+                20,
+                (i) => MapEntry('attr_$i', _random.nextDouble() * 1000),
+              ),
+            ),
             'relations': List.generate(
-                10,
-                (i) => {
-                      'id': _random.nextInt(1000),
-                      'type': 'relation_$i',
-                      'weight': _random.nextDouble(),
-                    }),
+              10,
+              (i) => {
+                'id': _random.nextInt(1000),
+                'type': 'relation_$i',
+                'weight': _random.nextDouble(),
+              },
+            ),
           },
           'analytics': {
-            'metrics': Map.fromEntries(List.generate(50,
-                (i) => MapEntry('metric_$i', _random.nextDouble() * 10000))),
+            'metrics': Map.fromEntries(
+              List.generate(
+                50,
+                (i) => MapEntry('metric_$i', _random.nextDouble() * 10000),
+              ),
+            ),
             'trends': List.generate(100, (i) => _random.nextDouble() * 100),
             'segments': List.generate(
-                20,
-                (i) => {
-                      'name': 'segment_$i',
-                      'size': _random.nextInt(10000),
-                      'conversion': _random.nextDouble(),
-                    }),
+              20,
+              (i) => {
+                'name': 'segment_$i',
+                'size': _random.nextInt(10000),
+                'conversion': _random.nextDouble(),
+              },
+            ),
           },
           'metadata': {
             'version': '1.0.0',
@@ -330,8 +344,10 @@ final class TestRpcContract extends RpcResponderContract {
     );
   }
 
-  Future<TestResponse> _processRequest(TestRequest request,
-      {RpcContext? context}) async {
+  Future<TestResponse> _processRequest(
+    TestRequest request, {
+    RpcContext? context,
+  }) async {
     final start = DateTime.now();
 
     // Симулируем обработку
@@ -351,8 +367,10 @@ final class TestRpcContract extends RpcResponderContract {
     );
   }
 
-  Stream<TestResponse> _streamResponses(TestRequest request,
-      {RpcContext? context}) async* {
+  Stream<TestResponse> _streamResponses(
+    TestRequest request, {
+    RpcContext? context,
+  }) async* {
     for (int i = 0; i < 5; i++) {
       yield TestResponse(
         requestId: request.id,
@@ -363,8 +381,10 @@ final class TestRpcContract extends RpcResponderContract {
     }
   }
 
-  Future<TestResponse> _collectRequests(Stream<TestRequest> requests,
-      {RpcContext? context}) async {
+  Future<TestResponse> _collectRequests(
+    Stream<TestRequest> requests, {
+    RpcContext? context,
+  }) async {
     final start = DateTime.now();
     final collected = <String>[];
 
@@ -383,8 +403,10 @@ final class TestRpcContract extends RpcResponderContract {
     );
   }
 
-  Stream<TestResponse> _processStream(Stream<TestRequest> requests,
-      {RpcContext? context}) async* {
+  Stream<TestResponse> _processStream(
+    Stream<TestRequest> requests, {
+    RpcContext? context,
+  }) async* {
     await for (final request in requests) {
       await Future.delayed(Duration(microseconds: 25));
 
@@ -403,32 +425,40 @@ final class TestRpcCallerContract extends RpcCallerContract {
   TestRpcCallerContract(RpcCallerEndpoint endpoint)
       : super('TestService', endpoint);
 
-  Future<TestResponse> processRequest(TestRequest request,
-          {RpcContext? context}) =>
+  Future<TestResponse> processRequest(
+    TestRequest request, {
+    RpcContext? context,
+  }) =>
       callUnary<TestRequest, TestResponse>(
         methodName: 'processRequest',
         request: request,
         context: context,
       );
 
-  Stream<TestResponse> streamResponses(TestRequest request,
-          {RpcContext? context}) =>
+  Stream<TestResponse> streamResponses(
+    TestRequest request, {
+    RpcContext? context,
+  }) =>
       callServerStream<TestRequest, TestResponse>(
         methodName: 'streamResponses',
         request: request,
         context: context,
       );
 
-  Future<TestResponse> collectRequests(Stream<TestRequest> requests,
-          {RpcContext? context}) =>
+  Future<TestResponse> collectRequests(
+    Stream<TestRequest> requests, {
+    RpcContext? context,
+  }) =>
       callClientStream<TestRequest, TestResponse>(
         methodName: 'collectRequests',
         requests: requests,
         context: context,
       );
 
-  Stream<TestResponse> processStream(Stream<TestRequest> requests,
-          {RpcContext? context}) =>
+  Stream<TestResponse> processStream(
+    Stream<TestRequest> requests, {
+    RpcContext? context,
+  }) =>
       callBidirectionalStream<TestRequest, TestResponse>(
         methodName: 'processStream',
         requests: requests,
@@ -514,20 +544,25 @@ class ProfessionalBenchmarkStats {
     print('📊 === $category: $name ===');
     print('   Sample: ${latencies.length} measurements');
     print(
-        '   Mean: ${_formatMetric(mean, unit)} | Median: ${_formatMetric(median, unit)}');
+      '   Mean: ${_formatMetric(mean, unit)} | Median: ${_formatMetric(median, unit)}',
+    );
     print(
-        '   Min/Max: ${_formatMetric(min, unit)} / ${_formatMetric(max, unit)}');
+      '   Min/Max: ${_formatMetric(min, unit)} / ${_formatMetric(max, unit)}',
+    );
     print(
-        '   P95/P99: ${_formatMetric(p95, unit)} / ${_formatMetric(p99, unit)}');
+      '   P95/P99: ${_formatMetric(p95, unit)} / ${_formatMetric(p99, unit)}',
+    );
     print('   Throughput: ${throughputPerSecond.toStringAsFixed(0)} ops/sec');
     print(
-        '   Std Dev: ${_formatMetric(standardDeviation, unit)} (CV: ${(coefficientOfVariation * 100).toStringAsFixed(1)}%)');
+      '   Std Dev: ${_formatMetric(standardDeviation, unit)} (CV: ${(coefficientOfVariation * 100).toStringAsFixed(1)}%)',
+    );
 
     // Quality check
     final outliers = outlierAnalysis;
     if (outliers.total > 0) {
       print(
-          '   ⚠️  Outliers: ${outliers.total} (${outliers.percentage.toStringAsFixed(1)}%)');
+        '   ⚠️  Outliers: ${outliers.total} (${outliers.percentage.toStringAsFixed(1)}%)',
+      );
     }
 
     // Metadata
@@ -563,15 +598,8 @@ class ProfessionalBenchmarkStats {
           'std_dev': standardDeviation,
           'coefficient_of_variation': coefficientOfVariation,
         },
-        'percentiles': {
-          'p90': p90,
-          'p95': p95,
-          'p99': p99,
-          'p999': p999,
-        },
-        'performance': {
-          'throughput_ops_per_sec': throughputPerSecond,
-        },
+        'percentiles': {'p90': p90, 'p95': p95, 'p99': p99, 'p999': p999},
+        'performance': {'throughput_ops_per_sec': throughputPerSecond},
         'quality': {
           'outliers_count': outlierAnalysis.total,
           'outliers_percentage': outlierAnalysis.percentage,
@@ -639,27 +667,38 @@ class ProfessionalRpcBenchmark {
   void _printHeader() {
     print('');
     print(
-        '╔══════════════════════════════════════════════════════════════════════════════╗');
+      '╔══════════════════════════════════════════════════════════════════════════════╗',
+    );
     print(
-        '║                                                                              ║');
+      '║                                                                              ║',
+    );
     print(
-        '║    🚀 PROFESSIONAL RPC DART PERFORMANCE BENCHMARK SUITE 🚀                 ║');
+      '║    🚀 PROFESSIONAL RPC DART PERFORMANCE BENCHMARK SUITE 🚀                 ║',
+    );
     print(
-        '║                                                                              ║');
+      '║                                                                              ║',
+    );
     print(
-        '║    Comprehensive end-to-end RPC stack performance analysis                  ║');
+      '║    Comprehensive end-to-end RPC stack performance analysis                  ║',
+    );
     print(
-        '║    • Full RPC call lifecycle testing                                        ║');
+      '║    • Full RPC call lifecycle testing                                        ║',
+    );
     print(
-        '║    • Transport overhead analysis                                            ║');
+      '║    • Transport overhead analysis                                            ║',
+    );
     print(
-        '║    • Scalability and concurrency assessment                                 ║');
+      '║    • Scalability and concurrency assessment                                 ║',
+    );
     print(
-        '║    • Statistical analysis with outlier detection                            ║');
+      '║    • Statistical analysis with outlier detection                            ║',
+    );
     print(
-        '║                                                                              ║');
+      '║                                                                              ║',
+    );
     print(
-        '╚══════════════════════════════════════════════════════════════════════════════╝');
+      '╚══════════════════════════════════════════════════════════════════════════════╝',
+    );
     print('');
   }
 
@@ -719,7 +758,8 @@ class ProfessionalRpcBenchmark {
 
           // ignore: unused_local_variable
           final collected = await contract.collectRequests(
-              Stream.fromIterable([TestDataGenerator.generateSimple()]));
+            Stream.fromIterable([TestDataGenerator.generateSimple()]),
+          );
         } catch (e) {
           // Ignore warmup errors
         }
@@ -741,11 +781,20 @@ class ProfessionalRpcBenchmark {
 
     // Core RPC benchmarks
     await _benchmarkUnaryRpc(
-        contract, 'Simple Data', TestDataGenerator.generateSimple);
+      contract,
+      'Simple Data',
+      TestDataGenerator.generateSimple,
+    );
     await _benchmarkUnaryRpc(
-        contract, 'Medium Data', TestDataGenerator.generateMedium);
+      contract,
+      'Medium Data',
+      TestDataGenerator.generateMedium,
+    );
     await _benchmarkUnaryRpc(
-        contract, 'Complex Data', TestDataGenerator.generateComplex);
+      contract,
+      'Complex Data',
+      TestDataGenerator.generateComplex,
+    );
 
     // Streaming benchmarks
     await _benchmarkServerStream(contract);
@@ -767,7 +816,9 @@ class ProfessionalRpcBenchmark {
     final testData = dataGenerator();
     final latencies = <double>[];
     final progress = ProgressIndicator(
-        'Unary RPC - $dataType', config.measurementIterations);
+      'Unary RPC - $dataType',
+      config.measurementIterations,
+    );
 
     await _forceGc();
 
@@ -795,9 +846,7 @@ class ProfessionalRpcBenchmark {
       category: 'Unary RPC',
       latencies: latencies,
       unit: 'μs',
-      metadata: {
-        'data_type': dataType,
-      },
+      metadata: {'data_type': dataType},
     );
 
     stats.printProfessionalReport();
@@ -858,11 +907,14 @@ class ProfessionalRpcBenchmark {
 
     for (int i = 0; i < iterations; i++) {
       final requests = List.generate(
-          requestCount, (_) => TestDataGenerator.generateSimple());
+        requestCount,
+        (_) => TestDataGenerator.generateSimple(),
+      );
 
       final stopwatch = Stopwatch()..start();
-      final response =
-          await contract.collectRequests(Stream.fromIterable(requests));
+      final response = await contract.collectRequests(
+        Stream.fromIterable(requests),
+      );
       stopwatch.stop();
 
       latencies.add(stopwatch.elapsedMicroseconds.toDouble());
@@ -888,7 +940,8 @@ class ProfessionalRpcBenchmark {
 
   /// Benchmark bidirectional streaming
   Future<void> _benchmarkBidirectionalStream(
-      TestRpcCallerContract contract) async {
+    TestRpcCallerContract contract,
+  ) async {
     print('   🔄 Testing Bidirectional Stream RPC');
 
     final latencies = <double>[];
@@ -897,8 +950,10 @@ class ProfessionalRpcBenchmark {
     final progress = ProgressIndicator('Bidirectional Stream RPC', iterations);
 
     for (int i = 0; i < iterations; i++) {
-      final requests = Stream.periodic(Duration(microseconds: 100),
-          (index) => TestDataGenerator.generateSimple()).take(requestCount);
+      final requests = Stream.periodic(
+        Duration(microseconds: 100),
+        (index) => TestDataGenerator.generateSimple(),
+      ).take(requestCount);
 
       final stopwatch = Stopwatch()..start();
       final responses = await contract.processStream(requests).toList();
@@ -937,13 +992,17 @@ class ProfessionalRpcBenchmark {
       final latencies = <double>[];
       const iterationsPerConcurrency = 50;
       final progress = ProgressIndicator(
-          'Scalability $concurrency', iterationsPerConcurrency);
+        'Scalability $concurrency',
+        iterationsPerConcurrency,
+      );
 
       for (int i = 0; i < iterationsPerConcurrency; i++) {
         final stopwatch = Stopwatch()..start();
 
-        final futures = List.generate(concurrency,
-            (_) => contract.processRequest(TestDataGenerator.generateMedium()));
+        final futures = List.generate(
+          concurrency,
+          (_) => contract.processRequest(TestDataGenerator.generateMedium()),
+        );
 
         final responses = await Future.wait(futures);
         stopwatch.stop();
@@ -976,11 +1035,14 @@ class ProfessionalRpcBenchmark {
     _totalStopwatch.stop();
 
     print(
-        '╔══════════════════════════════════════════════════════════════════════════════╗');
+      '╔══════════════════════════════════════════════════════════════════════════════╗',
+    );
     print(
-        '║                           COMPREHENSIVE BENCHMARK REPORT                    ║');
+      '║                           COMPREHENSIVE BENCHMARK REPORT                    ║',
+    );
     print(
-        '╚══════════════════════════════════════════════════════════════════════════════╝');
+      '╚══════════════════════════════════════════════════════════════════════════════╝',
+    );
 
     // Summary statistics
     final groups = <String, List<ProfessionalBenchmarkStats>>{};
@@ -999,17 +1061,20 @@ class ProfessionalRpcBenchmark {
       print('   $category:');
       print('     • ${stats.length} test scenarios');
       print(
-          '     • Average throughput: ${avgThroughput.toStringAsFixed(0)} ops/sec');
+        '     • Average throughput: ${avgThroughput.toStringAsFixed(0)} ops/sec',
+      );
       print('     • Average latency: ${avgLatency.toStringAsFixed(1)} μs');
     });
 
     print('');
     print('⏱️  EXECUTION SUMMARY:');
     print(
-        '   • Total execution time: ${(_totalStopwatch.elapsedMilliseconds / 1000).toStringAsFixed(1)}s');
+      '   • Total execution time: ${(_totalStopwatch.elapsedMilliseconds / 1000).toStringAsFixed(1)}s',
+    );
     print('   • Tests completed: ${results.length}');
     print(
-        '   • Total measurements: ${results.map((r) => r.latencies.length).reduce((a, b) => a + b)}');
+      '   • Total measurements: ${results.map((r) => r.latencies.length).reduce((a, b) => a + b)}',
+    );
 
     await _exportResults();
 
@@ -1047,10 +1112,12 @@ class ProfessionalRpcBenchmark {
         },
       };
 
-      final resultsFile =
-          File('${config.outputDirectory}/rpc_benchmark_results.json');
-      await resultsFile
-          .writeAsString(JsonEncoder.withIndent('  ').convert(exportData));
+      final resultsFile = File(
+        '${config.outputDirectory}/rpc_benchmark_results.json',
+      );
+      await resultsFile.writeAsString(
+        JsonEncoder.withIndent('  ').convert(exportData),
+      );
 
       // Bencher.dev compatible format
       final bencherResults = <String, dynamic>{};
@@ -1068,10 +1135,12 @@ class ProfessionalRpcBenchmark {
         };
       }
 
-      final bencherFile =
-          File('${config.outputDirectory}/bencher_results.json');
-      await bencherFile
-          .writeAsString(JsonEncoder.withIndent('  ').convert(bencherResults));
+      final bencherFile = File(
+        '${config.outputDirectory}/bencher_results.json',
+      );
+      await bencherFile.writeAsString(
+        JsonEncoder.withIndent('  ').convert(bencherResults),
+      );
 
       print('   📄 Professional results: ${resultsFile.path}');
       print('   📊 Bencher.dev format: ${bencherFile.path}');
@@ -1084,8 +1153,9 @@ class ProfessionalRpcBenchmark {
   Future<void> _handleOutputFile() async {
     if (config.outputPath != null && config.outputPath!.endsWith('.json')) {
       try {
-        final sourceFile =
-            File('${config.outputDirectory}/rpc_benchmark_results.json');
+        final sourceFile = File(
+          '${config.outputDirectory}/rpc_benchmark_results.json',
+        );
         final targetFile = File(config.outputPath!);
 
         if (sourceFile.existsSync()) {

--- a/packages/rpc_dart/example/core_methods/bidirectional_stream_example.dart
+++ b/packages/rpc_dart/example/core_methods/bidirectional_stream_example.dart
@@ -51,7 +51,7 @@ class BidirectionalStreamExample {
         'время',
         'случайное число',
         'привет, мир!',
-        'завершить'
+        'завершить',
       ];
 
       final responses = <String>[];
@@ -78,7 +78,7 @@ class BidirectionalStreamExample {
       final secureMessages = [
         'admin:получить статус',
         'admin:получить пользователей',
-        'admin:выход'
+        'admin:выход',
       ];
 
       await client
@@ -94,8 +94,9 @@ class BidirectionalStreamExample {
       print('\n--- Пример 3: Чат с отменой ---');
 
       final cancellationToken = RpcCancellationToken();
-      final cancelContext = RpcContext.withCancellation(cancellationToken)
-          .withValue('chat-type', 'long-running');
+      final cancelContext = RpcContext.withCancellation(
+        cancellationToken,
+      ).withValue('chat-type', 'long-running');
 
       // Отменяем через 300мс
       Future.delayed(Duration(milliseconds: 300), () {
@@ -153,8 +154,10 @@ final class ChatServiceResponder extends RpcResponderContract
   }
 
   @override
-  Stream<RpcString> chatWithServer(Stream<RpcString> messages,
-      {RpcContext? context}) async* {
+  Stream<RpcString> chatWithServer(
+    Stream<RpcString> messages, {
+    RpcContext? context,
+  }) async* {
     final logger = RpcLogger('ChatWithServer');
     logger.info('🔧 Начинаем чат-сессию');
     logger.info('🔍 Context: $context');
@@ -243,8 +246,10 @@ final class ChatServiceCaller extends RpcCallerContract
       : super('ChatService', endpoint);
 
   @override
-  Stream<RpcString> chatWithServer(Stream<RpcString> messages,
-      {RpcContext? context}) {
+  Stream<RpcString> chatWithServer(
+    Stream<RpcString> messages, {
+    RpcContext? context,
+  }) {
     return callBidirectionalStream<RpcString, RpcString>(
       methodName: 'ChatWithServer',
       requestCodec: RpcString.codec,

--- a/packages/rpc_dart/example/core_methods/client_stream_example.dart
+++ b/packages/rpc_dart/example/core_methods/client_stream_example.dart
@@ -47,15 +47,16 @@ class ClientStreamingExample {
       // Пример 1: Базовая агрегация данных
       print('\n--- Пример 1: Агрегация текстовых сообщений ---');
 
-      final context1 = RpcContextUtils.withTracing(traceId: 'client-stream-123')
-          .withValue('aggregation-type', 'text');
+      final context1 = RpcContextUtils.withTracing(
+        traceId: 'client-stream-123',
+      ).withValue('aggregation-type', 'text');
 
       final messages = [
         'Сообщение 1: Привет',
         'Сообщение 2: Как дела?',
         'Сообщение 3: Это тест',
         'Сообщение 4: Клиентского',
-        'Сообщение 5: Стриминга!'
+        'Сообщение 5: Стриминга!',
       ];
 
       print('КЛИЕНТ: Отправляем ${messages.length} сообщений');
@@ -67,8 +68,10 @@ class ClientStreamingExample {
         return message;
       });
 
-      final result1 =
-          await client.aggregateMessages(messageStream, context: context1);
+      final result1 = await client.aggregateMessages(
+        messageStream,
+        context: context1,
+      );
       print('КЛИЕНТ: Результат агрегации: "${result1.value}"');
 
       // Пример 2: Агрегация с аутентификацией
@@ -77,14 +80,14 @@ class ClientStreamingExample {
       final authContext = RpcContextUtils.withBearerToken('aggregate-token-456')
           .withAdditionalHeaders({
         'client-version': '1.4.0',
-        'aggregation-format': 'structured'
+        'aggregation-format': 'structured',
       }).withTraceId('auth-aggregate-456');
 
       final secureMessages = [
         'admin:status',
         'admin:reports',
         'admin:analytics',
-        'admin:summary'
+        'admin:summary',
       ];
 
       final secureStream = Stream.fromIterable(secureMessages.map((m) => m.rpc))
@@ -94,17 +97,19 @@ class ClientStreamingExample {
         return message;
       });
 
-      final result2 =
-          await client.aggregateMessages(secureStream, context: authContext);
+      final result2 = await client.aggregateMessages(
+        secureStream,
+        context: authContext,
+      );
       print('КЛИЕНТ: Защищенный результат: "${result2.value}"');
 
       // Пример 3: Агрегация с отменой
       print('\n--- Пример 3: Агрегация с отменой ---');
 
       final cancellationToken = RpcCancellationToken();
-      final cancelContext = RpcContext.withCancellation(cancellationToken)
-          .withValue('batch-size', 100)
-          .withTraceId('cancel-aggregate-789');
+      final cancelContext = RpcContext.withCancellation(
+        cancellationToken,
+      ).withValue('batch-size', 100).withTraceId('cancel-aggregate-789');
 
       // Отменяем через 150мс
       Future.delayed(Duration(milliseconds: 150), () {
@@ -118,8 +123,10 @@ class ClientStreamingExample {
       ).take(10);
 
       try {
-        final result3 = await client.aggregateMessages(longMessages,
-            context: cancelContext);
+        final result3 = await client.aggregateMessages(
+          longMessages,
+          context: cancelContext,
+        );
         print('КЛИЕНТ: Результат отменённой агрегации: "${result3.value}"');
       } catch (e) {
         print('КЛИЕНТ: Агрегация отменена: $e');
@@ -128,21 +135,23 @@ class ClientStreamingExample {
       // Пример 4: Агрегация файлов
       print('\n--- Пример 4: Агрегация файлов ---');
 
-      final fileContext = RpcContext.withHeaders(
-              {'operation': 'file-processing', 'format': 'batch'})
-          .withTimeout(Duration(seconds: 5))
-          .withTraceId('file-aggregate-012');
+      final fileContext = RpcContext.withHeaders({
+        'operation': 'file-processing',
+        'format': 'batch',
+      }).withTimeout(Duration(seconds: 5)).withTraceId('file-aggregate-012');
 
       final fileMessages = [
         'file:document1.pdf',
         'file:image2.jpg',
         'file:data3.json',
-        'file:report4.xlsx'
+        'file:report4.xlsx',
       ];
 
       final fileStream = Stream.fromIterable(fileMessages.map((f) => f.rpc));
-      final result4 =
-          await client.aggregateMessages(fileStream, context: fileContext);
+      final result4 = await client.aggregateMessages(
+        fileStream,
+        context: fileContext,
+      );
       print('КЛИЕНТ: Результат обработки файлов: "${result4.value}"');
     } catch (e, stackTrace) {
       print('ОШИБКА: $e');
@@ -180,8 +189,10 @@ final class DataAggregatorResponder extends RpcResponderContract
   }
 
   @override
-  Future<RpcString> aggregateMessages(Stream<RpcString> messages,
-      {RpcContext? context}) async {
+  Future<RpcString> aggregateMessages(
+    Stream<RpcString> messages, {
+    RpcContext? context,
+  }) async {
     final logger = RpcLogger('AggregateMessages');
     logger.info('🔧 Начинаем агрегацию сообщений');
     logger.info('🔍 Context: $context');
@@ -192,8 +203,9 @@ final class DataAggregatorResponder extends RpcResponderContract
     final operation = context?.getHeader('operation');
     final authToken = context?.getHeader('authorization');
 
-    logger
-        .info('📊 Type: $aggregationType, Batch: $batchSize, Format: $format');
+    logger.info(
+      '📊 Type: $aggregationType, Batch: $batchSize, Format: $format',
+    );
 
     final receivedMessages = <String>[];
     int count = 0;
@@ -268,8 +280,10 @@ final class DataAggregatorCaller extends RpcCallerContract
       : super('DataAggregatorService', endpoint);
 
   @override
-  Future<RpcString> aggregateMessages(Stream<RpcString> messages,
-      {RpcContext? context}) {
+  Future<RpcString> aggregateMessages(
+    Stream<RpcString> messages, {
+    RpcContext? context,
+  }) {
     return callClientStream<RpcString, RpcString>(
       methodName: 'AggregateMessages',
       requestCodec: RpcString.codec,

--- a/packages/rpc_dart/example/core_methods/server_stream_example.dart
+++ b/packages/rpc_dart/example/core_methods/server_stream_example.dart
@@ -46,8 +46,10 @@ class ServerStreamingExample {
           .withTraceId('server-stream-trace-123')
           .withValue('stream-type', 'simple');
 
-      await for (final response
-          in client.getServerStream('Дай мне данные'.rpc, context: context1)) {
+      await for (final response in client.getServerStream(
+        'Дай мне данные'.rpc,
+        context: context1,
+      )) {
         print('КЛИЕНТ: Получен ответ: "$response"');
       }
 
@@ -58,8 +60,10 @@ class ServerStreamingExample {
           .withTraceId('numbers-stream-trace-456')
           .withAdditionalHeaders({'count': '10', 'delay': '100'});
 
-      await for (final number
-          in client.getNumberStream(5.rpc, context: context2)) {
+      await for (final number in client.getNumberStream(
+        5.rpc,
+        context: context2,
+      )) {
         print('КЛИЕНТ: Получено число: $number');
       }
 
@@ -67,8 +71,9 @@ class ServerStreamingExample {
       print('\n--- Пример 3: Server stream с отменой ---');
 
       final cancellationToken = RpcCancellationToken();
-      final cancelContext = RpcContext.withCancellation(cancellationToken)
-          .withValue('stream-type', 'long-running');
+      final cancelContext = RpcContext.withCancellation(
+        cancellationToken,
+      ).withValue('stream-type', 'long-running');
 
       // Отменяем через 200мс
       Future.delayed(Duration(milliseconds: 200), () {
@@ -78,8 +83,9 @@ class ServerStreamingExample {
 
       try {
         await for (final response in client.getLongRunningStream(
-            'Долгий stream'.rpc,
-            context: cancelContext)) {
+          'Долгий stream'.rpc,
+          context: cancelContext,
+        )) {
           print('КЛИЕНТ: Получен ответ: "$response"');
         }
       } catch (e) {
@@ -139,8 +145,10 @@ final class DataStreamServiceResponder extends RpcResponderContract
   }
 
   @override
-  Stream<RpcString> getServerStream(RpcString request,
-      {RpcContext? context}) async* {
+  Stream<RpcString> getServerStream(
+    RpcString request, {
+    RpcContext? context,
+  }) async* {
     final logger = RpcLogger('GetServerStream');
     logger.info('🔧 Получен запрос: ${request.value}');
     logger.info('🔍 Context: $context');
@@ -191,8 +199,10 @@ final class DataStreamServiceResponder extends RpcResponderContract
   }
 
   @override
-  Stream<RpcString> getLongRunningStream(RpcString request,
-      {RpcContext? context}) async* {
+  Stream<RpcString> getLongRunningStream(
+    RpcString request, {
+    RpcContext? context,
+  }) async* {
     final logger = RpcLogger('GetLongRunningStream');
     logger.info('🔧 Начинаем долгий поток: ${request.value}');
     logger.info('🔍 Context: $context');
@@ -249,8 +259,10 @@ final class DataStreamServiceCaller extends RpcCallerContract
   }
 
   @override
-  Stream<RpcString> getLongRunningStream(RpcString request,
-      {RpcContext? context}) {
+  Stream<RpcString> getLongRunningStream(
+    RpcString request, {
+    RpcContext? context,
+  }) {
     return callServerStream<RpcString, RpcString>(
       methodName: 'GetLongRunningStream',
       requestCodec: RpcString.codec,

--- a/packages/rpc_dart/example/core_methods/unary_example.dart
+++ b/packages/rpc_dart/example/core_methods/unary_example.dart
@@ -50,17 +50,22 @@ class UnaryRpcExample {
           .withAdditionalHeaders({'user-id': 'user-456'}).withTraceId(
               'trace-${DateTime.now().millisecondsSinceEpoch}');
 
-      final response2 =
-          await client.getCurrentTime('Время'.rpc, context: context2);
+      final response2 = await client.getCurrentTime(
+        'Время'.rpc,
+        context: context2,
+      );
       print('КЛИЕНТ: Получен ответ: "$response2"');
 
       // Пример 3: Вызов с таймаутом
       print('\n--- Пример 3: Вызов с таймаутом ---');
-      final timeoutContext = RpcContext.withTimeout(Duration(milliseconds: 500))
-          .withValue('request-type', 'health-check');
+      final timeoutContext = RpcContext.withTimeout(
+        Duration(milliseconds: 500),
+      ).withValue('request-type', 'health-check');
 
-      final response3 =
-          await client.checkHealth('Статус'.rpc, context: timeoutContext);
+      final response3 = await client.checkHealth(
+        'Статус'.rpc,
+        context: timeoutContext,
+      );
       print('КЛИЕНТ: Получен ответ: "$response3"');
 
       // Пример 4: Вызов с ошибкой
@@ -83,8 +88,10 @@ class UnaryRpcExample {
           cancellationToken.cancel('User cancelled');
         });
 
-        await client.longOperation('Долгая операция'.rpc,
-            context: cancelContext);
+        await client.longOperation(
+          'Долгая операция'.rpc,
+          context: cancelContext,
+        );
       } catch (e) {
         print('КЛИЕНТ: Операция отменена: $e');
       }
@@ -170,8 +177,10 @@ final class MultiServiceResponder extends RpcResponderContract
   }
 
   @override
-  Future<RpcString> getCurrentTime(RpcString message,
-      {RpcContext? context}) async {
+  Future<RpcString> getCurrentTime(
+    RpcString message, {
+    RpcContext? context,
+  }) async {
     final logger = RpcLogger('GetCurrentTime');
     logger.info('🔧 Получен запрос времени: ${message.value}');
     logger.info('🔍 Context: $context');
@@ -185,8 +194,10 @@ final class MultiServiceResponder extends RpcResponderContract
   }
 
   @override
-  Future<RpcString> checkHealth(RpcString message,
-      {RpcContext? context}) async {
+  Future<RpcString> checkHealth(
+    RpcString message, {
+    RpcContext? context,
+  }) async {
     final logger = RpcLogger('CheckHealth');
     logger.info('🔧 Проверка здоровья: ${message.value}');
     logger.info('🔍 Context: $context');
@@ -208,8 +219,10 @@ final class MultiServiceResponder extends RpcResponderContract
   }
 
   @override
-  Future<RpcString> longOperation(RpcString message,
-      {RpcContext? context}) async {
+  Future<RpcString> longOperation(
+    RpcString message, {
+    RpcContext? context,
+  }) async {
     final logger = RpcLogger('LongOperation');
     logger.info('🔧 Начинаем долгую операцию: ${message.value}');
     logger.info('🔍 Context: $context');

--- a/packages/rpc_dart/example/example.dart
+++ b/packages/rpc_dart/example/example.dart
@@ -50,8 +50,9 @@ Future<void> _demonstrateMethods(CalculatorCaller calculator) async {
 
   // 2. Server Streaming
   print('2️⃣ Server Stream: один запрос → поток ответов');
-  await for (final step
-      in calculator.calculateSteps(Request(20, 4, 'multiply'))) {
+  await for (final step in calculator.calculateSteps(
+    Request(20, 4, 'multiply'),
+  )) {
     print('   📤 ${step.message}');
   }
   print('');
@@ -284,8 +285,10 @@ final class CalculatorResponder extends RpcResponderContract
   }
 
   // 3. Client Streaming
-  Future<Summary> processBatch(Stream<Request> reqs,
-      {RpcContext? context}) async {
+  Future<Summary> processBatch(
+    Stream<Request> reqs, {
+    RpcContext? context,
+  }) async {
     int count = 0;
     double total = 0;
 

--- a/packages/rpc_dart/example/more/advanced_routing_example.dart
+++ b/packages/rpc_dart/example/more/advanced_routing_example.dart
@@ -55,7 +55,6 @@ Future<void> _demonstrateRealWorldRouting() async {
         priority: 100,
         description: '🌟 Premium пользователи → VIP сервер',
       )
-
       // A/B тестирование Payment Service V2 (приоритет 90)
       .routeWhen(
         toTransport: paymentV2TransportPair.$1,
@@ -65,9 +64,7 @@ Future<void> _demonstrateRealWorldRouting() async {
         priority: 90,
         description: '🧪 A/B тест Payment Service V2',
       )
-
       // 🎯 СРЕДНИЙ ПРИОРИТЕТ: Обычные сервисы (приоритет 50)
-
       .routeCall(
         calledServiceName: 'OrderService',
         toTransport: orderTransportPair.$1,
@@ -78,16 +75,13 @@ Future<void> _demonstrateRealWorldRouting() async {
         toTransport: auditTransportPair.$1,
         priority: 50,
       )
-
       // 🎯 НИЗКИЙ ПРИОРИТЕТ: Fallback правила (срабатывают последними)
-
       // Обычные пользователи UserService (приоритет 10)
       .routeCall(
         calledServiceName: 'UserService',
         toTransport: userTransportPair.$1,
         priority: 10,
       )
-
       // Стабильная версия Payment Service (приоритет 10)
       .routeCall(
         calledServiceName: 'PaymentService',
@@ -133,7 +127,9 @@ Future<void> _setupDomainServers(
 
 /// Создает demo контракт для примера роутинга
 RpcResponderContract _createDemoServiceContract(
-    String serviceName, String label) {
+  String serviceName,
+  String label,
+) {
   return _DemoServiceContract(serviceName, label);
 }
 
@@ -316,7 +312,8 @@ final class _DemoServiceContract extends RpcResponderContract {
         final reason = context?.getHeader('x-reason') ?? 'not specified';
         final adminId = context?.getHeader('x-admin-id') ?? 'unknown';
         return RpcString(
-            '🔍 $_label: удаление пользователя [админ: $adminId, причина: $reason]');
+          '🔍 $_label: удаление пользователя [админ: $adminId, причина: $reason]',
+        );
       },
     );
   }

--- a/packages/rpc_dart/example/more/contract_modes_example.dart
+++ b/packages/rpc_dart/example/more/contract_modes_example.dart
@@ -57,10 +57,12 @@ class SerializableResponse implements IRpcSerializable {
 }
 
 // Кодеки для сериализуемых типов
-final serializableRequestCodec =
-    RpcCodec<SerializableRequest>(SerializableRequest.fromJson);
-final serializableResponseCodec =
-    RpcCodec<SerializableResponse>(SerializableResponse.fromJson);
+final serializableRequestCodec = RpcCodec<SerializableRequest>(
+  SerializableRequest.fromJson,
+);
+final serializableResponseCodec = RpcCodec<SerializableResponse>(
+  SerializableResponse.fromJson,
+);
 
 //
 // RESPONDER КОНТРАКТЫ С РАЗНЫМИ РЕЖИМАМИ
@@ -147,8 +149,11 @@ final class AutoResponder extends RpcResponderContract {
 /// Zero-copy caller
 final class ZeroCopyCaller extends RpcCallerContract {
   ZeroCopyCaller(RpcCallerEndpoint endpoint)
-      : super('ZeroCopyService', endpoint,
-            dataTransferMode: RpcDataTransferMode.zeroCopy);
+      : super(
+          'ZeroCopyService',
+          endpoint,
+          dataTransferMode: RpcDataTransferMode.zeroCopy,
+        );
 
   Future<ZeroCopyResponse> echo(ZeroCopyRequest request) {
     // В zero-copy режиме кодеки передавать нельзя
@@ -162,8 +167,11 @@ final class ZeroCopyCaller extends RpcCallerContract {
 /// Codec caller
 final class CodecCaller extends RpcCallerContract {
   CodecCaller(RpcCallerEndpoint endpoint)
-      : super('CodecService', endpoint,
-            dataTransferMode: RpcDataTransferMode.codec);
+      : super(
+          'CodecService',
+          endpoint,
+          dataTransferMode: RpcDataTransferMode.codec,
+        );
 
   Future<SerializableResponse> echo(SerializableRequest request) {
     // В codec режиме кодеки обязательны
@@ -179,8 +187,11 @@ final class CodecCaller extends RpcCallerContract {
 /// Auto caller
 final class AutoCaller extends RpcCallerContract {
   AutoCaller(RpcCallerEndpoint endpoint)
-      : super('AutoService', endpoint,
-            dataTransferMode: RpcDataTransferMode.auto);
+      : super(
+          'AutoService',
+          endpoint,
+          dataTransferMode: RpcDataTransferMode.auto,
+        );
 
   Future<ZeroCopyResponse> zeroCopyEcho(ZeroCopyRequest request) {
     // Auto режим - кодеки не указаны = zero-copy
@@ -207,7 +218,8 @@ final class AutoCaller extends RpcCallerContract {
 
 Future<void> main() async {
   print(
-      '🚀 Демонстрация централизованного управления режимами передачи данных\n');
+    '🚀 Демонстрация централизованного управления режимами передачи данных\n',
+  );
 
   // Создаем пару транспортов
   final (clientTransport, serverTransport) = RpcInMemoryTransport.pair();
@@ -294,8 +306,9 @@ Future<void> demoAutoMode(
 
   // Вызываем zero-copy метод
   try {
-    final response1 =
-        await caller.zeroCopyEcho(ZeroCopyRequest('Hello Auto Zero-Copy!'));
+    final response1 = await caller.zeroCopyEcho(
+      ZeroCopyRequest('Hello Auto Zero-Copy!'),
+    );
     print('✅ Zero-copy результат: $response1');
   } catch (e) {
     print('❌ Zero-copy ошибка: $e');
@@ -303,8 +316,9 @@ Future<void> demoAutoMode(
 
   // Вызываем codec метод
   try {
-    final response2 =
-        await caller.codecEcho(SerializableRequest('Hello Auto Codec!'));
+    final response2 = await caller.codecEcho(
+      SerializableRequest('Hello Auto Codec!'),
+    );
     print('✅ Codec результат: $response2\n');
   } catch (e) {
     print('❌ Codec ошибка: $e\n');
@@ -329,8 +343,9 @@ Future<void> demoFlexibleCodecs(
   print('Передача кодеков в zero-copy режиме (они будут проигнорированы):');
   try {
     // Теперь это работает! Кодеки просто игнорируются
-    final response = await flexibleCaller
-        .flexibleEcho(ZeroCopyRequest('test with ignored codecs'));
+    final response = await flexibleCaller.flexibleEcho(
+      ZeroCopyRequest('test with ignored codecs'),
+    );
     print('✅ Успешно! Кодеки проигнорированы: $response');
   } catch (e) {
     print('❌ Неожиданная ошибка: $e');
@@ -352,8 +367,11 @@ Future<void> demoFlexibleCodecs(
 
 final class FlexibleCaller extends RpcCallerContract {
   FlexibleCaller(RpcCallerEndpoint endpoint)
-      : super('FlexibleService', endpoint,
-            dataTransferMode: RpcDataTransferMode.zeroCopy);
+      : super(
+          'FlexibleService',
+          endpoint,
+          dataTransferMode: RpcDataTransferMode.zeroCopy,
+        );
 
   Future<ZeroCopyResponse> flexibleEcho(ZeroCopyRequest request) {
     // Демонстрируем что в zero-copy режиме можно передать кодеки

--- a/packages/rpc_dart/example/more/responder_dispose_example.dart
+++ b/packages/rpc_dart/example/more/responder_dispose_example.dart
@@ -67,18 +67,21 @@ void main() async {
 
   // Разрегистрируем один сервис
   print(
-      '\n🗑️  Разрегистрируем DatabaseService (dispose() вызовется автоматически)...');
+    '\n🗑️  Разрегистрируем DatabaseService (dispose() вызовется автоматически)...',
+  );
   responderEndpoint.unregisterServiceContract('DatabaseService');
 
   print('📊 Состояние после разрегистрации:');
   print(
-      '  Database connections: ${databaseService.activeConnections} (должно быть 0)');
+    '  Database connections: ${databaseService.activeConnections} (должно быть 0)',
+  );
   print('  Cache size: ${cachingService.cacheSize} (не изменилось)');
   print('  Analytics timers: ${analyticsService.activeTimers} (не изменилось)');
 
   // Закрываем эндпоинт (остальные dispose() вызовутся автоматически)
   print(
-      '\n🚪 Закрываем эндпоинт (dispose() вызовется для всех оставшихся сервисов)...');
+    '\n🚪 Закрываем эндпоинт (dispose() вызовется для всех оставшихся сервисов)...',
+  );
   await responderEndpoint.close();
 
   print('📊 Финальное состояние ресурсов:');
@@ -132,8 +135,10 @@ final class DatabaseService extends RpcResponderContract {
     );
   }
 
-  Future<ResourceResponse> _initializeDatabase(ResourceRequest request,
-      {RpcContext? context}) async {
+  Future<ResourceResponse> _initializeDatabase(
+    ResourceRequest request, {
+    RpcContext? context,
+  }) async {
     print('  🗄️  [Database] Инициализация подключений...');
 
     // Создаем имитацию подключений к БД
@@ -152,14 +157,19 @@ final class DatabaseService extends RpcResponderContract {
 
     print('  🗄️  [Database] Создано $activeConnections подключений');
     return ResourceResponse(
-        'Database initialized with $activeConnections connections');
+      'Database initialized with $activeConnections connections',
+    );
   }
 
-  Future<ResourceResponse> _executeQuery(ResourceRequest request,
-      {RpcContext? context}) async {
+  Future<ResourceResponse> _executeQuery(
+    ResourceRequest request, {
+    RpcContext? context,
+  }) async {
     if (activeConnections == 0) {
-      return ResourceResponse('No database connections available',
-          success: false);
+      return ResourceResponse(
+        'No database connections available',
+        success: false,
+      );
     }
     return ResourceResponse('Query executed successfully');
   }
@@ -209,8 +219,10 @@ final class CachingService extends RpcResponderContract {
     );
   }
 
-  Future<ResourceResponse> _initializeCache(ResourceRequest request,
-      {RpcContext? context}) async {
+  Future<ResourceResponse> _initializeCache(
+    ResourceRequest request, {
+    RpcContext? context,
+  }) async {
     print('  💾 [Cache] Инициализация кеша...');
 
     // Заполняем кеш тестовыми данными
@@ -290,13 +302,17 @@ final class AnalyticsService extends RpcResponderContract {
     }
 
     print(
-        '  📊 [Analytics] Создано $activeTimers таймеров и ${_eventStreams.length} event streams');
+      '  📊 [Analytics] Создано $activeTimers таймеров и ${_eventStreams.length} event streams',
+    );
   }
 
-  Future<ResourceResponse> _initializeAnalytics(ResourceRequest request,
-      {RpcContext? context}) async {
+  Future<ResourceResponse> _initializeAnalytics(
+    ResourceRequest request, {
+    RpcContext? context,
+  }) async {
     return ResourceResponse(
-        'Analytics already initialized with $activeTimers timers');
+      'Analytics already initialized with $activeTimers timers',
+    );
   }
 
   /// 🆕 Переопределяем dispose() для освобождения analytics ресурсов

--- a/packages/rpc_dart/lib/src/codec/special_cbor.dart
+++ b/packages/rpc_dart/lib/src/codec/special_cbor.dart
@@ -122,10 +122,12 @@ abstract interface class CborCodec {
 
   /// Кодирует bool
   static void _encodeBool(bool value, BytesBuilder builder) {
-    builder.addByte(_getMajorTypeByte(
-      _majorTypeSimple,
-      value ? _simpleValueTrue : _simpleValueFalse,
-    ));
+    builder.addByte(
+      _getMajorTypeByte(
+        _majorTypeSimple,
+        value ? _simpleValueTrue : _simpleValueFalse,
+      ),
+    );
   }
 
   /// Кодирует int
@@ -142,32 +144,31 @@ abstract interface class CborCodec {
     if (value <= 23) {
       builder.addByte(_getMajorTypeByte(_majorTypeUnsignedInt, value));
     } else if (value <= 0xFF) {
-      builder.addByte(_getMajorTypeByte(
-        _majorTypeUnsignedInt,
-        _additionalInfoOneByteFollow,
-      ));
+      builder.addByte(
+        _getMajorTypeByte(_majorTypeUnsignedInt, _additionalInfoOneByteFollow),
+      );
       builder.addByte(value & 0xFF);
     } else if (value <= 0xFFFF) {
-      builder.addByte(_getMajorTypeByte(
-        _majorTypeUnsignedInt,
-        _additionalInfoTwoByteFollow,
-      ));
+      builder.addByte(
+        _getMajorTypeByte(_majorTypeUnsignedInt, _additionalInfoTwoByteFollow),
+      );
       builder.addByte((value >> 8) & 0xFF);
       builder.addByte(value & 0xFF);
     } else if (value <= 0xFFFFFFFF) {
-      builder.addByte(_getMajorTypeByte(
-        _majorTypeUnsignedInt,
-        _additionalInfoFourByteFollow,
-      ));
+      builder.addByte(
+        _getMajorTypeByte(_majorTypeUnsignedInt, _additionalInfoFourByteFollow),
+      );
       builder.addByte((value >> 24) & 0xFF);
       builder.addByte((value >> 16) & 0xFF);
       builder.addByte((value >> 8) & 0xFF);
       builder.addByte(value & 0xFF);
     } else {
-      builder.addByte(_getMajorTypeByte(
-        _majorTypeUnsignedInt,
-        _additionalInfoEightByteFollow,
-      ));
+      builder.addByte(
+        _getMajorTypeByte(
+          _majorTypeUnsignedInt,
+          _additionalInfoEightByteFollow,
+        ),
+      );
 
       // Правильное кодирование 64-битного числа согласно RFC 7049
       builder.addByte((value >> 56) & 0xFF);
@@ -186,32 +187,31 @@ abstract interface class CborCodec {
     if (value <= 23) {
       builder.addByte(_getMajorTypeByte(_majorTypeNegativeInt, value));
     } else if (value <= 0xFF) {
-      builder.addByte(_getMajorTypeByte(
-        _majorTypeNegativeInt,
-        _additionalInfoOneByteFollow,
-      ));
+      builder.addByte(
+        _getMajorTypeByte(_majorTypeNegativeInt, _additionalInfoOneByteFollow),
+      );
       builder.addByte(value & 0xFF);
     } else if (value <= 0xFFFF) {
-      builder.addByte(_getMajorTypeByte(
-        _majorTypeNegativeInt,
-        _additionalInfoTwoByteFollow,
-      ));
+      builder.addByte(
+        _getMajorTypeByte(_majorTypeNegativeInt, _additionalInfoTwoByteFollow),
+      );
       builder.addByte((value >> 8) & 0xFF);
       builder.addByte(value & 0xFF);
     } else if (value <= 0xFFFFFFFF) {
-      builder.addByte(_getMajorTypeByte(
-        _majorTypeNegativeInt,
-        _additionalInfoFourByteFollow,
-      ));
+      builder.addByte(
+        _getMajorTypeByte(_majorTypeNegativeInt, _additionalInfoFourByteFollow),
+      );
       builder.addByte((value >> 24) & 0xFF);
       builder.addByte((value >> 16) & 0xFF);
       builder.addByte((value >> 8) & 0xFF);
       builder.addByte(value & 0xFF);
     } else {
-      builder.addByte(_getMajorTypeByte(
-        _majorTypeNegativeInt,
-        _additionalInfoEightByteFollow,
-      ));
+      builder.addByte(
+        _getMajorTypeByte(
+          _majorTypeNegativeInt,
+          _additionalInfoEightByteFollow,
+        ),
+      );
 
       // Правильное кодирование 64-битного числа согласно RFC 7049
       builder.addByte((value >> 56) & 0xFF);
@@ -228,10 +228,9 @@ abstract interface class CborCodec {
   /// Кодирует double
   static void _encodeDouble(double value, BytesBuilder builder) {
     // Для float используем IEEE 754 64-bit (Double)
-    builder.addByte(_getMajorTypeByte(
-      _majorTypeSimple,
-      _additionalInfoEightByteFollow,
-    ));
+    builder.addByte(
+      _getMajorTypeByte(_majorTypeSimple, _additionalInfoEightByteFollow),
+    );
 
     // Конвертируем double в bytes в формате IEEE 754
     final ByteData data = ByteData(8);
@@ -300,32 +299,28 @@ abstract interface class CborCodec {
     if (length <= 23) {
       builder.addByte(_getMajorTypeByte(majorType, length));
     } else if (length <= 0xFF) {
-      builder.addByte(_getMajorTypeByte(
-        majorType,
-        _additionalInfoOneByteFollow,
-      ));
+      builder.addByte(
+        _getMajorTypeByte(majorType, _additionalInfoOneByteFollow),
+      );
       builder.addByte(length & 0xFF);
     } else if (length <= 0xFFFF) {
-      builder.addByte(_getMajorTypeByte(
-        majorType,
-        _additionalInfoTwoByteFollow,
-      ));
+      builder.addByte(
+        _getMajorTypeByte(majorType, _additionalInfoTwoByteFollow),
+      );
       builder.addByte((length >> 8) & 0xFF);
       builder.addByte(length & 0xFF);
     } else if (length <= 0xFFFFFFFF) {
-      builder.addByte(_getMajorTypeByte(
-        majorType,
-        _additionalInfoFourByteFollow,
-      ));
+      builder.addByte(
+        _getMajorTypeByte(majorType, _additionalInfoFourByteFollow),
+      );
       builder.addByte((length >> 24) & 0xFF);
       builder.addByte((length >> 16) & 0xFF);
       builder.addByte((length >> 8) & 0xFF);
       builder.addByte(length & 0xFF);
     } else {
-      builder.addByte(_getMajorTypeByte(
-        majorType,
-        _additionalInfoEightByteFollow,
-      ));
+      builder.addByte(
+        _getMajorTypeByte(majorType, _additionalInfoEightByteFollow),
+      );
       builder.addByte((length >> 56) & 0xFF);
       builder.addByte((length >> 48) & 0xFF);
       builder.addByte((length >> 40) & 0xFF);
@@ -479,13 +474,16 @@ class _CborReader {
       while (true) {
         if (_offset >= _bytes.length) {
           throw FormatException(
-              'Unexpected end of CBOR data inside indefinite-length array');
+            'Unexpected end of CBOR data inside indefinite-length array',
+          );
         }
 
         // Проверяем наличие break маркера
         if (_bytes[_offset] ==
             CborCodec._getMajorTypeByte(
-                CborCodec._majorTypeSimple, CborCodec._simpleValueBreak)) {
+              CborCodec._majorTypeSimple,
+              CborCodec._simpleValueBreak,
+            )) {
           _offset++; // Пропускаем break маркер
           break;
         }
@@ -516,13 +514,16 @@ class _CborReader {
       while (true) {
         if (_offset >= _bytes.length) {
           throw FormatException(
-              'Unexpected end of CBOR data inside indefinite-length map');
+            'Unexpected end of CBOR data inside indefinite-length map',
+          );
         }
 
         // Проверяем наличие break маркера
         if (_bytes[_offset] ==
             CborCodec._getMajorTypeByte(
-                CborCodec._majorTypeSimple, CborCodec._simpleValueBreak)) {
+              CborCodec._majorTypeSimple,
+              CborCodec._simpleValueBreak,
+            )) {
           _offset++; // Пропускаем break маркер
           break;
         }
@@ -562,7 +563,8 @@ class _CborReader {
         return null;
       case CborCodec._simpleValueBreak:
         throw FormatException(
-            'Unexpected break value outside indefinite-length item');
+          'Unexpected break value outside indefinite-length item',
+        );
       case CborCodec._additionalInfoEightByteFollow:
         // IEEE 754 Double
         final byteData = ByteData(8);
@@ -570,7 +572,9 @@ class _CborReader {
           byteData.setUint8(i, _readByte());
         }
         return byteData.getFloat64(
-            0, Endian.big); // Используем big-endian по RFC 7049
+          0,
+          Endian.big,
+        ); // Используем big-endian по RFC 7049
       default:
         if (additionalInfo >= 0 && additionalInfo <= 19) {
           // Простые значения 0-19
@@ -881,16 +885,19 @@ class _FastCborWriter {
 
   /// Кодирует null
   void _writeNull() {
-    _builder.addByte(_getMajorTypeByte(
-        CborCodec._majorTypeSimple, CborCodec._simpleValueNull));
+    _builder.addByte(
+      _getMajorTypeByte(CborCodec._majorTypeSimple, CborCodec._simpleValueNull),
+    );
   }
 
   /// Кодирует bool
   void _writeBool(bool value) {
-    _builder.addByte(_getMajorTypeByte(
-      CborCodec._majorTypeSimple,
-      value ? CborCodec._simpleValueTrue : CborCodec._simpleValueFalse,
-    ));
+    _builder.addByte(
+      _getMajorTypeByte(
+        CborCodec._majorTypeSimple,
+        value ? CborCodec._simpleValueTrue : CborCodec._simpleValueFalse,
+      ),
+    );
   }
 
   /// Кодирует int
@@ -905,35 +912,44 @@ class _FastCborWriter {
   /// Кодирует положительное число
   void _writePositiveInt(int value) {
     if (value <= 23) {
-      _builder
-          .addByte(_getMajorTypeByte(CborCodec._majorTypeUnsignedInt, value));
+      _builder.addByte(
+        _getMajorTypeByte(CborCodec._majorTypeUnsignedInt, value),
+      );
     } else if (value <= 0xFF) {
-      _builder.addByte(_getMajorTypeByte(
-        CborCodec._majorTypeUnsignedInt,
-        CborCodec._additionalInfoOneByteFollow,
-      ));
+      _builder.addByte(
+        _getMajorTypeByte(
+          CborCodec._majorTypeUnsignedInt,
+          CborCodec._additionalInfoOneByteFollow,
+        ),
+      );
       _builder.addByte(value & 0xFF);
     } else if (value <= 0xFFFF) {
-      _builder.addByte(_getMajorTypeByte(
-        CborCodec._majorTypeUnsignedInt,
-        CborCodec._additionalInfoTwoByteFollow,
-      ));
+      _builder.addByte(
+        _getMajorTypeByte(
+          CborCodec._majorTypeUnsignedInt,
+          CborCodec._additionalInfoTwoByteFollow,
+        ),
+      );
       _builder.addByte((value >> 8) & 0xFF);
       _builder.addByte(value & 0xFF);
     } else if (value <= 0xFFFFFFFF) {
-      _builder.addByte(_getMajorTypeByte(
-        CborCodec._majorTypeUnsignedInt,
-        CborCodec._additionalInfoFourByteFollow,
-      ));
+      _builder.addByte(
+        _getMajorTypeByte(
+          CborCodec._majorTypeUnsignedInt,
+          CborCodec._additionalInfoFourByteFollow,
+        ),
+      );
       _builder.addByte((value >> 24) & 0xFF);
       _builder.addByte((value >> 16) & 0xFF);
       _builder.addByte((value >> 8) & 0xFF);
       _builder.addByte(value & 0xFF);
     } else {
-      _builder.addByte(_getMajorTypeByte(
-        CborCodec._majorTypeUnsignedInt,
-        CborCodec._additionalInfoEightByteFollow,
-      ));
+      _builder.addByte(
+        _getMajorTypeByte(
+          CborCodec._majorTypeUnsignedInt,
+          CborCodec._additionalInfoEightByteFollow,
+        ),
+      );
 
       // Правильное кодирование 64-битного числа согласно RFC 7049
       _builder.addByte((value >> 56) & 0xFF);
@@ -950,35 +966,44 @@ class _FastCborWriter {
   /// Кодирует отрицательное число
   void _writeNegativeInt(int value) {
     if (value <= 23) {
-      _builder
-          .addByte(_getMajorTypeByte(CborCodec._majorTypeNegativeInt, value));
+      _builder.addByte(
+        _getMajorTypeByte(CborCodec._majorTypeNegativeInt, value),
+      );
     } else if (value <= 0xFF) {
-      _builder.addByte(_getMajorTypeByte(
-        CborCodec._majorTypeNegativeInt,
-        CborCodec._additionalInfoOneByteFollow,
-      ));
+      _builder.addByte(
+        _getMajorTypeByte(
+          CborCodec._majorTypeNegativeInt,
+          CborCodec._additionalInfoOneByteFollow,
+        ),
+      );
       _builder.addByte(value & 0xFF);
     } else if (value <= 0xFFFF) {
-      _builder.addByte(_getMajorTypeByte(
-        CborCodec._majorTypeNegativeInt,
-        CborCodec._additionalInfoTwoByteFollow,
-      ));
+      _builder.addByte(
+        _getMajorTypeByte(
+          CborCodec._majorTypeNegativeInt,
+          CborCodec._additionalInfoTwoByteFollow,
+        ),
+      );
       _builder.addByte((value >> 8) & 0xFF);
       _builder.addByte(value & 0xFF);
     } else if (value <= 0xFFFFFFFF) {
-      _builder.addByte(_getMajorTypeByte(
-        CborCodec._majorTypeNegativeInt,
-        CborCodec._additionalInfoFourByteFollow,
-      ));
+      _builder.addByte(
+        _getMajorTypeByte(
+          CborCodec._majorTypeNegativeInt,
+          CborCodec._additionalInfoFourByteFollow,
+        ),
+      );
       _builder.addByte((value >> 24) & 0xFF);
       _builder.addByte((value >> 16) & 0xFF);
       _builder.addByte((value >> 8) & 0xFF);
       _builder.addByte(value & 0xFF);
     } else {
-      _builder.addByte(_getMajorTypeByte(
-        CborCodec._majorTypeNegativeInt,
-        CborCodec._additionalInfoEightByteFollow,
-      ));
+      _builder.addByte(
+        _getMajorTypeByte(
+          CborCodec._majorTypeNegativeInt,
+          CborCodec._additionalInfoEightByteFollow,
+        ),
+      );
 
       // Правильное кодирование 64-битного числа согласно RFC 7049
       _builder.addByte((value >> 56) & 0xFF);
@@ -995,10 +1020,12 @@ class _FastCborWriter {
   /// Кодирует double
   void _writeDouble(double value) {
     // Для float используем IEEE 754 64-bit (Double)
-    _builder.addByte(_getMajorTypeByte(
-      CborCodec._majorTypeSimple,
-      CborCodec._additionalInfoEightByteFollow,
-    ));
+    _builder.addByte(
+      _getMajorTypeByte(
+        CborCodec._majorTypeSimple,
+        CborCodec._additionalInfoEightByteFollow,
+      ),
+    );
 
     // Конвертируем double в bytes в формате IEEE 754
     final ByteData data = ByteData(8);
@@ -1067,32 +1094,28 @@ class _FastCborWriter {
     if (length <= 23) {
       _builder.addByte(_getMajorTypeByte(majorType, length));
     } else if (length <= 0xFF) {
-      _builder.addByte(_getMajorTypeByte(
-        majorType,
-        CborCodec._additionalInfoOneByteFollow,
-      ));
+      _builder.addByte(
+        _getMajorTypeByte(majorType, CborCodec._additionalInfoOneByteFollow),
+      );
       _builder.addByte(length & 0xFF);
     } else if (length <= 0xFFFF) {
-      _builder.addByte(_getMajorTypeByte(
-        majorType,
-        CborCodec._additionalInfoTwoByteFollow,
-      ));
+      _builder.addByte(
+        _getMajorTypeByte(majorType, CborCodec._additionalInfoTwoByteFollow),
+      );
       _builder.addByte((length >> 8) & 0xFF);
       _builder.addByte(length & 0xFF);
     } else if (length <= 0xFFFFFFFF) {
-      _builder.addByte(_getMajorTypeByte(
-        majorType,
-        CborCodec._additionalInfoFourByteFollow,
-      ));
+      _builder.addByte(
+        _getMajorTypeByte(majorType, CborCodec._additionalInfoFourByteFollow),
+      );
       _builder.addByte((length >> 24) & 0xFF);
       _builder.addByte((length >> 16) & 0xFF);
       _builder.addByte((length >> 8) & 0xFF);
       _builder.addByte(length & 0xFF);
     } else {
-      _builder.addByte(_getMajorTypeByte(
-        majorType,
-        CborCodec._additionalInfoEightByteFollow,
-      ));
+      _builder.addByte(
+        _getMajorTypeByte(majorType, CborCodec._additionalInfoEightByteFollow),
+      );
       _builder.addByte((length >> 56) & 0xFF);
       _builder.addByte((length >> 48) & 0xFF);
       _builder.addByte((length >> 40) & 0xFF);

--- a/packages/rpc_dart/lib/src/contracts/context.dart
+++ b/packages/rpc_dart/lib/src/contracts/context.dart
@@ -438,8 +438,9 @@ abstract final class RpcContextUtils {
     if (spanId != null) headers['x-span-id'] = spanId;
     if (parentSpanId != null) headers['x-parent-span-id'] = parentSpanId;
 
-    return RpcContext.withHeaders(headers)
-        .withTraceId(traceId ?? _generateTraceId());
+    return RpcContext.withHeaders(
+      headers,
+    ).withTraceId(traceId ?? _generateTraceId());
   }
 
   /// Генерирует новый trace ID
@@ -484,8 +485,9 @@ class RpcContextBuilder {
   factory RpcContextBuilder.inheritFrom(RpcContext? parent) {
     if (parent?.traceId != null) {
       // Наследуем trace ID и базовые заголовки
-      return RpcContextBuilder.from(parent!)
-          .withGeneratedRequestId(); // Генерируем новый request ID для нового вызова
+      return RpcContextBuilder.from(
+        parent!,
+      ).withGeneratedRequestId(); // Генерируем новый request ID для нового вызова
     }
 
     // Создаем новый контекст с новым trace ID

--- a/packages/rpc_dart/lib/src/contracts/contract.dart
+++ b/packages/rpc_dart/lib/src/contracts/contract.dart
@@ -45,11 +45,11 @@ abstract class RpcResponderContract implements IRpcContract {
   }
 
   /// Возвращает фактически используемые кодеки с учетом режима передачи данных
-  (IRpcCodec<TRequest>?, IRpcCodec<TResponse>?)
-      _getEffectiveCodecs<TRequest, TResponse>(
-    IRpcCodec<TRequest>? requestCodec,
-    IRpcCodec<TResponse>? responseCodec,
-  ) {
+  (
+    IRpcCodec<TRequest>?,
+    IRpcCodec<TResponse>?
+  ) _getEffectiveCodecs<TRequest, TResponse>(
+      IRpcCodec<TRequest>? requestCodec, IRpcCodec<TResponse>? responseCodec) {
     final isZeroCopy = _isZeroCopyAllowed(requestCodec, responseCodec);
 
     if (isZeroCopy) {
@@ -72,10 +72,11 @@ abstract class RpcResponderContract implements IRpcContract {
       // Для codec режима требуются оба кодека
       if (requestCodec == null || responseCodec == null) {
         throw ArgumentError(
-            'Для режима сериализации требуются оба кодека (requestCodec и responseCodec). '
-            'Текущий режим контракта: $dataTransferMode. '
-            'Получено: requestCodec=${requestCodec != null ? 'указан' : 'null'}, '
-            'responseCodec=${responseCodec != null ? 'указан' : 'null'}');
+          'Для режима сериализации требуются оба кодека (requestCodec и responseCodec). '
+          'Текущий режим контракта: $dataTransferMode. '
+          'Получено: requestCodec=${requestCodec != null ? 'указан' : 'null'}, '
+          'responseCodec=${responseCodec != null ? 'указан' : 'null'}',
+        );
       }
     }
 
@@ -84,9 +85,10 @@ abstract class RpcResponderContract implements IRpcContract {
     if (dataTransferMode == RpcDataTransferMode.auto && !isZeroCopy) {
       if ((requestCodec == null) != (responseCodec == null)) {
         throw ArgumentError(
-            'В auto режиме для сериализации требуются оба кодека. '
-            'Получено: requestCodec=${requestCodec != null ? 'указан' : 'null'}, '
-            'responseCodec=${responseCodec != null ? 'указан' : 'null'}');
+          'В auto режиме для сериализации требуются оба кодека. '
+          'Получено: requestCodec=${requestCodec != null ? 'указан' : 'null'}, '
+          'responseCodec=${responseCodec != null ? 'указан' : 'null'}',
+        );
       }
     }
   }
@@ -126,8 +128,10 @@ abstract class RpcResponderContract implements IRpcContract {
     _validateCodecsForCodecMode(requestCodec, responseCodec);
 
     // Получаем фактически используемые кодеки
-    final (effectiveRequestCodec, effectiveResponseCodec) =
-        _getEffectiveCodecs(requestCodec, responseCodec);
+    final (effectiveRequestCodec, effectiveResponseCodec) = _getEffectiveCodecs(
+      requestCodec,
+      responseCodec,
+    );
     final isZeroCopy =
         effectiveRequestCodec == null && effectiveResponseCodec == null;
 
@@ -142,8 +146,10 @@ abstract class RpcResponderContract implements IRpcContract {
       );
     } else {
       // Сериализация регистрация с обёрткой для корректного приведения типов
-      Future<IRpcSerializable> wrappedHandler(IRpcSerializable request,
-          {RpcContext? context}) async {
+      Future<IRpcSerializable> wrappedHandler(
+        IRpcSerializable request, {
+        RpcContext? context,
+      }) async {
         final typedRequest = request as TRequest;
         final response = await handler(typedRequest, context: context);
         return response as IRpcSerializable;
@@ -179,8 +185,10 @@ abstract class RpcResponderContract implements IRpcContract {
     _validateCodecsForCodecMode(requestCodec, responseCodec);
 
     // Получаем фактически используемые кодеки
-    final (effectiveRequestCodec, effectiveResponseCodec) =
-        _getEffectiveCodecs(requestCodec, responseCodec);
+    final (effectiveRequestCodec, effectiveResponseCodec) = _getEffectiveCodecs(
+      requestCodec,
+      responseCodec,
+    );
     final isZeroCopy =
         effectiveRequestCodec == null && effectiveResponseCodec == null;
 
@@ -195,8 +203,10 @@ abstract class RpcResponderContract implements IRpcContract {
       );
     } else {
       // Сериализация регистрация с обёрткой для корректного приведения типов
-      Stream<IRpcSerializable> wrappedHandler(IRpcSerializable request,
-          {RpcContext? context}) async* {
+      Stream<IRpcSerializable> wrappedHandler(
+        IRpcSerializable request, {
+        RpcContext? context,
+      }) async* {
         final typedRequest = request as TRequest;
         final responseStream = handler(typedRequest, context: context);
         await for (final response in responseStream) {
@@ -234,8 +244,10 @@ abstract class RpcResponderContract implements IRpcContract {
     _validateCodecsForCodecMode(requestCodec, responseCodec);
 
     // Получаем фактически используемые кодеки
-    final (effectiveRequestCodec, effectiveResponseCodec) =
-        _getEffectiveCodecs(requestCodec, responseCodec);
+    final (effectiveRequestCodec, effectiveResponseCodec) = _getEffectiveCodecs(
+      requestCodec,
+      responseCodec,
+    );
     final isZeroCopy =
         effectiveRequestCodec == null && effectiveResponseCodec == null;
 
@@ -257,8 +269,10 @@ abstract class RpcResponderContract implements IRpcContract {
       );
     } else {
       // Сериализация регистрация с обёрткой для корректного приведения типов
-      Future<IRpcSerializable> wrappedHandler(Stream<IRpcSerializable> requests,
-          {RpcContext? context}) async {
+      Future<IRpcSerializable> wrappedHandler(
+        Stream<IRpcSerializable> requests, {
+        RpcContext? context,
+      }) async {
         final typedRequestStream = requests.cast<TRequest>();
         final response = await handler(typedRequestStream, context: context);
         return response as IRpcSerializable;
@@ -294,8 +308,10 @@ abstract class RpcResponderContract implements IRpcContract {
     _validateCodecsForCodecMode(requestCodec, responseCodec);
 
     // Получаем фактически используемые кодеки
-    final (effectiveRequestCodec, effectiveResponseCodec) =
-        _getEffectiveCodecs(requestCodec, responseCodec);
+    final (effectiveRequestCodec, effectiveResponseCodec) = _getEffectiveCodecs(
+      requestCodec,
+      responseCodec,
+    );
     final isZeroCopy =
         effectiveRequestCodec == null && effectiveResponseCodec == null;
 
@@ -320,8 +336,10 @@ abstract class RpcResponderContract implements IRpcContract {
       );
     } else {
       // Сериализация регистрация с обёрткой для корректного приведения типов
-      Stream<IRpcSerializable> wrappedHandler(Stream<IRpcSerializable> requests,
-          {RpcContext? context}) async* {
+      Stream<IRpcSerializable> wrappedHandler(
+        Stream<IRpcSerializable> requests, {
+        RpcContext? context,
+      }) async* {
         final typedRequestStream = requests.cast<TRequest>();
         final responseStream = handler(typedRequestStream, context: context);
         await for (final response in responseStream) {
@@ -396,7 +414,8 @@ abstract class RpcCallerContract implements IRpcContract {
   /// Получает все токены отмены для указанного метода
   /// Возвращает пустую мапу, если метод не найден
   Map<String, RpcCancellationToken> getCancellationTokensForMethod(
-      String methodName) {
+    String methodName,
+  ) {
     return _endpoint.getCancellationTokensForMethod(serviceName, methodName);
   }
 
@@ -439,11 +458,11 @@ abstract class RpcCallerContract implements IRpcContract {
   }
 
   /// Возвращает фактически используемые кодеки с учетом режима передачи данных
-  (IRpcCodec<TRequest>?, IRpcCodec<TResponse>?)
-      _getEffectiveCodecs<TRequest, TResponse>(
-    IRpcCodec<TRequest>? requestCodec,
-    IRpcCodec<TResponse>? responseCodec,
-  ) {
+  (
+    IRpcCodec<TRequest>?,
+    IRpcCodec<TResponse>?
+  ) _getEffectiveCodecs<TRequest, TResponse>(
+      IRpcCodec<TRequest>? requestCodec, IRpcCodec<TResponse>? responseCodec) {
     final isZeroCopy = _isZeroCopyAllowed(requestCodec, responseCodec);
 
     if (isZeroCopy) {
@@ -466,10 +485,11 @@ abstract class RpcCallerContract implements IRpcContract {
       // Для codec режима требуются оба кодека
       if (requestCodec == null || responseCodec == null) {
         throw ArgumentError(
-            'Для режима сериализации требуются оба кодека (requestCodec и responseCodec). '
-            'Текущий режим контракта: $dataTransferMode. '
-            'Получено: requestCodec=${requestCodec != null ? 'указан' : 'null'}, '
-            'responseCodec=${responseCodec != null ? 'указан' : 'null'}');
+          'Для режима сериализации требуются оба кодека (requestCodec и responseCodec). '
+          'Текущий режим контракта: $dataTransferMode. '
+          'Получено: requestCodec=${requestCodec != null ? 'указан' : 'null'}, '
+          'responseCodec=${responseCodec != null ? 'указан' : 'null'}',
+        );
       }
     }
 
@@ -478,9 +498,10 @@ abstract class RpcCallerContract implements IRpcContract {
     if (dataTransferMode == RpcDataTransferMode.auto && !isZeroCopy) {
       if ((requestCodec == null) != (responseCodec == null)) {
         throw ArgumentError(
-            'В auto режиме для сериализации требуются оба кодека. '
-            'Получено: requestCodec=${requestCodec != null ? 'указан' : 'null'}, '
-            'responseCodec=${responseCodec != null ? 'указан' : 'null'}');
+          'В auto режиме для сериализации требуются оба кодека. '
+          'Получено: requestCodec=${requestCodec != null ? 'указан' : 'null'}, '
+          'responseCodec=${responseCodec != null ? 'указан' : 'null'}',
+        );
       }
     }
   }
@@ -522,8 +543,10 @@ abstract class RpcCallerContract implements IRpcContract {
     _validateCodecsForCodecMode(requestCodec, responseCodec);
 
     // Получаем фактически используемые кодеки
-    final (effectiveRequestCodec, effectiveResponseCodec) =
-        _getEffectiveCodecs(requestCodec, responseCodec);
+    final (effectiveRequestCodec, effectiveResponseCodec) = _getEffectiveCodecs(
+      requestCodec,
+      responseCodec,
+    );
 
     return _endpoint.unaryRequest<TRequest, TResponse>(
       serviceName: serviceName,
@@ -550,8 +573,10 @@ abstract class RpcCallerContract implements IRpcContract {
     _validateCodecsForCodecMode(requestCodec, responseCodec);
 
     // Получаем фактически используемые кодеки
-    final (effectiveRequestCodec, effectiveResponseCodec) =
-        _getEffectiveCodecs(requestCodec, responseCodec);
+    final (effectiveRequestCodec, effectiveResponseCodec) = _getEffectiveCodecs(
+      requestCodec,
+      responseCodec,
+    );
 
     return _endpoint.serverStream<TRequest, TResponse>(
       serviceName: serviceName,
@@ -578,8 +603,10 @@ abstract class RpcCallerContract implements IRpcContract {
     _validateCodecsForCodecMode(requestCodec, responseCodec);
 
     // Получаем фактически используемые кодеки
-    final (effectiveRequestCodec, effectiveResponseCodec) =
-        _getEffectiveCodecs(requestCodec, responseCodec);
+    final (effectiveRequestCodec, effectiveResponseCodec) = _getEffectiveCodecs(
+      requestCodec,
+      responseCodec,
+    );
 
     final builder = _endpoint.clientStream<TRequest, TResponse>(
       serviceName: serviceName,
@@ -606,8 +633,10 @@ abstract class RpcCallerContract implements IRpcContract {
     _validateCodecsForCodecMode(requestCodec, responseCodec);
 
     // Получаем фактически используемые кодеки
-    final (effectiveRequestCodec, effectiveResponseCodec) =
-        _getEffectiveCodecs(requestCodec, responseCodec);
+    final (effectiveRequestCodec, effectiveResponseCodec) = _getEffectiveCodecs(
+      requestCodec,
+      responseCodec,
+    );
 
     return _endpoint.bidirectionalStream<TRequest, TResponse>(
       serviceName: serviceName,

--- a/packages/rpc_dart/lib/src/contracts/models.dart
+++ b/packages/rpc_dart/lib/src/contracts/models.dart
@@ -48,7 +48,9 @@ final class RpcMethodRegistration<TRequest extends IRpcSerializable,
 
   /// Безопасный вызов unary handler'а с типизацией и контекстом
   Future<TResponse> callUnaryHandler(
-      RpcContext context, TRequest request) async {
+    RpcContext context,
+    TRequest request,
+  ) async {
     final typedHandler =
         handler as Future<TResponse> Function(TRequest, {RpcContext? context});
     return await typedHandler(request, context: context);
@@ -56,7 +58,9 @@ final class RpcMethodRegistration<TRequest extends IRpcSerializable,
 
   /// Безопасный вызов server stream handler'а с типизацией и контекстом
   Stream<TResponse> callServerStreamHandler(
-      RpcContext context, TRequest request) {
+    RpcContext context,
+    TRequest request,
+  ) {
     final typedHandler =
         handler as Stream<TResponse> Function(TRequest, {RpcContext? context});
     return typedHandler(request, context: context);
@@ -64,17 +68,25 @@ final class RpcMethodRegistration<TRequest extends IRpcSerializable,
 
   /// Безопасный вызов client stream handler'а с типизацией и контекстом
   Future<TResponse> callClientStreamHandler(
-      RpcContext context, Stream<TRequest> requests) async {
-    final typedHandler = handler as Future<TResponse> Function(Stream<TRequest>,
-        {RpcContext? context});
+    RpcContext context,
+    Stream<TRequest> requests,
+  ) async {
+    final typedHandler = handler as Future<TResponse> Function(
+      Stream<TRequest>, {
+      RpcContext? context,
+    });
     return await typedHandler(requests, context: context);
   }
 
   /// Безопасный вызов bidirectional stream handler'а с типизацией и контекстом
   Stream<TResponse> callBidirectionalStreamHandler(
-      RpcContext context, Stream<TRequest> requests) {
-    final typedHandler = handler as Stream<TResponse> Function(Stream<TRequest>,
-        {RpcContext? context});
+    RpcContext context,
+    Stream<TRequest> requests,
+  ) {
+    final typedHandler = handler as Stream<TResponse> Function(
+      Stream<TRequest>, {
+      RpcContext? context,
+    });
     return typedHandler(requests, context: context);
   }
 
@@ -116,7 +128,9 @@ final class RpcZeroCopyMethodRegistration<TRequest extends Object,
 
   /// Безопасный вызов unary handler'а с типизацией и контекстом
   Future<TResponse> callUnaryHandler(
-      RpcContext context, TRequest request) async {
+    RpcContext context,
+    TRequest request,
+  ) async {
     final typedHandler =
         handler as Future<TResponse> Function(TRequest, {RpcContext? context});
     return await typedHandler(request, context: context);
@@ -124,7 +138,9 @@ final class RpcZeroCopyMethodRegistration<TRequest extends Object,
 
   /// Безопасный вызов server stream handler'а с типизацией и контекстом
   Stream<TResponse> callServerStreamHandler(
-      RpcContext context, TRequest request) {
+    RpcContext context,
+    TRequest request,
+  ) {
     final typedHandler =
         handler as Stream<TResponse> Function(TRequest, {RpcContext? context});
     return typedHandler(request, context: context);
@@ -132,17 +148,25 @@ final class RpcZeroCopyMethodRegistration<TRequest extends Object,
 
   /// Безопасный вызов client stream handler'а с типизацией и контекстом
   Future<TResponse> callClientStreamHandler(
-      RpcContext context, Stream<TRequest> requests) async {
-    final typedHandler = handler as Future<TResponse> Function(Stream<TRequest>,
-        {RpcContext? context});
+    RpcContext context,
+    Stream<TRequest> requests,
+  ) async {
+    final typedHandler = handler as Future<TResponse> Function(
+      Stream<TRequest>, {
+      RpcContext? context,
+    });
     return await typedHandler(requests, context: context);
   }
 
   /// Безопасный вызов bidirectional stream handler'а с типизацией и контекстом
   Stream<TResponse> callBidirectionalStreamHandler(
-      RpcContext context, Stream<TRequest> requests) {
-    final typedHandler = handler as Stream<TResponse> Function(Stream<TRequest>,
-        {RpcContext? context});
+    RpcContext context,
+    Stream<TRequest> requests,
+  ) {
+    final typedHandler = handler as Stream<TResponse> Function(
+      Stream<TRequest>, {
+      RpcContext? context,
+    });
     return typedHandler(requests, context: context);
   }
 }

--- a/packages/rpc_dart/lib/src/endpoint/_index.dart
+++ b/packages/rpc_dart/lib/src/endpoint/_index.dart
@@ -9,6 +9,34 @@ import 'package:rpc_dart/rpc_dart.dart';
 part 'caller_endpoint.dart';
 part 'responder_endpoint.dart';
 
+/// Результат проверки состояния RPC эндпоинта.
+final class RpcEndpointHealth {
+  /// Снимок состояния самого эндпоинта.
+  final RpcHealthStatus endpointStatus;
+
+  /// Состояние зависимостей эндпоинта (как правило, транспорта).
+  final Map<String, RpcHealthStatus> dependencies;
+
+  /// Время формирования отчета.
+  final DateTime timestamp;
+
+  RpcEndpointHealth({
+    required this.endpointStatus,
+    Map<String, RpcHealthStatus>? dependencies,
+    DateTime? timestamp,
+  })  : dependencies = Map.unmodifiable(dependencies ?? const {}),
+        timestamp = timestamp ?? DateTime.now();
+
+  /// Возвращает true, если эндпоинт и все зависимости находятся в рабочем
+  /// состоянии.
+  bool get isHealthy =>
+      endpointStatus.isHealthy &&
+      dependencies.values.every((status) => status.isHealthy);
+
+  /// Состояние основного транспорта эндпоинта (если присутствует).
+  RpcHealthStatus? get transportStatus => dependencies['transport'];
+}
+
 /// Базовый класс для всех RPC эндпоинтов
 abstract base class RpcEndpointBase {
   final IRpcTransport _transport;
@@ -24,6 +52,145 @@ abstract base class RpcEndpointBase {
     this.debugLabel,
     this.loggerColors,
   }) : _transport = transport;
+
+  /// Собирает метрики эндпоинта, которые будут добавлены в отчет о состоянии.
+  /// Наследники могут переопределить метод и добавить свои показатели.
+  Map<String, Object?> collectEndpointMetrics() {
+    final metrics = <String, Object?>{
+      'isActive': _isActive,
+      'middlewareCount': _middlewares.length,
+      'transportClosed': _transport.isClosed,
+      'transportType': _transport.runtimeType.toString(),
+    };
+
+    if (debugLabel != null) {
+      metrics['debugLabel'] = debugLabel;
+    }
+
+    return metrics;
+  }
+
+  RpcHealthStatus _createEndpointStatus(RpcHealthStatus transportStatus) {
+    final metrics = collectEndpointMetrics();
+    final componentName = logger.name;
+
+    if (!_isActive) {
+      return RpcHealthStatus.closed(
+        component: componentName,
+        message: 'Endpoint closed',
+        details: metrics,
+      );
+    }
+
+    switch (transportStatus.level) {
+      case RpcHealthLevel.healthy:
+        return RpcHealthStatus.healthy(
+          component: componentName,
+          message: 'Endpoint active',
+          details: metrics,
+        );
+      case RpcHealthLevel.reconnecting:
+        return RpcHealthStatus.reconnecting(
+          component: componentName,
+          message: 'Endpoint waiting for transport reconnection',
+          details: metrics,
+        );
+      case RpcHealthLevel.degraded:
+        return RpcHealthStatus.degraded(
+          component: componentName,
+          message: 'Endpoint degraded due to transport state',
+          details: metrics,
+        );
+      case RpcHealthLevel.unhealthy:
+        return RpcHealthStatus.unhealthy(
+          component: componentName,
+          message: 'Endpoint unavailable because transport failed',
+          details: metrics,
+        );
+      case RpcHealthLevel.closed:
+        return RpcHealthStatus.degraded(
+          component: componentName,
+          message: 'Endpoint active but transport closed',
+          details: {...metrics, 'transportState': transportStatus.level.name},
+        );
+    }
+  }
+
+  Future<RpcHealthStatus> _safeTransportHealth() async {
+    try {
+      return await _transport.health();
+    } catch (error, stackTrace) {
+      await logger.error(
+        'Transport health check failed: $error',
+        error: error,
+        stackTrace: stackTrace,
+      );
+
+      return _transport.isClosed
+          ? RpcHealthStatus.closed(
+              component: _transport.runtimeType.toString(),
+              message: 'Transport is closed after failed health check',
+              details: {
+                'isClosed': _transport.isClosed,
+                'error': error.toString(),
+              },
+            )
+          : RpcHealthStatus.unhealthy(
+              component: _transport.runtimeType.toString(),
+              message: 'Transport health check failed: $error',
+              details: {
+                'isClosed': _transport.isClosed,
+                'error': error.toString(),
+              },
+            );
+    }
+  }
+
+  /// Возвращает снимок состояния эндпоинта и его транспорта.
+  Future<RpcEndpointHealth> health({RpcHealthStatus? transportOverride}) async {
+    final transportStatus = transportOverride ?? await _safeTransportHealth();
+    final endpointStatus = _createEndpointStatus(transportStatus);
+
+    return RpcEndpointHealth(
+      endpointStatus: endpointStatus,
+      dependencies: {'transport': transportStatus},
+    );
+  }
+
+  /// Пытается переподключить транспорт и возвращает обновленный отчет о состоянии.
+  Future<RpcEndpointHealth> reconnect() async {
+    RpcHealthStatus transportStatus;
+
+    try {
+      transportStatus = await _transport.reconnect();
+    } on UnsupportedError catch (error) {
+      await logger.warning(
+        'Transport does not support reconnect: ${error.message ?? error.toString()}',
+      );
+      transportStatus = RpcHealthStatus.degraded(
+        component: _transport.runtimeType.toString(),
+        message: 'Reconnect is not supported by this transport',
+        details: {
+          'supported': false,
+          'isClosed': _transport.isClosed,
+          'error': error.toString(),
+        },
+      );
+    } catch (error, stackTrace) {
+      await logger.error(
+        'Transport reconnect failed: $error',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      transportStatus = RpcHealthStatus.unhealthy(
+        component: _transport.runtimeType.toString(),
+        message: 'Reconnect failed: $error',
+        details: {'isClosed': _transport.isClosed, 'error': error.toString()},
+      );
+    }
+
+    return health(transportOverride: transportStatus);
+  }
 
   void addMiddleware(IRpcMiddleware middleware) {
     _middlewares.add(middleware);

--- a/packages/rpc_dart/lib/src/endpoint/caller_endpoint.dart
+++ b/packages/rpc_dart/lib/src/endpoint/caller_endpoint.dart
@@ -11,11 +11,29 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
   final Map<String, Map<String, RpcCancellationToken>> _cancellationTokens = {};
 
   @override
-  RpcLogger get logger => RpcLogger(
-        'RpcCallerEndpoint',
-        colors: loggerColors,
-        label: debugLabel,
+  Map<String, Object?> collectEndpointMetrics() {
+    final metrics = Map<String, Object?>.from(super.collectEndpointMetrics());
+
+    final activeCalls = _cancellationTokens.values.fold<int>(
+      0,
+      (previousValue, tokens) => previousValue + tokens.length,
+    );
+
+    metrics['pendingRequests'] = activeCalls;
+    metrics['trackedMethods'] = _cancellationTokens.length;
+
+    if (_cancellationTokens.isNotEmpty) {
+      metrics['activeMethodKeys'] = List<String>.unmodifiable(
+        _cancellationTokens.keys,
       );
+    }
+
+    return metrics;
+  }
+
+  @override
+  RpcLogger get logger =>
+      RpcLogger('RpcCallerEndpoint', colors: loggerColors, label: debugLabel);
 
   RpcCallerEndpoint({
     required super.transport,
@@ -53,8 +71,12 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
 
   /// Отменяет конкретный вызов по requestId
   /// Возвращает true, если токен был найден и отменен
-  bool cancelRequest(String serviceName, String methodName, String requestId,
-      [String? reason]) {
+  bool cancelRequest(
+    String serviceName,
+    String methodName,
+    String requestId, [
+    String? reason,
+  ]) {
     final key = _createMethodKey(serviceName, methodName);
     final methodTokens = _cancellationTokens[key];
     if (methodTokens != null) {
@@ -133,15 +155,16 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
       // Проверяем роль транспорта через интерфейс
       if (!transport.isClient) {
         throw ArgumentError(
-            'CRITICAL ERROR: RpcCallerEndpoint requires CLIENT transport!\n'
-            'Received server transport (isClient: false).\n'
-            'Client endpoints must use transports with odd Stream IDs (1, 3, 5...).\n\n'
-            'Correct usage:\n'
-            '  final (clientTransport, serverTransport) = RpcInMemoryTransport.pair();\n'
-            '  final callerEndpoint = RpcCallerEndpoint(transport: clientTransport);\n'
-            '  final responderEndpoint = RpcResponderEndpoint(transport: serverTransport);\n\n'
-            'INCORRECT:\n'
-            '  final callerEndpoint = RpcCallerEndpoint(transport: serverTransport);\n');
+          'CRITICAL ERROR: RpcCallerEndpoint requires CLIENT transport!\n'
+          'Received server transport (isClient: false).\n'
+          'Client endpoints must use transports with odd Stream IDs (1, 3, 5...).\n\n'
+          'Correct usage:\n'
+          '  final (clientTransport, serverTransport) = RpcInMemoryTransport.pair();\n'
+          '  final callerEndpoint = RpcCallerEndpoint(transport: clientTransport);\n'
+          '  final responderEndpoint = RpcResponderEndpoint(transport: serverTransport);\n\n'
+          'INCORRECT:\n'
+          '  final callerEndpoint = RpcCallerEndpoint(transport: serverTransport);\n',
+        );
       }
 
       logger.internal('Transport validated: client (isClient: true)');
@@ -184,9 +207,7 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
     String serviceName,
     String methodName,
   ) {
-    final routingHeaders = {
-      'x-route-service': serviceName,
-    };
+    final routingHeaders = {'x-route-service': serviceName};
 
     final key = _createMethodKey(serviceName, methodName);
 
@@ -246,7 +267,8 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
     // Проверяем активность эндпоинта
     if (!isActive) {
       throw StateError(
-          'RpcCallerEndpoint закрыт и не может обрабатывать запросы');
+        'RpcCallerEndpoint закрыт и не может обрабатывать запросы',
+      );
     }
 
     final isZeroCopy = requestCodec == null && responseCodec == null;
@@ -254,14 +276,17 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
     // Zero-copy режим: требуется поддержка zero-copy транспортом
     if (isZeroCopy && !transport.supportsZeroCopy) {
       throw ArgumentError(
-          'Zero-copy режим требует транспорт с поддержкой zero-copy. '
-          'Для сетевых транспортов передайте кодеки.');
+        'Zero-copy режим требует транспорт с поддержкой zero-copy. '
+        'Для сетевых транспортов передайте кодеки.',
+      );
     }
 
     // Режим сериализации: кодеки обязательны
     if (!isZeroCopy && (requestCodec == null || responseCodec == null)) {
-      throw ArgumentError('Кодеки обязательны для режима сериализации. '
-          'Для zero-copy не передавайте кодеки (null).');
+      throw ArgumentError(
+        'Кодеки обязательны для режима сериализации. '
+        'Для zero-copy не передавайте кодеки (null).',
+      );
     }
 
     // Автоматически создаем или дополняем контекст с trace ID и роутинговыми заголовками
@@ -294,10 +319,8 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
 
   /// Внутренняя реализация универсального унарного вызова
   Future<TResponse> _executeUniversalUnaryCall<TRequest extends Object,
-      TResponse extends Object>(
-    CallProcessor<TRequest, TResponse> processor,
-    TRequest request,
-  ) async {
+          TResponse extends Object>(
+      CallProcessor<TRequest, TResponse> processor, TRequest request) async {
     try {
       // Отправляем запрос
       await processor.send(request);
@@ -311,13 +334,15 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
 
         // Проверяем статус в метаданных
         if (response.metadata != null) {
-          final statusStr = response.metadata!
-              .getHeaderValue(RpcConstants.GRPC_STATUS_HEADER);
+          final statusStr = response.metadata!.getHeaderValue(
+            RpcConstants.GRPC_STATUS_HEADER,
+          );
           if (statusStr != null) {
             final status = int.tryParse(statusStr) ?? RpcStatus.UNKNOWN;
             if (status != RpcStatus.OK) {
-              final message = response.metadata!
-                      .getHeaderValue(RpcConstants.GRPC_MESSAGE_HEADER) ??
+              final message = response.metadata!.getHeaderValue(
+                    RpcConstants.GRPC_MESSAGE_HEADER,
+                  ) ??
                   'Unknown error';
               throw Exception('gRPC error $status: $message');
             }
@@ -326,7 +351,8 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
       }
 
       throw Exception(
-          'gRPC error ${RpcStatus.UNAVAILABLE}: No response received');
+        'gRPC error ${RpcStatus.UNAVAILABLE}: No response received',
+      );
     } finally {
       await processor.close();
     }
@@ -373,7 +399,8 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
     // Проверяем активность эндпоинта
     if (!isActive) {
       throw StateError(
-          'RpcCallerEndpoint закрыт и не может обрабатывать запросы');
+        'RpcCallerEndpoint закрыт и не может обрабатывать запросы',
+      );
     }
 
     final isZeroCopy = requestCodec == null && responseCodec == null;
@@ -381,18 +408,22 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
     // Zero-copy режим: требуется поддержка zero-copy транспортом
     if (isZeroCopy && !transport.supportsZeroCopy) {
       throw ArgumentError(
-          'Zero-copy режим требует транспорт с поддержкой zero-copy. '
-          'Для сетевых транспортов передайте кодеки.');
+        'Zero-copy режим требует транспорт с поддержкой zero-copy. '
+        'Для сетевых транспортов передайте кодеки.',
+      );
     }
 
     // Режим сериализации: кодеки обязательны
     if (!isZeroCopy && (requestCodec == null || responseCodec == null)) {
-      throw ArgumentError('Кодеки обязательны для режима сериализации. '
-          'Для zero-copy не передавайте кодеки (null).');
+      throw ArgumentError(
+        'Кодеки обязательны для режима сериализации. '
+        'Для zero-copy не передавайте кодеки (null).',
+      );
     }
 
     logger.internal(
-        'Создание ${isZeroCopy ? "zero-copy" : "serialized"} server stream для $serviceName/$methodName');
+      'Создание ${isZeroCopy ? "zero-copy" : "serialized"} server stream для $serviceName/$methodName',
+    );
 
     // Автоматически создаем или дополняем контекст с trace ID и роутинговыми заголовками
     final enhancedContext = _effectiveContext(context, serviceName, methodName);
@@ -422,7 +453,8 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
     RpcContext? context,
   }) {
     logger.internal(
-        'Создание client stream builder для $serviceName/$methodName');
+      'Создание client stream builder для $serviceName/$methodName',
+    );
 
     // Автоматически создаем или дополняем контекст с trace ID и роутинговыми заголовками
     final enhancedContext = _effectiveContext(context, serviceName, methodName);
@@ -450,8 +482,11 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
             await caller.send(request);
           },
           onError: (error, stackTrace) {
-            logger.error('Ошибка в потоке запросов client stream',
-                error: error, stackTrace: stackTrace);
+            logger.error(
+              'Ошибка в потоке запросов client stream',
+              error: error,
+              stackTrace: stackTrace,
+            );
           },
           onDone: () {
             logger.internal('Поток запросов client stream завершен');
@@ -483,8 +518,9 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
     IRpcCodec<R>? responseCodec,
     RpcContext? context,
   }) {
-    logger
-        .internal('Создание bidirectional stream для $serviceName/$methodName');
+    logger.internal(
+      'Создание bidirectional stream для $serviceName/$methodName',
+    );
 
     // Автоматически создаем или дополняем контекст с trace ID и роутинговыми заголовками
     final enhancedContext = _effectiveContext(context, serviceName, methodName);
@@ -518,8 +554,11 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
     final requestSubscription = requests.listen(
       (request) => caller.send(request),
       onError: (error, stackTrace) {
-        logger.error('Ошибка при отправке запроса в bidirectional stream',
-            error: error, stackTrace: stackTrace);
+        logger.error(
+          'Ошибка при отправке запроса в bidirectional stream',
+          error: error,
+          stackTrace: stackTrace,
+        );
         controller.addError(error, stackTrace);
       },
       onDone: () async {

--- a/packages/rpc_dart/lib/src/endpoint/responder_endpoint.dart
+++ b/packages/rpc_dart/lib/src/endpoint/responder_endpoint.dart
@@ -15,6 +15,26 @@ typedef _MethodCallInfo = ({
 /// Серверный RPC эндпоинт для обработки запросов
 final class RpcResponderEndpoint extends RpcEndpointBase {
   @override
+  Map<String, Object?> collectEndpointMetrics() {
+    final metrics = Map<String, Object?>.from(super.collectEndpointMetrics());
+
+    metrics['registeredContracts'] = _contracts.length;
+    metrics['registeredMethods'] = _methods.length;
+    metrics['isListening'] = _isListening;
+    metrics['openStreams'] = _streamMethods.length;
+    metrics['metadataStreams'] = _streamMetadata.length;
+    metrics['bufferedMessages'] = _streamMessages.length;
+    metrics['clientStreamBuffers'] = _clientStreamMessages.length;
+    metrics['activeResponders'] = _streamResponders.length;
+
+    if (_contracts.isNotEmpty) {
+      metrics['contractKeys'] = List<String>.unmodifiable(_contracts.keys);
+    }
+
+    return metrics;
+  }
+
+  @override
   RpcLogger get logger => RpcLogger(
         'RpcResponderEndpoint',
         colors: loggerColors,
@@ -57,8 +77,12 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     int? streamId,
     String? methodKey,
   }) {
-    final logMessage = _formatLogMessage(message,
-        context: context, streamId: streamId, methodKey: methodKey);
+    final logMessage = _formatLogMessage(
+      message,
+      context: context,
+      streamId: streamId,
+      methodKey: methodKey,
+    );
     logger.internal(logMessage, rpcContext: context);
   }
 
@@ -68,8 +92,12 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     int? streamId,
     String? methodKey,
   }) {
-    final logMessage = _formatLogMessage(message,
-        context: context, streamId: streamId, methodKey: methodKey);
+    final logMessage = _formatLogMessage(
+      message,
+      context: context,
+      streamId: streamId,
+      methodKey: methodKey,
+    );
     logger.internal(logMessage, rpcContext: context);
   }
 
@@ -81,10 +109,18 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     Object? error,
     StackTrace? stackTrace,
   }) {
-    final logMessage = _formatLogMessage(message,
-        context: context, streamId: streamId, methodKey: methodKey);
-    logger.error(logMessage,
-        rpcContext: context, error: error, stackTrace: stackTrace);
+    final logMessage = _formatLogMessage(
+      message,
+      context: context,
+      streamId: streamId,
+      methodKey: methodKey,
+    );
+    logger.error(
+      logMessage,
+      rpcContext: context,
+      error: error,
+      stackTrace: stackTrace,
+    );
   }
 
   String _formatLogMessage(
@@ -114,12 +150,14 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     }
 
     // Создаем контекст с автогенерацией trace ID
-    return _createContextFromMessage(RpcTransportMessage(
-      streamId: streamId,
-      methodPath: _streamMethods[streamId] != null
-          ? '/${_streamMethods[streamId]!.replaceAll('.', '/')}'
-          : '/UnknownService/UnknownMethod',
-    ));
+    return _createContextFromMessage(
+      RpcTransportMessage(
+        streamId: streamId,
+        methodPath: _streamMethods[streamId] != null
+            ? '/${_streamMethods[streamId]!.replaceAll('.', '/')}'
+            : '/UnknownService/UnknownMethod',
+      ),
+    );
   }
 
   Map<String, dynamic> get registeredContracts => Map.unmodifiable(_contracts);
@@ -141,15 +179,16 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
       // Проверяем роль транспорта через интерфейс
       if (transport.isClient) {
         throw ArgumentError(
-            'CRITICAL ERROR: RpcResponderEndpoint requires SERVER transport!\n'
-            'Received client transport (isClient: true).\n'
-            'Server endpoints must use transports with even Stream IDs (2, 4, 6...).\n\n'
-            'Correct usage:\n'
-            '  final (clientTransport, serverTransport) = RpcInMemoryTransport.pair();\n'
-            '  final callerEndpoint = RpcCallerEndpoint(transport: clientTransport);\n'
-            '  final responderEndpoint = RpcResponderEndpoint(transport: serverTransport);\n\n'
-            'INCORRECT:\n'
-            '  final responderEndpoint = RpcResponderEndpoint(transport: clientTransport);\n');
+          'CRITICAL ERROR: RpcResponderEndpoint requires SERVER transport!\n'
+          'Received client transport (isClient: true).\n'
+          'Server endpoints must use transports with even Stream IDs (2, 4, 6...).\n\n'
+          'Correct usage:\n'
+          '  final (clientTransport, serverTransport) = RpcInMemoryTransport.pair();\n'
+          '  final callerEndpoint = RpcCallerEndpoint(transport: clientTransport);\n'
+          '  final responderEndpoint = RpcResponderEndpoint(transport: serverTransport);\n\n'
+          'INCORRECT:\n'
+          '  final responderEndpoint = RpcResponderEndpoint(transport: clientTransport);\n',
+        );
       }
 
       logger.internal('Transport validated: server (isClient: false)');
@@ -166,16 +205,12 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     super.start();
 
     if (_isListening) {
-      logger.warning(
-        'RpcResponderEndpoint уже слушает входящие запросы',
-      );
+      logger.warning('RpcResponderEndpoint уже слушает входящие запросы');
       return;
     }
 
     _isListening = true;
-    transport.incomingMessages.listen(
-      _handleIncomingMessage,
-    );
+    transport.incomingMessages.listen(_handleIncomingMessage);
   }
 
   /// Этап 2: Обрабатывает входящее сообщение от транспорта
@@ -214,7 +249,8 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
         // СПЕЦИАЛЬНАЯ ОБРАБОТКА для Client Streaming - создаем респондер ТОЛЬКО СЕЙЧАС
         if (method != null && method.type == RpcMethodType.clientStream) {
           logger.internal(
-              'Stream $streamId завершен, создаем ClientStreamResponder с накопленными сообщениями');
+            'Stream $streamId завершен, создаем ClientStreamResponder с накопленными сообщениями',
+          );
           final parts = methodKey.split('.');
           final serviceName = parts[0];
           final methodName = parts[1];
@@ -250,8 +286,9 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
   void _handleMetadataMessage(int streamId, RpcTransportMessage message) {
     // Проверяем, является ли это уведомлением об отмене от клиента
     if (message.metadata != null) {
-      final isCancelled =
-          message.metadata!.getHeaderValue('x-client-cancelled');
+      final isCancelled = message.metadata!.getHeaderValue(
+        'x-client-cancelled',
+      );
       if (isCancelled == 'true') {
         final reason =
             message.metadata!.getHeaderValue('x-cancellation-reason') ??
@@ -265,9 +302,7 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     final methodInfo = _parseMethodPath(methodPath);
 
     if (methodInfo == null) {
-      logger.warning(
-        'Некорректный путь метода: $methodPath',
-      );
+      logger.warning('Некорректный путь метода: $methodPath');
       return;
     }
 
@@ -312,9 +347,7 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     // Находим и отменяем активный респондер для данного stream
     final responder = _streamResponders[streamId];
     if (responder != null) {
-      logger.internal(
-        'Отменяем активный респондер [streamId: $streamId]',
-      );
+      logger.internal('Отменяем активный респондер [streamId: $streamId]');
 
       // Отменяем респондер (он сам должен очистить ресурсы)
       if (responder is UnaryResponder) {
@@ -333,9 +366,7 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     // Очищаем все данные для этого stream
     _cleanupStream(streamId);
 
-    logger.internal(
-      'Обработка отмены завершена [streamId: $streamId]',
-    );
+    logger.internal('Обработка отмены завершена [streamId: $streamId]');
   }
 
   /// Этап 2.2: Обрабатывает сообщение с данными
@@ -347,9 +378,7 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
       final methodInfo = _parseMethodPath(methodPath);
 
       if (methodInfo == null) {
-        logger.warning(
-          'Некорректный путь метода: $methodPath',
-        );
+        logger.warning('Некорректный путь метода: $methodPath');
         return;
       }
 
@@ -458,9 +487,7 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
 
   /// Этап 2.3: Очищает информацию о потоке при его завершении
   void _cleanupStream(int streamId) {
-    logger.internal(
-      'Поток завершен [streamId: $streamId]',
-    );
+    logger.internal('Поток завершен [streamId: $streamId]');
 
     // Закрываем и удаляем респондер, если он существует
     final responder = _streamResponders[streamId];
@@ -479,9 +506,7 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     // Сообщаем транспорту, что этот ID больше не используется
     try {
       transport.releaseStreamId(streamId);
-      logger.internal(
-        'ID стрима освобожден [streamId: $streamId]',
-      );
+      logger.internal('ID стрима освобожден [streamId: $streamId]');
     } catch (e) {
       logger.warning(
         'Не удалось освободить ID стрима [streamId: $streamId]: $e',
@@ -491,9 +516,7 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
 
   /// Этап 3: Парсинг пути метода из строки формата /service/method
   (String, String)? _parseMethodPath(String methodPath) {
-    final parts = methodPath.split(
-      '/',
-    );
+    final parts = methodPath.split('/');
 
     if (parts.length != 3 || parts[0].isNotEmpty) {
       return null;
@@ -563,7 +586,8 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     if (isZeroCopyMethod && transport.supportsZeroCopy) {
       // 🚀 Создаем zero-copy унарный респондер используя ZeroCopyStreamProcessor
       contextLogger.internal(
-          'Создание zero-copy унарного респондера [streamId: $streamId]');
+        'Создание zero-copy унарного респондера [streamId: $streamId]',
+      );
 
       final zeroCopyMethod = contract!.zeroCopyMethods[methodName]!;
 
@@ -587,9 +611,12 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
       processor.requests.listen((request) async {
         try {
           contextLogger.internal(
-              'Обработка zero-copy унарного запроса [streamId: $streamId]');
-          final response =
-              await zeroCopyMethod.callUnaryHandler(context, request);
+            'Обработка zero-copy унарного запроса [streamId: $streamId]',
+          );
+          final response = await zeroCopyMethod.callUnaryHandler(
+            context,
+            request,
+          );
           await processor.send(response);
           await processor.finishSending();
         } catch (e, stackTrace) {
@@ -614,14 +641,17 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
           savedMessage.isDirect &&
           savedMessage.directPayload != null) {
         contextLogger.internal(
-            'Создаем zero-copy поток с сохраненным direct сообщением [streamId: $streamId]');
+          'Создаем zero-copy поток с сохраненным direct сообщением [streamId: $streamId]',
+        );
         // Создаем поток который начинается с сохраненного direct сообщения
         messageStream = _createStreamWithSavedMessage(streamId, savedMessage);
       } else {
         contextLogger.internal(
-            'Создаем обычный zero-copy поток сообщений [streamId: $streamId]');
-        messageStream =
-            transport.incomingMessages.where((msg) => msg.streamId == streamId);
+          'Создаем обычный zero-copy поток сообщений [streamId: $streamId]',
+        );
+        messageStream = transport.incomingMessages.where(
+          (msg) => msg.streamId == streamId,
+        );
       }
 
       // Привязываем процессор к потоку сообщений
@@ -638,8 +668,10 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
         handler: (request) async {
           // Используем типизированный wrapper для безопасного вызова
           final typedRequest = request as dynamic; // Dart runtime cast
-          final response =
-              await i.method.callUnaryHandler(context, typedRequest);
+          final response = await i.method.callUnaryHandler(
+            context,
+            typedRequest,
+          );
           return i.method.castResponse(response);
         },
         context: context, // Передаем контекст для мониторинга отмены
@@ -667,12 +699,14 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
   void _handleClientStreamMethod(_MethodCallInfo i) {
     final streamId = i.streamId;
     logger.internal(
-        '_handleClientStreamMethod для stream $streamId, уже есть: ${_streamResponders.containsKey(streamId)}');
+      '_handleClientStreamMethod для stream $streamId, уже есть: ${_streamResponders.containsKey(streamId)}',
+    );
 
     // Если респондер уже существует, НЕ создаем новый
     if (_streamResponders.containsKey(streamId)) {
       logger.internal(
-          'Респондер для stream $streamId уже существует, респондер обработает сообщение через transport.incomingMessages');
+        'Респондер для stream $streamId уже существует, респондер обработает сообщение через transport.incomingMessages',
+      );
       return;
     }
 
@@ -680,11 +714,13 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     final methodName = i.methodName;
 
     // Создаем контекст из метаданных
-    final context = _createContextFromMessage(_streamMetadata[streamId] ??
-        RpcTransportMessage(
-          streamId: streamId,
-          methodPath: '/$serviceName/$methodName',
-        ));
+    final context = _createContextFromMessage(
+      _streamMetadata[streamId] ??
+          RpcTransportMessage(
+            streamId: streamId,
+            methodPath: '/$serviceName/$methodName',
+          ),
+    );
 
     // Создаем контекстный логгер
     final contextLogger = _createContextLogger(context);
@@ -697,7 +733,8 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     if (isZeroCopyMethod && transport.supportsZeroCopy) {
       // 🚀 Создаем zero-copy клиентский стрим респондер
       contextLogger.internal(
-          'Создание zero-copy клиентского стрим респондера [streamId: $streamId]');
+        'Создание zero-copy клиентского стрим респондера [streamId: $streamId]',
+      );
 
       final zeroCopyMethod = contract!.zeroCopyMethods[methodName]!;
 
@@ -708,10 +745,13 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
         methodName: methodName,
         handler: (Stream<Object> requests) async {
           contextLogger.internal(
-              'Обработка zero-copy клиентского стрим запроса [streamId: $streamId]');
+            'Обработка zero-copy клиентского стрим запроса [streamId: $streamId]',
+          );
           // Вызываем zero-copy handler (типы уже адаптированы в контракте)
           return await zeroCopyMethod.callClientStreamHandler(
-              context, requests);
+            context,
+            requests,
+          );
         },
         context: context, // Передаем контекст для мониторинга отмены
         logger: contextLogger,
@@ -719,7 +759,8 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
 
       _streamResponders[responder.id] = responder;
       contextLogger.internal(
-          'Сохранили zero-copy ClientStreamResponder для stream ${responder.id}');
+        'Сохранили zero-copy ClientStreamResponder для stream ${responder.id}',
+      );
 
       // 🚀 Создаем поток сообщений для zero-copy клиентского стрима
       Stream<RpcTransportMessage> messageStream;
@@ -727,13 +768,16 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
       final savedMessages = _clientStreamMessages[streamId];
       if (savedMessages != null && savedMessages.isNotEmpty) {
         contextLogger.internal(
-            'Создание zero-copy потока с ${savedMessages.length} накопленными сообщениями [streamId: $streamId]');
+          'Создание zero-copy потока с ${savedMessages.length} накопленными сообщениями [streamId: $streamId]',
+        );
         messageStream = _createStreamWithSavedMessages(streamId, savedMessages);
       } else {
         contextLogger.internal(
-            'Создание zero-copy потока сообщений [streamId: $streamId]');
-        messageStream =
-            transport.incomingMessages.where((msg) => msg.streamId == streamId);
+          'Создание zero-copy потока сообщений [streamId: $streamId]',
+        );
+        messageStream = transport.incomingMessages.where(
+          (msg) => msg.streamId == streamId,
+        );
       }
 
       responder.bindToMessageStream(messageStream);
@@ -750,8 +794,10 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
         handler: (Stream<IRpcSerializable> requests) async {
           // Используем типизированные wrapper'ы для безопасного вызова
           final typedRequests = i.method.castRequestStream(requests);
-          final response =
-              await i.method.callClientStreamHandler(context, typedRequests);
+          final response = await i.method.callClientStreamHandler(
+            context,
+            typedRequests,
+          );
           return i.method.castResponse(response);
         },
         context: context, // Передаем контекст для мониторинга отмены
@@ -761,7 +807,8 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
       // Сохраняем респондер
       _streamResponders[responder.id] = responder;
       logger.internal(
-          'Сохранили ClientStreamResponder для stream ${responder.id}. Всего респондеров: ${_streamResponders.length}');
+        'Сохранили ClientStreamResponder для stream ${responder.id}. Всего респондеров: ${_streamResponders.length}',
+      );
 
       // Создаем поток сообщений для этого streamId
       // Используем накопленные сообщения Client Streaming
@@ -770,17 +817,21 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
       final savedMessages = _clientStreamMessages[streamId];
       if (savedMessages != null && savedMessages.isNotEmpty) {
         logger.internal(
-            'Создание потока с ${savedMessages.length} накопленными сообщениями [streamId: $streamId]');
+          'Создание потока с ${savedMessages.length} накопленными сообщениями [streamId: $streamId]',
+        );
         messageStream = _createStreamWithSavedMessages(streamId, savedMessages);
       } else {
         logger.internal(
-            'Создание обычного потока сообщений [streamId: $streamId]');
-        messageStream =
-            transport.incomingMessages.where((msg) => msg.streamId == streamId);
+          'Создание обычного потока сообщений [streamId: $streamId]',
+        );
+        messageStream = transport.incomingMessages.where(
+          (msg) => msg.streamId == streamId,
+        );
       }
 
       logger.internal(
-          'Привязка потока сообщений к ClientStreamResponder [streamId: $streamId]');
+        'Привязка потока сообщений к ClientStreamResponder [streamId: $streamId]',
+      );
       responder.bindToMessageStream(messageStream);
     }
   }
@@ -796,11 +847,13 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     final methodName = i.methodName;
 
     // Создаем контекст из метаданных
-    final context = _createContextFromMessage(_streamMetadata[streamId] ??
-        RpcTransportMessage(
-          streamId: streamId,
-          methodPath: '/$serviceName/$methodName',
-        ));
+    final context = _createContextFromMessage(
+      _streamMetadata[streamId] ??
+          RpcTransportMessage(
+            streamId: streamId,
+            methodPath: '/$serviceName/$methodName',
+          ),
+    );
 
     // Создаем контекстный логгер
     final contextLogger = _createContextLogger(context);
@@ -813,7 +866,8 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     if (isZeroCopyMethod && transport.supportsZeroCopy) {
       // 🚀 Создаем zero-copy серверный стрим респондер
       contextLogger.internal(
-          'Создание zero-copy серверного стрим респондера [streamId: $streamId]');
+        'Создание zero-copy серверного стрим респондера [streamId: $streamId]',
+      );
 
       final zeroCopyMethod = contract!.zeroCopyMethods[methodName]!;
 
@@ -824,7 +878,8 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
         methodName: methodName,
         handler: (request) {
           contextLogger.internal(
-              'Обработка zero-copy серверного стрим запроса [streamId: $streamId]');
+            'Обработка zero-copy серверного стрим запроса [streamId: $streamId]',
+          );
           // Вызываем zero-copy handler который возвращает Stream<Object>
           return zeroCopyMethod.callServerStreamHandler(context, request);
         },
@@ -842,13 +897,16 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
           savedMessage.isDirect &&
           savedMessage.directPayload != null) {
         contextLogger.internal(
-            'Создаем zero-copy серверный стрим поток с сохраненным direct сообщением [streamId: $streamId]');
+          'Создаем zero-copy серверный стрим поток с сохраненным direct сообщением [streamId: $streamId]',
+        );
         messageStream = _createStreamWithSavedMessage(streamId, savedMessage);
       } else {
         contextLogger.internal(
-            'Создаем обычный zero-copy серверный стрим поток сообщений [streamId: $streamId]');
-        messageStream =
-            transport.incomingMessages.where((msg) => msg.streamId == streamId);
+          'Создаем обычный zero-copy серверный стрим поток сообщений [streamId: $streamId]',
+        );
+        messageStream = transport.incomingMessages.where(
+          (msg) => msg.streamId == streamId,
+        );
       }
 
       responder.bindToMessageStream(messageStream);
@@ -864,11 +922,14 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
         handler: (request) {
           // Используем типизированный wrapper для безопасного вызова
           final typedRequest = request as dynamic; // Dart runtime cast
-          final responseStream =
-              i.method.callServerStreamHandler(context, typedRequest);
+          final responseStream = i.method.callServerStreamHandler(
+            context,
+            typedRequest,
+          );
           // Кастим поток ответов к базовому типу
-          return responseStream
-              .map((response) => i.method.castResponse(response));
+          return responseStream.map(
+            (response) => i.method.castResponse(response),
+          );
         },
         context: context, // Передаем контекст для мониторинга отмены
         logger: contextLogger, // Передаем контекстный логгер
@@ -884,41 +945,51 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
           !savedMessage.isMetadataOnly &&
           (savedMessage.payload != null || savedMessage.isDirect)) {
         logger.internal(
-            'Создание потока с сохраненным сообщением [streamId: $streamId]${savedMessage.isDirect ? " (zero-copy)" : ""}');
+          'Создание потока с сохраненным сообщением [streamId: $streamId]${savedMessage.isDirect ? " (zero-copy)" : ""}',
+        );
         // Создаем поток который начинается с сохраненного сообщения
         messageStream = _createStreamWithSavedMessage(streamId, savedMessage);
       } else {
         logger.internal(
-            'Создание обычного потока сообщений [streamId: $streamId]');
+          'Создание обычного потока сообщений [streamId: $streamId]',
+        );
         // Обычный поток сообщений для этого streamId
-        messageStream =
-            transport.incomingMessages.where((msg) => msg.streamId == streamId);
+        messageStream = transport.incomingMessages.where(
+          (msg) => msg.streamId == streamId,
+        );
       }
 
       logger.internal(
-          'Привязка потока сообщений к ServerStreamResponder [streamId: $streamId]');
+        'Привязка потока сообщений к ServerStreamResponder [streamId: $streamId]',
+      );
       responder.bindToMessageStream(messageStream);
     }
   }
 
   /// Создает поток сообщений начинающийся с сохраненного сообщения
   Stream<RpcTransportMessage> _createStreamWithSavedMessage(
-      int streamId, RpcTransportMessage savedMessage) async* {
+    int streamId,
+    RpcTransportMessage savedMessage,
+  ) async* {
     // Сначала отправляем сохраненное сообщение
     yield savedMessage;
 
     // Затем пропускаем остальные сообщения для этого streamId
-    await for (final msg
-        in transport.incomingMessages.where((m) => m.streamId == streamId)) {
+    await for (final msg in transport.incomingMessages.where(
+      (m) => m.streamId == streamId,
+    )) {
       yield msg;
     }
   }
 
   /// Создает поток сообщений начинающийся с сохраненных сообщений
   Stream<RpcTransportMessage> _createStreamWithSavedMessages(
-      int streamId, List<RpcTransportMessage> savedMessages) async* {
+    int streamId,
+    List<RpcTransportMessage> savedMessages,
+  ) async* {
     logger.internal(
-        'Создание потока для stream $streamId с ${savedMessages.length} сохраненными сообщениями');
+      'Создание потока для stream $streamId с ${savedMessages.length} сохраненными сообщениями',
+    );
 
     // Создаем копию списка, чтобы избежать concurrent modification
     final messagesCopy = List<RpcTransportMessage>.from(savedMessages);
@@ -942,18 +1013,22 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
           : message;
 
       logger.internal(
-          'Отдаем сохраненное сообщение для stream $streamId${isLastMessage ? " (END_STREAM)" : ""}');
+        'Отдаем сохраненное сообщение для stream $streamId${isLastMessage ? " (END_STREAM)" : ""}',
+      );
       yield messageToYield;
     }
 
-    logger
-        .internal('Все сохраненные сообщения отправлены для stream $streamId');
+    logger.internal(
+      'Все сохраненные сообщения отправлены для stream $streamId',
+    );
 
     // Затем пропускаем остальные сообщения для этого streamId
-    await for (final msg
-        in transport.incomingMessages.where((m) => m.streamId == streamId)) {
+    await for (final msg in transport.incomingMessages.where(
+      (m) => m.streamId == streamId,
+    )) {
       logger.internal(
-          'Передаем новое сообщение от transport для stream $streamId');
+        'Передаем новое сообщение от transport для stream $streamId',
+      );
       yield msg;
     }
   }
@@ -969,11 +1044,13 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     final methodName = i.methodName;
 
     // Создаем контекст из метаданных
-    final context = _createContextFromMessage(_streamMetadata[streamId] ??
-        RpcTransportMessage(
-          streamId: streamId,
-          methodPath: '/$serviceName/$methodName',
-        ));
+    final context = _createContextFromMessage(
+      _streamMetadata[streamId] ??
+          RpcTransportMessage(
+            streamId: streamId,
+            methodPath: '/$serviceName/$methodName',
+          ),
+    );
 
     // Создаем контекстный логгер
     final contextLogger = _createContextLogger(context);
@@ -986,7 +1063,8 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     if (isZeroCopyMethod && transport.supportsZeroCopy) {
       // 🚀 Создаем zero-copy двунаправленный стрим респондер
       contextLogger.internal(
-          'Создание zero-copy двунаправленного стрим респондера [streamId: $streamId]');
+        'Создание zero-copy двунаправленного стрим респондера [streamId: $streamId]',
+      );
 
       final zeroCopyMethod = contract!.zeroCopyMethods[methodName]!;
 
@@ -1009,20 +1087,29 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
           !savedMessage.isMetadataOnly &&
           (savedMessage.payload != null || savedMessage.isDirect)) {
         contextLogger.internal(
-            'Создание zero-copy потока с сохраненным сообщением [streamId: $streamId]${savedMessage.isDirect ? " (zero-copy)" : ""}');
+          'Создание zero-copy потока с сохраненным сообщением [streamId: $streamId]${savedMessage.isDirect ? " (zero-copy)" : ""}',
+        );
         messageStream = _createStreamWithSavedMessage(streamId, savedMessage);
       } else {
         contextLogger.internal(
-            'Создание zero-copy потока сообщений [streamId: $streamId]');
-        messageStream =
-            transport.incomingMessages.where((msg) => msg.streamId == streamId);
+          'Создание zero-copy потока сообщений [streamId: $streamId]',
+        );
+        messageStream = transport.incomingMessages.where(
+          (msg) => msg.streamId == streamId,
+        );
       }
 
       responder.bindToMessageStream(messageStream);
 
       // 🚀 Настраиваем zero-copy обработчик
-      _setupZeroCopyBidirectionalHandler(responder, zeroCopyMethod, serviceName,
-          methodName, streamId, context);
+      _setupZeroCopyBidirectionalHandler(
+        responder,
+        zeroCopyMethod,
+        serviceName,
+        methodName,
+        streamId,
+        context,
+      );
     } else {
       // Обычный двунаправленный стрим респондер
       final responder =
@@ -1047,22 +1134,32 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
           !savedMessage.isMetadataOnly &&
           (savedMessage.payload != null || savedMessage.isDirect)) {
         logger.internal(
-            'Создание потока с сохраненным сообщением [streamId: $streamId]${savedMessage.isDirect ? " (zero-copy)" : ""}');
+          'Создание потока с сохраненным сообщением [streamId: $streamId]${savedMessage.isDirect ? " (zero-copy)" : ""}',
+        );
         messageStream = _createStreamWithSavedMessage(streamId, savedMessage);
       } else {
         logger.internal(
-            'Создание обычного потока сообщений [streamId: $streamId]');
-        messageStream =
-            transport.incomingMessages.where((msg) => msg.streamId == streamId);
+          'Создание обычного потока сообщений [streamId: $streamId]',
+        );
+        messageStream = transport.incomingMessages.where(
+          (msg) => msg.streamId == streamId,
+        );
       }
 
       logger.internal(
-          'Привязка потока сообщений к BidirectionalStreamResponder [streamId: $streamId]');
+        'Привязка потока сообщений к BidirectionalStreamResponder [streamId: $streamId]',
+      );
       responder.bindToMessageStream(messageStream);
 
       // Подключаем пользовательский обработчик к потоку запросов
-      _setupBidirectionalHandler(responder, i.method, i.serviceName,
-          i.methodName, i.streamId, context);
+      _setupBidirectionalHandler(
+        responder,
+        i.method,
+        i.serviceName,
+        i.methodName,
+        i.streamId,
+        context,
+      );
     }
   }
 
@@ -1076,28 +1173,34 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     RpcContext context,
   ) {
     logger.internal(
-        'Настройка обработчика двунаправленного стрима [id: ${responder.id}]');
+      'Настройка обработчика двунаправленного стрима [id: ${responder.id}]',
+    );
 
     // Подписываемся на поток запросов и связываем с пользовательским обработчиком
     unawaited(() async {
       try {
         logger.internal(
-            'Вызов пользовательского обработчика [id: ${responder.id}]');
+          'Вызов пользовательского обработчика [id: ${responder.id}]',
+        );
 
         // Используем переданный контекст (уже создан из метаданных)
 
         // Используем типизированные wrapper'ы для безопасного вызова
         final typedRequests = method.castRequestStream(responder.requests);
-        final responseStream =
-            method.callBidirectionalStreamHandler(context, typedRequests);
+        final responseStream = method.callBidirectionalStreamHandler(
+          context,
+          typedRequests,
+        );
 
         logger.internal(
-            'Получен поток ответов от обработчика [id: ${responder.id}]');
+          'Получен поток ответов от обработчика [id: ${responder.id}]',
+        );
 
         // Подписываемся на поток ответов от обработчика и отправляем их клиенту
         await for (final response in responseStream) {
-          logger
-              .internal('Отправка ответа от обработчика [id: ${responder.id}]');
+          logger.internal(
+            'Отправка ответа от обработчика [id: ${responder.id}]',
+          );
           await responder.send(method.castResponse(response));
         }
 
@@ -1126,25 +1229,31 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     RpcContext context,
   ) {
     logger.internal(
-        'Настройка zero-copy обработчика двунаправленного стрима [id: ${responder.id}]');
+      'Настройка zero-copy обработчика двунаправленного стрима [id: ${responder.id}]',
+    );
 
     // Подписываемся на поток запросов и связываем с пользовательским обработчиком
     unawaited(() async {
       try {
         logger.internal(
-            'Вызов zero-copy пользовательского обработчика [id: ${responder.id}]');
+          'Вызов zero-copy пользовательского обработчика [id: ${responder.id}]',
+        );
 
         // Вызываем zero-copy handler (типы уже адаптированы в контракте)
         final responseStream = zeroCopyMethod.callBidirectionalStreamHandler(
-            context, responder.requests);
+          context,
+          responder.requests,
+        );
 
         logger.internal(
-            'Получен поток ответов от zero-copy обработчика [id: ${responder.id}]');
+          'Получен поток ответов от zero-copy обработчика [id: ${responder.id}]',
+        );
 
         // Подписываемся на поток ответов от обработчика и отправляем их клиенту
         await for (final response in responseStream) {
           logger.internal(
-              'Отправка ответа от zero-copy обработчика [id: ${responder.id}]');
+            'Отправка ответа от zero-copy обработчика [id: ${responder.id}]',
+          );
           await responder.send(response);
         }
 
@@ -1173,9 +1282,7 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
       );
     }
 
-    logger.internal(
-      'Регистрируем контракт сервиса: $serviceName',
-    );
+    logger.internal('Регистрируем контракт сервиса: $serviceName');
     _contracts[serviceName] = contract;
 
     // Вызываем setup для регистрации методов в контракте
@@ -1190,14 +1297,10 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
       final methodKey = '$serviceName.$methodName';
 
       if (_methods.containsKey(methodKey)) {
-        throw RpcException(
-          'Метод $methodKey уже зарегистрирован',
-        );
+        throw RpcException('Метод $methodKey уже зарегистрирован');
       }
 
-      logger.internal(
-        'Регистрируем метод: $methodKey (${method.type.name})',
-      );
+      logger.internal('Регистрируем метод: $methodKey (${method.type.name})');
       _methods[methodKey] = method;
     }
 
@@ -1237,9 +1340,7 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
       );
     }
 
-    logger.internal(
-      'Разрегистрируем контракт сервиса: $serviceName',
-    );
+    logger.internal('Разрегистрируем контракт сервиса: $serviceName');
 
     // Получаем контракт для вызова dispose()
     final contract = _contracts[serviceName]!;
@@ -1247,9 +1348,7 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     // 🆕 Освобождаем ресурсы контракта ПЕРЕД удалением
     try {
       contract.dispose();
-      logger.internal(
-        'Ресурсы контракта $serviceName освобождены',
-      );
+      logger.internal('Ресурсы контракта $serviceName освобождены');
     } catch (e, stackTrace) {
       logger.error(
         'Ошибка при освобождении ресурсов контракта $serviceName: $e',
@@ -1301,8 +1400,10 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
       case RpcMethodType.unaryRequest:
         wrappedHandler = (dynamic request, {RpcContext? context}) async {
           // Для zero-copy directPayload приходит как есть, без каста к IRpcSerializable
-          final result =
-              await zeroCopyMethod.callUnaryHandler(context!, request);
+          final result = await zeroCopyMethod.callUnaryHandler(
+            context!,
+            request,
+          );
           return result; // Возвращаем как есть, без каста
         };
         break;
@@ -1317,7 +1418,9 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
             (Stream<dynamic> requests, {RpcContext? context}) async {
           final objectStream = requests.cast<Object>();
           final result = await zeroCopyMethod.callClientStreamHandler(
-              context!, objectStream);
+            context!,
+            objectStream,
+          );
           return result; // Возвращаем как есть
         };
         break;
@@ -1325,7 +1428,9 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
         wrappedHandler = (Stream<dynamic> requests, {RpcContext? context}) {
           final objectStream = requests.cast<Object>();
           return zeroCopyMethod.callBidirectionalStreamHandler(
-              context!, objectStream);
+            context!,
+            objectStream,
+          );
           // .map не нужен - возвращаем объекты как есть
         };
         break;
@@ -1351,9 +1456,7 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     final method = _methods[methodKey];
 
     if (method == null) {
-      throw RpcException(
-        'Метод $methodKey не зарегистрирован',
-      );
+      throw RpcException('Метод $methodKey не зарегистрирован');
     }
 
     if (method.type != expectedType) {
@@ -1471,8 +1574,5 @@ final class _ZeroCopyUnaryResponderWrapper implements IRpcResponder {
   @override
   final int id;
 
-  _ZeroCopyUnaryResponderWrapper({
-    required this.processor,
-    required this.id,
-  });
+  _ZeroCopyUnaryResponderWrapper({required this.processor, required this.id});
 }

--- a/packages/rpc_dart/lib/src/logs/context_aware_logger.dart
+++ b/packages/rpc_dart/lib/src/logs/context_aware_logger.dart
@@ -19,7 +19,9 @@ final class RpcContextAwareLogger implements RpcLogger {
   @override
   RpcContextAwareLogger child(String childName, {String? label}) {
     return RpcContextAwareLogger(
-        _baseLogger.child(childName, label: label), _context);
+      _baseLogger.child(childName, label: label),
+      _context,
+    );
   }
 
   @override
@@ -269,20 +271,41 @@ mixin RpcContextualLogging {
   }
 
   /// Удобные методы для логирования с контекстом
-  Future<void> infoWithContext(String message,
-          {String? context, Map<String, dynamic>? data}) =>
-      logWithContext(RpcLoggerLevel.info, message,
-          context: context, data: data);
+  Future<void> infoWithContext(
+    String message, {
+    String? context,
+    Map<String, dynamic>? data,
+  }) =>
+      logWithContext(
+        RpcLoggerLevel.info,
+        message,
+        context: context,
+        data: data,
+      );
 
-  Future<void> debugWithContext(String message,
-          {String? context, Map<String, dynamic>? data}) =>
-      logWithContext(RpcLoggerLevel.debug, message,
-          context: context, data: data);
+  Future<void> debugWithContext(
+    String message, {
+    String? context,
+    Map<String, dynamic>? data,
+  }) =>
+      logWithContext(
+        RpcLoggerLevel.debug,
+        message,
+        context: context,
+        data: data,
+      );
 
-  Future<void> warningWithContext(String message,
-          {String? context, Map<String, dynamic>? data}) =>
-      logWithContext(RpcLoggerLevel.warning, message,
-          context: context, data: data);
+  Future<void> warningWithContext(
+    String message, {
+    String? context,
+    Map<String, dynamic>? data,
+  }) =>
+      logWithContext(
+        RpcLoggerLevel.warning,
+        message,
+        context: context,
+        data: data,
+      );
 
   Future<void> errorWithContext(
     String message, {

--- a/packages/rpc_dart/lib/src/logs/default_rpc_logger.dart
+++ b/packages/rpc_dart/lib/src/logs/default_rpc_logger.dart
@@ -24,8 +24,14 @@ class DefaultRpcLoggerFormatter implements IRpcLoggerFormatter {
 
   @override
   LogFormattingResult format(
-      DateTime timestamp, RpcLoggerLevel level, String source, String message,
-      {String? context, String? requestId, String? traceId}) {
+    DateTime timestamp,
+    RpcLoggerLevel level,
+    String source,
+    String message, {
+    String? context,
+    String? requestId,
+    String? traceId,
+  }) {
     final formattedTime =
         '${timestamp.hour.toString().padLeft(2, '0')}:${timestamp.minute.toString().padLeft(2, '0')}:${timestamp.second.toString().padLeft(2, '0')}';
 
@@ -115,9 +121,7 @@ class DefaultRpcLogger implements RpcLogger {
         _colors = colors,
         _formatter = formatter ?? const DefaultRpcLoggerFormatter(),
         _filter = filter ??
-            DefaultRpcLoggerFilter(
-              minLogLevel ?? RpcLogger.defaultMinLogLevel,
-            );
+            DefaultRpcLoggerFilter(minLogLevel ?? RpcLogger.defaultMinLogLevel);
 
   @override
   Future<void> log({
@@ -180,8 +184,15 @@ class DefaultRpcLogger implements RpcLogger {
       }
     }
 
-    final formattedLog = _formatter.format(timestamp, level, name, fullMessage,
-        context: context, requestId: requestId, traceId: traceId);
+    final formattedLog = _formatter.format(
+      timestamp,
+      level,
+      name,
+      fullMessage,
+      context: context,
+      requestId: requestId,
+      traceId: traceId,
+    );
 
     // Если включен цветной вывод, используем цвет только для заголовка
     if (_coloredLoggingEnabled) {

--- a/packages/rpc_dart/lib/src/logs/rpc_logger.dart
+++ b/packages/rpc_dart/lib/src/logs/rpc_logger.dart
@@ -16,10 +16,7 @@ enum RpcLoggerLevel {
 
   /// Создание из строки JSON
   static RpcLoggerLevel fromJson(String json) {
-    return values.firstWhere(
-      (e) => e.name == json,
-      orElse: () => none,
-    );
+    return values.firstWhere((e) => e.name == json, orElse: () => none);
   }
 }
 
@@ -51,8 +48,14 @@ class LogFormattingResult {
 abstract interface class IRpcLoggerFormatter {
   /// Форматирует сообщение лога, возвращая заголовок и содержимое раздельно
   LogFormattingResult format(
-      DateTime timestamp, RpcLoggerLevel level, String source, String message,
-      {String? context, String? requestId, String? traceId});
+    DateTime timestamp,
+    RpcLoggerLevel level,
+    String source,
+    String message, {
+    String? context,
+    String? requestId,
+    String? traceId,
+  });
 }
 
 /// {@template rpc_logger}

--- a/packages/rpc_dart/lib/src/logs/rpc_logger_extensions.dart
+++ b/packages/rpc_dart/lib/src/logs/rpc_logger_extensions.dart
@@ -190,9 +190,7 @@ extension RpcLoggerExtensions on RpcLogger {
       return child(operation);
     }
 
-    final opContext = context.withAdditionalHeaders({
-      'x-operation': operation,
-    });
+    final opContext = context.withAdditionalHeaders({'x-operation': operation});
 
     return RpcContextAwareLogger(child(operation), opContext);
   }

--- a/packages/rpc_dart/lib/src/logs/rpc_logger_registry.dart
+++ b/packages/rpc_dart/lib/src/logs/rpc_logger_registry.dart
@@ -27,8 +27,12 @@ final class _RpcLoggerRegistry {
   ///
   /// Если логгер с таким именем не найден, создает новый
   /// Если передан context, создает контекстно-осведомленный логгер
-  RpcLogger get(String name,
-      {RpcLoggerColors? colors, String? label, RpcContext? context}) {
+  RpcLogger get(
+    String name, {
+    RpcLoggerColors? colors,
+    String? label,
+    RpcContext? context,
+  }) {
     // Создаем базовый логгер
     RpcLogger baseLogger;
 

--- a/packages/rpc_dart/lib/src/primitives/list.dart
+++ b/packages/rpc_dart/lib/src/primitives/list.dart
@@ -43,8 +43,7 @@ class RpcList<T extends IRpcSerializable> implements IRpcSerializable {
 
   static RpcList<T> Function(
       Map<String, dynamic>) fromJson<T extends IRpcSerializable>(
-    T Function(Map<String, dynamic>) fromJson,
-  ) =>
+          T Function(Map<String, dynamic>) fromJson) =>
       (Map<String, dynamic> json) => fromJsonRaw<T>(json['items'], fromJson);
 
   @override

--- a/packages/rpc_dart/lib/src/rpc/_index.dart
+++ b/packages/rpc_dart/lib/src/rpc/_index.dart
@@ -12,6 +12,7 @@ export 'streams/_index.dart';
 part 'core/message.dart';
 part 'core/parser.dart';
 part 'core/rpc.dart';
+part 'core/health.dart';
 part 'core/transport.dart';
 
 part 'transports/in_memory_transport.dart';

--- a/packages/rpc_dart/lib/src/rpc/core/health.dart
+++ b/packages/rpc_dart/lib/src/rpc/core/health.dart
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2025 Karim "nogipx" Mamatkazin <nogipx@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+part of '../_index.dart';
+
+/// Уровень состояния компонента RPC.
+///
+/// Значения перечислены по возрастанию серьезности для удобного сравнения.
+enum RpcHealthLevel {
+  /// Компонент полностью работоспособен.
+  healthy,
+
+  /// Компонент выполняет переподключение либо ожидает внешние ресурсы,
+  /// временно недоступен для работы, но процесс восстановления уже запущен.
+  reconnecting,
+
+  /// Компонент работает, но имеются ограничения (например, деградировавший
+  /// транспорт или потеря некоторых возможностей).
+  degraded,
+
+  /// Компонент недоступен из-за ошибки.
+  unhealthy,
+
+  /// Компонент окончательно закрыт и не может быть использован.
+  closed,
+}
+
+/// Снимок состояния компонента системы.
+///
+/// Используется как результат проверки health() и reconnect().
+class RpcHealthStatus {
+  /// Имя компонента, для которого сформирован статус.
+  final String component;
+
+  /// Текущий уровень состояния.
+  final RpcHealthLevel level;
+
+  /// Краткое описание состояния.
+  final String message;
+
+  /// Дополнительные диагностические данные.
+  final Map<String, Object?> details;
+
+  /// Время формирования снимка состояния.
+  final DateTime timestamp;
+
+  RpcHealthStatus({
+    required this.component,
+    required this.level,
+    String? message,
+    Map<String, Object?>? details,
+    DateTime? timestamp,
+  })  : message = message ?? '',
+        details = Map.unmodifiable(details ?? const {}),
+        timestamp = timestamp ?? DateTime.now();
+
+  /// Возвращает true, если компонент находится в полностью работоспособном
+  /// состоянии без деградации.
+  bool get isHealthy => level == RpcHealthLevel.healthy;
+
+  /// Создает статус для полностью работоспособного компонента.
+  factory RpcHealthStatus.healthy({
+    required String component,
+    String message = 'Component healthy',
+    Map<String, Object?>? details,
+  }) =>
+      RpcHealthStatus(
+        component: component,
+        level: RpcHealthLevel.healthy,
+        message: message,
+        details: details,
+      );
+
+  /// Создает статус для компонента в состоянии деградации.
+  factory RpcHealthStatus.degraded({
+    required String component,
+    String message = 'Component degraded',
+    Map<String, Object?>? details,
+  }) =>
+      RpcHealthStatus(
+        component: component,
+        level: RpcHealthLevel.degraded,
+        message: message,
+        details: details,
+      );
+
+  /// Создает статус для компонента, выполняющего переподключение.
+  factory RpcHealthStatus.reconnecting({
+    required String component,
+    String message = 'Component reconnecting',
+    Map<String, Object?>? details,
+  }) =>
+      RpcHealthStatus(
+        component: component,
+        level: RpcHealthLevel.reconnecting,
+        message: message,
+        details: details,
+      );
+
+  /// Создает статус для компонента с ошибкой.
+  factory RpcHealthStatus.unhealthy({
+    required String component,
+    String message = 'Component unhealthy',
+    Map<String, Object?>? details,
+  }) =>
+      RpcHealthStatus(
+        component: component,
+        level: RpcHealthLevel.unhealthy,
+        message: message,
+        details: details,
+      );
+
+  /// Создает статус для окончательно закрытого компонента.
+  factory RpcHealthStatus.closed({
+    required String component,
+    String message = 'Component closed',
+    Map<String, Object?>? details,
+  }) =>
+      RpcHealthStatus(
+        component: component,
+        level: RpcHealthLevel.closed,
+        message: message,
+        details: details,
+      );
+}
+
+/// Расширение для сравнения серьезности уровней здоровья.
+extension RpcHealthLevelSeverity on RpcHealthLevel {
+  /// Целочисленная серьезность уровня. Чем больше значение, тем хуже состояние.
+  int get severity => switch (this) {
+        RpcHealthLevel.healthy => 0,
+        RpcHealthLevel.reconnecting => 1,
+        RpcHealthLevel.degraded => 2,
+        RpcHealthLevel.unhealthy => 3,
+        RpcHealthLevel.closed => 4,
+      };
+}

--- a/packages/rpc_dart/lib/src/rpc/core/message.dart
+++ b/packages/rpc_dart/lib/src/rpc/core/message.dart
@@ -39,8 +39,11 @@ final class RpcMetadata {
   /// [methodName] Имя метода (например, "Send")
   /// [host] Хост-заголовок (опционально)
   /// Возвращает метаданные, готовые для отправки при инициализации запроса.
-  static RpcMetadata forClientRequest(String serviceName, String methodName,
-      {String host = ''}) {
+  static RpcMetadata forClientRequest(
+    String serviceName,
+    String methodName, {
+    String host = '',
+  }) {
     final methodPath = '/$serviceName/$methodName';
     return RpcMetadata([
       RpcHeader(':method', 'POST'),
@@ -60,8 +63,10 @@ final class RpcMetadata {
   /// Упрощенная версия для случаев, когда путь уже сформирован.
   /// [methodPath] Путь метода в формате /ServiceName/MethodName
   /// [host] Хост-заголовок (опционально)
-  static RpcMetadata forClientRequestWithPath(String methodPath,
-      {String host = ''}) {
+  static RpcMetadata forClientRequestWithPath(
+    String methodPath, {
+    String host = '',
+  }) {
     return RpcMetadata([
       RpcHeader(':method', 'POST'),
       RpcHeader(':path', methodPath),
@@ -99,17 +104,11 @@ final class RpcMetadata {
   /// Возвращает метаданные-трейлеры для завершения потока.
   static RpcMetadata forTrailer(int statusCode, {String message = ''}) {
     final headers = [
-      RpcHeader(
-        RpcConstants.GRPC_STATUS_HEADER,
-        statusCode.toString(),
-      ),
+      RpcHeader(RpcConstants.GRPC_STATUS_HEADER, statusCode.toString()),
     ];
 
     if (message.isNotEmpty) {
-      headers.add(RpcHeader(
-        RpcConstants.GRPC_MESSAGE_HEADER,
-        message,
-      ));
+      headers.add(RpcHeader(RpcConstants.GRPC_MESSAGE_HEADER, message));
     }
 
     return RpcMetadata(headers);

--- a/packages/rpc_dart/lib/src/rpc/core/parser.dart
+++ b/packages/rpc_dart/lib/src/rpc/core/parser.dart
@@ -75,14 +75,16 @@ final class RpcMessageParser {
       // Если мы еще не знаем длину сообщения, извлекаем ее из заголовка
       if (_state.expectedMessageLength == null) {
         try {
-          final header =
-              RpcMessageFrame.parseHeader(Uint8List.fromList(_state.buffer));
+          final header = RpcMessageFrame.parseHeader(
+            Uint8List.fromList(_state.buffer),
+          );
           _state.isCompressed = header.isCompressed;
           _state.expectedMessageLength = header.messageLength;
 
           // Удаляем заголовок из буфера
-          _state.buffer =
-              _state.buffer.sublist(RpcConstants.MESSAGE_PREFIX_SIZE);
+          _state.buffer = _state.buffer.sublist(
+            RpcConstants.MESSAGE_PREFIX_SIZE,
+          );
         } catch (e, trace) {
           _logger?.error(
             'Ошибка при парсинге заголовка: $e',
@@ -96,8 +98,10 @@ final class RpcMessageParser {
       // Если у нас достаточно данных для полного сообщения
       if (_state.buffer.length >= _state.expectedMessageLength!) {
         // Извлекаем сообщение
-        final messageBytes =
-            _state.buffer.sublist(0, _state.expectedMessageLength!);
+        final messageBytes = _state.buffer.sublist(
+          0,
+          _state.expectedMessageLength!,
+        );
         result.add(Uint8List.fromList(messageBytes));
 
         // Обновляем буфер, удаляя обработанное сообщение

--- a/packages/rpc_dart/lib/src/rpc/core/rpc.dart
+++ b/packages/rpc_dart/lib/src/rpc/core/rpc.dart
@@ -119,12 +119,11 @@ abstract interface class RpcMessageFrame {
   /// [messageBytes] Байты сериализованного сообщения
   /// [compressed] Флаг, указывающий, сжато ли сообщение
   /// Возвращает полностью упакованное сообщение с префиксом
-  static Uint8List encode(
-    Uint8List messageBytes, {
-    bool compressed = false,
-  }) {
+  static Uint8List encode(Uint8List messageBytes, {bool compressed = false}) {
     final result = List<int>.filled(
-        RpcConstants.MESSAGE_PREFIX_SIZE + messageBytes.length, 0);
+      RpcConstants.MESSAGE_PREFIX_SIZE + messageBytes.length,
+      0,
+    );
 
     // Устанавливаем флаг сжатия
     result[RpcConstants.COMPRESSION_FLAG_INDEX] =

--- a/packages/rpc_dart/lib/src/rpc/core/transport.dart
+++ b/packages/rpc_dart/lib/src/rpc/core/transport.dart
@@ -200,6 +200,14 @@ abstract class IRpcTransport {
   ///
   /// Освобождает все связанные ресурсы и закрывает базовое соединение.
   Future<void> close();
+
+  /// Проверяет состояние транспорта и возвращает диагностический снимок.
+  Future<RpcHealthStatus> health();
+
+  /// Пытается восстановить соединение транспорта. Если транспорт не поддерживает
+  /// переподключение, он должен вернуть статус с уровнем [RpcHealthLevel.degraded]
+  /// или [RpcHealthLevel.unhealthy] с признаком `supported: false` в деталях.
+  Future<RpcHealthStatus> reconnect();
 }
 
 /// Менеджер Stream ID для HTTP/2 соединений.

--- a/packages/rpc_dart/lib/src/rpc/streams/base_processor.dart
+++ b/packages/rpc_dart/lib/src/rpc/streams/base_processor.dart
@@ -98,7 +98,8 @@ final class StreamProcessor<TRequest extends Object, TResponse extends Object> {
     _methodPath = '/$_serviceName/$_methodName';
 
     _logger?.internal(
-        'Создан ${_isZeroCopy ? "Zero-copy" : "Serialized"} StreamProcessor для $_methodPath [streamId: $_streamId]${_context?.cancellationToken != null ? " с cancellation token" : ""}');
+      'Создан ${_isZeroCopy ? "Zero-copy" : "Serialized"} StreamProcessor для $_methodPath [streamId: $_streamId]${_context?.cancellationToken != null ? " с cancellation token" : ""}',
+    );
 
     _setupCancellationMonitoring();
     _setupResponseHandler();
@@ -120,40 +121,46 @@ final class StreamProcessor<TRequest extends Object, TResponse extends Object> {
         if (!_isActive) return;
 
         _logger?.internal(
-            'Отправка ответа для $_methodPath [streamId: $_streamId]');
+          'Отправка ответа для $_methodPath [streamId: $_streamId]',
+        );
         try {
           if (_isZeroCopy) {
             // Zero-copy путь
-            _logger
-                ?.internal('Zero-copy отправка ответа [streamId: $_streamId]');
-            await _transport.sendDirectObject(
-              _streamId,
-              response,
-            );
             _logger?.internal(
-                'Zero-copy ответ отправлен для $_methodPath [streamId: $_streamId]');
+              'Zero-copy отправка ответа [streamId: $_streamId]',
+            );
+            await _transport.sendDirectObject(_streamId, response);
+            _logger?.internal(
+              'Zero-copy ответ отправлен для $_methodPath [streamId: $_streamId]',
+            );
           } else {
             // Сериализация для сетевых транспортов
             final serialized = _responseCodec!.serialize(response);
             _logger?.internal(
-                'Ответ сериализован, размер: ${serialized.length} байт [streamId: $_streamId]');
+              'Ответ сериализован, размер: ${serialized.length} байт [streamId: $_streamId]',
+            );
 
             final framedMessage = RpcMessageFrame.encode(serialized);
             await _transport.sendMessage(_streamId, framedMessage);
 
             _logger?.internal(
-                'Ответ отправлен для $_methodPath [streamId: $_streamId]');
+              'Ответ отправлен для $_methodPath [streamId: $_streamId]',
+            );
           }
         } catch (e, stackTrace) {
           // Проверяем, не закрыт ли транспорт
           if (e.toString().contains('Transport is closed') ||
               e.toString().contains('closed')) {
             _logger?.internal(
-                'Транспорт закрыт, пропускаем отправку ответа [streamId: $_streamId]');
+              'Транспорт закрыт, пропускаем отправку ответа [streamId: $_streamId]',
+            );
             return;
           }
-          _logger?.error('Ошибка при отправке ответа [streamId: $_streamId]',
-              error: e, stackTrace: stackTrace);
+          _logger?.error(
+            'Ошибка при отправке ответа [streamId: $_streamId]',
+            error: e,
+            stackTrace: stackTrace,
+          );
         }
       },
       onDone: () async {
@@ -163,24 +170,30 @@ final class StreamProcessor<TRequest extends Object, TResponse extends Object> {
           final trailers = RpcMetadata.forTrailer(RpcStatus.OK);
           await _transport.sendMetadata(_streamId, trailers, endStream: true);
           _logger?.internal(
-              'Трейлер отправлен для $_methodPath [streamId: $_streamId]');
+            'Трейлер отправлен для $_methodPath [streamId: $_streamId]',
+          );
         } catch (e, stackTrace) {
           // Проверяем, не закрыт ли транспорт
           if (e.toString().contains('Transport is closed') ||
               e.toString().contains('closed')) {
             _logger?.internal(
-                'Транспорт закрыт, пропускаем отправку трейлера [streamId: $_streamId]');
+              'Транспорт закрыт, пропускаем отправку трейлера [streamId: $_streamId]',
+            );
             return;
           }
-          _logger?.error('Ошибка при отправке трейлера [streamId: $_streamId]',
-              error: e, stackTrace: stackTrace);
+          _logger?.error(
+            'Ошибка при отправке трейлера [streamId: $_streamId]',
+            error: e,
+            stackTrace: stackTrace,
+          );
         }
       },
       onError: (error, stackTrace) {
         _logger?.error(
-            'Ошибка в потоке ответов для $_methodPath [streamId: $_streamId]',
-            error: error,
-            stackTrace: stackTrace);
+          'Ошибка в потоке ответов для $_methodPath [streamId: $_streamId]',
+          error: error,
+          stackTrace: stackTrace,
+        );
       },
     );
   }
@@ -196,10 +209,7 @@ final class StreamProcessor<TRequest extends Object, TResponse extends Object> {
       return;
     }
 
-    _logger?.logStreamBound(
-      methodPath: _methodPath,
-      streamId: _streamId,
-    );
+    _logger?.logStreamBound(methodPath: _methodPath, streamId: _streamId);
 
     _messageSubscription = messageStream.listen(
       _handleMessage,
@@ -414,7 +424,8 @@ final class StreamProcessor<TRequest extends Object, TResponse extends Object> {
     }
 
     _logger?.error(
-        'Отправка ошибки клиенту: $statusCode - $message [streamId: $_streamId]');
+      'Отправка ошибки клиенту: $statusCode - $message [streamId: $_streamId]',
+    );
 
     if (!_responseController.isClosed) {
       _responseController.close();
@@ -424,23 +435,30 @@ final class StreamProcessor<TRequest extends Object, TResponse extends Object> {
       // Если начальные метаданные не были отправлены, отправляем error response сразу
       if (!_initialMetadataSent) {
         _logger?.internal(
-            'Отправка ошибки без начальных метаданных [streamId: $_streamId]');
+          'Отправка ошибки без начальных метаданных [streamId: $_streamId]',
+        );
         // Создаем комбинированные метаданные: начальный response + error trailer
         final errorHeaders = [
           RpcHeader(':status', '200'), // HTTP 200 для gRPC
           RpcHeader(
-              RpcConstants.CONTENT_TYPE_HEADER, RpcConstants.GRPC_CONTENT_TYPE),
+            RpcConstants.CONTENT_TYPE_HEADER,
+            RpcConstants.GRPC_CONTENT_TYPE,
+          ),
           RpcHeader(RpcConstants.GRPC_STATUS_HEADER, statusCode.toString()),
         ];
 
         if (message.isNotEmpty) {
-          errorHeaders
-              .add(RpcHeader(RpcConstants.GRPC_MESSAGE_HEADER, message));
+          errorHeaders.add(
+            RpcHeader(RpcConstants.GRPC_MESSAGE_HEADER, message),
+          );
         }
 
         final errorMetadata = RpcMetadata(errorHeaders);
-        await _transport.sendMetadata(_streamId, errorMetadata,
-            endStream: true);
+        await _transport.sendMetadata(
+          _streamId,
+          errorMetadata,
+          endStream: true,
+        );
         _initialMetadataSent = true;
       } else {
         // Начальные метаданные уже отправлены, отправляем только trailer
@@ -454,13 +472,15 @@ final class StreamProcessor<TRequest extends Object, TResponse extends Object> {
       if (e.toString().contains('Transport is closed') ||
           e.toString().contains('closed')) {
         _logger?.internal(
-            'Транспорт закрыт, пропускаем отправку ошибки [streamId: $_streamId]');
+          'Транспорт закрыт, пропускаем отправку ошибки [streamId: $_streamId]',
+        );
         return;
       }
       _logger?.error(
-          'Ошибка при отправке ошибки клиенту [streamId: $_streamId]',
-          error: e,
-          stackTrace: stackTrace);
+        'Ошибка при отправке ошибки клиенту [streamId: $_streamId]',
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
   }
 
@@ -469,7 +489,8 @@ final class StreamProcessor<TRequest extends Object, TResponse extends Object> {
     if (!_isActive) return;
 
     _logger?.internal(
-        'Завершение отправки ответов для $_methodPath [streamId: $_streamId]');
+      'Завершение отправки ответов для $_methodPath [streamId: $_streamId]',
+    );
 
     if (!_responseController.isClosed) {
       await _responseController.close();
@@ -481,7 +502,8 @@ final class StreamProcessor<TRequest extends Object, TResponse extends Object> {
     if (!_isActive) return;
 
     _logger?.internal(
-        'Закрытие StreamProcessor для $_methodPath [streamId: $_streamId]');
+      'Закрытие StreamProcessor для $_methodPath [streamId: $_streamId]',
+    );
     _isActive = false;
 
     // Отменяем все подписки
@@ -634,7 +656,8 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
     _methodPath = '/$_serviceName/$_methodName';
 
     _logger?.internal(
-        'Создан ${_isZeroCopy ? "Zero-copy" : "Serialized"} CallProcessor для $_methodPath [streamId: $_streamId]${_context?.cancellationToken != null ? " с cancellation token" : ""}');
+      'Создан ${_isZeroCopy ? "Zero-copy" : "Serialized"} CallProcessor для $_methodPath [streamId: $_streamId]${_context?.cancellationToken != null ? " с cancellation token" : ""}',
+    );
 
     // Проверяем контекст перед началом работы
     _checkContextBeforeCall();
@@ -670,33 +693,38 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
           }
 
           _logger?.internal(
-              'Отправка запроса для $_methodPath [streamId: $_streamId]');
+            'Отправка запроса для $_methodPath [streamId: $_streamId]',
+          );
 
           if (_isZeroCopy) {
             // Zero-copy путь
-            _logger
-                ?.internal('Zero-copy отправка запроса [streamId: $_streamId]');
-            await _transport.sendDirectObject(
-              _streamId,
-              request,
-            );
             _logger?.internal(
-                'Zero-copy запрос отправлен для $_methodPath [streamId: $_streamId]');
+              'Zero-copy отправка запроса [streamId: $_streamId]',
+            );
+            await _transport.sendDirectObject(_streamId, request);
+            _logger?.internal(
+              'Zero-copy запрос отправлен для $_methodPath [streamId: $_streamId]',
+            );
           } else {
             // Сериализация для сетевых транспортов
             final serialized = _requestCodec!.serialize(request);
             _logger?.internal(
-                'Запрос сериализован, размер: ${serialized.length} байт [streamId: $_streamId]');
+              'Запрос сериализован, размер: ${serialized.length} байт [streamId: $_streamId]',
+            );
 
             final framedMessage = RpcMessageFrame.encode(serialized);
             await _transport.sendMessage(_streamId, framedMessage);
 
             _logger?.internal(
-                'Запрос отправлен для $_methodPath [streamId: $_streamId]');
+              'Запрос отправлен для $_methodPath [streamId: $_streamId]',
+            );
           }
         } catch (e, stackTrace) {
-          _logger?.error('Ошибка при отправке запроса [streamId: $_streamId]',
-              error: e, stackTrace: stackTrace);
+          _logger?.error(
+            'Ошибка при отправке запроса [streamId: $_streamId]',
+            error: e,
+            stackTrace: stackTrace,
+          );
           if (!_responseController.isClosed) {
             _responseController.addError(e, stackTrace);
           }
@@ -714,19 +742,22 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
         try {
           await _transport.finishSending(_streamId);
           _logger?.internal(
-              'finishSending выполнен для $_methodPath [streamId: $_streamId]');
+            'finishSending выполнен для $_methodPath [streamId: $_streamId]',
+          );
         } catch (e, stackTrace) {
           _logger?.error(
-              'Ошибка при завершении отправки запросов [streamId: $_streamId]',
-              error: e,
-              stackTrace: stackTrace);
+            'Ошибка при завершении отправки запросов [streamId: $_streamId]',
+            error: e,
+            stackTrace: stackTrace,
+          );
         }
       },
       onError: (error, stackTrace) {
         _logger?.error(
-            'Ошибка в потоке запросов для $_methodPath [streamId: $_streamId]',
-            error: error,
-            stackTrace: stackTrace);
+          'Ошибка в потоке запросов для $_methodPath [streamId: $_streamId]',
+          error: error,
+          stackTrace: stackTrace,
+        );
         if (!_responseController.isClosed) {
           _responseController.addError(error, stackTrace);
         }
@@ -739,15 +770,19 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
     _responseSubscription = _transport.getMessagesForStream(_streamId).listen(
       _handleResponse,
       onError: (error, stackTrace) {
-        _logger?.error('Ошибка в потоке ответов',
-            error: error, stackTrace: stackTrace);
+        _logger?.error(
+          'Ошибка в потоке ответов',
+          error: error,
+          stackTrace: stackTrace,
+        );
         if (!_responseController.isClosed) {
           _responseController.addError(error, stackTrace);
         }
       },
       onDone: () {
         _logger?.internal(
-            'Поток ответов завершен для $_methodPath [streamId: $_streamId]');
+          'Поток ответов завершен для $_methodPath [streamId: $_streamId]',
+        );
         if (!_responseController.isClosed) {
           _responseController.close();
         }
@@ -758,10 +793,13 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
   /// Отправляет начальные метаданные с поддержкой контекста
   Future<void> _sendInitialMetadata() async {
     _logger?.internal(
-        'Отправка начальных метаданных для $_methodPath [streamId: $_streamId]');
+      'Отправка начальных метаданных для $_methodPath [streamId: $_streamId]',
+    );
 
-    final baseMetadata =
-        RpcMetadata.forClientRequest(_serviceName, _methodName);
+    final baseMetadata = RpcMetadata.forClientRequest(
+      _serviceName,
+      _methodName,
+    );
 
     // Создаем новые метаданные с заголовками из контекста
     final headers = List<RpcHeader>.from(baseMetadata.headers);
@@ -780,15 +818,20 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
 
       // Передаем deadline серверу
       if (_context!.deadline != null) {
-        headers.add(RpcHeader('x-deadline',
-            _context!.deadline!.millisecondsSinceEpoch.toString()));
+        headers.add(
+          RpcHeader(
+            'x-deadline',
+            _context!.deadline!.millisecondsSinceEpoch.toString(),
+          ),
+        );
       }
 
       // Context values остаются ЛОКАЛЬНЫМИ - не передаются через сеть (соответствует стандарту gRPC)
       // Только headers передаются через HTTP/2 заголовки
 
       _logger?.internal(
-          'Добавлены заголовки контекста: ${_context!.headers.length} пользовательских + системные [streamId: $_streamId]');
+        'Добавлены заголовки контекста: ${_context!.headers.length} пользовательских + системные [streamId: $_streamId]',
+      );
     } else {
       // Даже для null контекста добавляем базовый request-id
       final requestId =
@@ -796,14 +839,16 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
       headers.add(RpcHeader('x-request-id', requestId));
 
       _logger?.internal(
-          'Добавлен базовый request-id для null контекста [streamId: $_streamId]');
+        'Добавлен базовый request-id для null контекста [streamId: $_streamId]',
+      );
     }
 
     final metadata = RpcMetadata(headers);
     await _transport.sendMetadata(_streamId, metadata);
 
     _logger?.internal(
-        'Начальные метаданные отправлены для $_methodPath [streamId: $_streamId]');
+      'Начальные метаданные отправлены для $_methodPath [streamId: $_streamId]',
+    );
   }
 
   /// Настраивает мониторинг отмены операции для CallProcessor
@@ -831,7 +876,8 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
 
           _isActive = false;
           final cancelledException = RpcCancelledException(
-              _context!.cancellationToken!.reason ?? 'Operation was cancelled');
+            _context!.cancellationToken!.reason ?? 'Operation was cancelled',
+          );
 
           if (!_requestController.isClosed) {
             _requestController.addError(cancelledException);
@@ -864,7 +910,9 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
         RpcHeader('x-client-cancelled', 'true'),
         RpcHeader('x-cancellation-reason', reason),
         RpcHeader(
-            RpcConstants.GRPC_STATUS_HEADER, RpcStatus.CANCELLED.toString()),
+          RpcConstants.GRPC_STATUS_HEADER,
+          RpcStatus.CANCELLED.toString(),
+        ),
       ];
 
       final cancellationMetadata = RpcMetadata(cancellationHeaders);
@@ -873,8 +921,11 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
         'Отправка уведомления об отмене серверу [streamId: $_streamId]',
       );
 
-      await _transport.sendMetadata(_streamId, cancellationMetadata,
-          endStream: true);
+      await _transport.sendMetadata(
+        _streamId,
+        cancellationMetadata,
+        endStream: true,
+      );
 
       _logger?.internal(
         'Уведомление об отмене отправлено серверу [streamId: $_streamId]',
@@ -897,14 +948,12 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
 
     // Проверяем deadline
     if (_context!.isExpired) {
-      throw RpcDeadlineExceededException(
-        _context!.deadline!,
-        Duration.zero,
-      );
+      throw RpcDeadlineExceededException(_context!.deadline!, Duration.zero);
     }
 
     _logger?.internal(
-        'Контекст проверен: requestId=${_context!.requestId}, traceId=${_context!.traceId} [streamId: $_streamId]');
+      'Контекст проверен: requestId=${_context!.requestId}, traceId=${_context!.traceId} [streamId: $_streamId]',
+    );
   }
 
   /// Обрабатывает входящий ответ
@@ -912,7 +961,8 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
     if (!_isActive) return;
 
     _logger?.internal(
-        'Обработка ответа [streamId: ${message.streamId}, isMetadataOnly: ${message.isMetadataOnly}, hasPayload: ${message.payload != null}, isDirect: ${message.isDirect}]');
+      'Обработка ответа [streamId: ${message.streamId}, isMetadataOnly: ${message.isMetadataOnly}, hasPayload: ${message.payload != null}, isDirect: ${message.isDirect}]',
+    );
 
     try {
       // Обрабатываем метаданные
@@ -925,7 +975,8 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
         if (!_responseController.isClosed) {
           _responseController.add(rpcMessage);
           _logger?.internal(
-              'Метаданные добавлены в поток ответов [streamId: $_streamId]');
+            'Метаданные добавлены в поток ответов [streamId: $_streamId]',
+          );
         }
       }
 
@@ -941,14 +992,18 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
       // Завершаем поток при получении END_STREAM
       if (message.isEndOfStream) {
         _logger?.internal(
-            'Получен END_STREAM, закрываем поток ответов [streamId: $_streamId]');
+          'Получен END_STREAM, закрываем поток ответов [streamId: $_streamId]',
+        );
         if (!_responseController.isClosed) {
           _responseController.close();
         }
       }
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при обработке ответа [streamId: $_streamId]',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при обработке ответа [streamId: $_streamId]',
+        error: e,
+        stackTrace: stackTrace,
+      );
       if (!_responseController.isClosed) {
         _responseController.addError(e, stackTrace);
       }
@@ -958,7 +1013,8 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
   /// Zero-copy: обрабатывает прямой объект ответа без сериализации
   void _processDirectResponse(Object directPayload) {
     _logger?.internal(
-        'Zero-copy обработка прямого ответа [streamId: $_streamId, type: ${directPayload.runtimeType}]');
+      'Zero-copy обработка прямого ответа [streamId: $_streamId, type: ${directPayload.runtimeType}]',
+    );
 
     try {
       final response = directPayload as TResponse;
@@ -967,16 +1023,19 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
       if (!_responseController.isClosed) {
         _responseController.add(rpcMessage);
         _logger?.internal(
-            'Zero-copy ответ добавлен в поток ответов [streamId: $_streamId]');
+          'Zero-copy ответ добавлен в поток ответов [streamId: $_streamId]',
+        );
       } else {
         _logger?.warning(
-            'Zero-copy: не могу добавить ответ в закрытый контроллер [streamId: $_streamId]');
+          'Zero-copy: не могу добавить ответ в закрытый контроллер [streamId: $_streamId]',
+        );
       }
     } catch (e, stackTrace) {
       _logger?.error(
-          'Zero-copy ошибка при обработке прямого ответа [streamId: $_streamId]',
-          error: e,
-          stackTrace: stackTrace);
+        'Zero-copy ошибка при обработке прямого ответа [streamId: $_streamId]',
+        error: e,
+        stackTrace: stackTrace,
+      );
       if (!_responseController.isClosed) {
         _responseController.addError(e, stackTrace);
       }
@@ -995,7 +1054,8 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
     }
 
     _logger?.internal(
-        'Получен ответ размером: ${messageBytes.length} байт [streamId: $_streamId]');
+      'Получен ответ размером: ${messageBytes.length} байт [streamId: $_streamId]',
+    );
 
     try {
       final uint8Message = messageBytes is Uint8List
@@ -1004,12 +1064,14 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
 
       final messages = _parser!(uint8Message);
       _logger?.internal(
-          'Парсер извлек ${messages.length} сообщений из фрейма [streamId: $_streamId]');
+        'Парсер извлек ${messages.length} сообщений из фрейма [streamId: $_streamId]',
+      );
 
       for (var msgBytes in messages) {
         try {
           _logger?.internal(
-              'Десериализация ответа размером ${msgBytes.length} байт [streamId: $_streamId]');
+            'Десериализация ответа размером ${msgBytes.length} байт [streamId: $_streamId]',
+          );
           final response = _responseCodec!.deserialize(msgBytes);
 
           final rpcMessage = RpcMessage.withPayload<TResponse>(response);
@@ -1017,24 +1079,30 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
           if (!_responseController.isClosed) {
             _responseController.add(rpcMessage);
             _logger?.internal(
-                'Ответ десериализован и добавлен в поток ответов [streamId: $_streamId]');
+              'Ответ десериализован и добавлен в поток ответов [streamId: $_streamId]',
+            );
           } else {
             _logger?.warning(
-                'Не могу добавить ответ в закрытый контроллер [streamId: $_streamId]');
+              'Не могу добавить ответ в закрытый контроллер [streamId: $_streamId]',
+            );
           }
         } catch (e, stackTrace) {
           _logger?.error(
-              'Ошибка при десериализации ответа [streamId: $_streamId]',
-              error: e,
-              stackTrace: stackTrace);
+            'Ошибка при десериализации ответа [streamId: $_streamId]',
+            error: e,
+            stackTrace: stackTrace,
+          );
           if (!_responseController.isClosed) {
             _responseController.addError(e, stackTrace);
           }
         }
       }
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при парсинге ответа [streamId: $_streamId]',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при парсинге ответа [streamId: $_streamId]',
+        error: e,
+        stackTrace: stackTrace,
+      );
       if (!_responseController.isClosed) {
         _responseController.addError(e, stackTrace);
       }
@@ -1060,7 +1128,8 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
     if (!_isActive) return;
 
     _logger?.internal(
-        'Завершение отправки запросов для $_methodPath [streamId: $_streamId]');
+      'Завершение отправки запросов для $_methodPath [streamId: $_streamId]',
+    );
 
     if (!_requestController.isClosed) {
       await _requestController.close();
@@ -1072,7 +1141,8 @@ final class CallProcessor<TRequest extends Object, TResponse extends Object> {
     if (!_isActive) return;
 
     _logger?.internal(
-        'Закрытие CallProcessor для $_methodPath [streamId: $_streamId]');
+      'Закрытие CallProcessor для $_methodPath [streamId: $_streamId]',
+    );
     _isActive = false;
 
     await _requestSubscription?.cancel();

--- a/packages/rpc_dart/lib/src/rpc/streams/bidirectional/caller.dart
+++ b/packages/rpc_dart/lib/src/rpc/streams/bidirectional/caller.dart
@@ -55,19 +55,23 @@ final class BidirectionalStreamCaller<TRequest extends Object,
     // Zero-copy режим: требуется RpcInMemoryTransport
     if (isZeroCopy && !transport.supportsZeroCopy) {
       throw ArgumentError(
-          'Zero-copy режим требует транспорт с поддержкой zero-copy. '
-          'Для сетевых транспортов передайте кодеки.');
+        'Zero-copy режим требует транспорт с поддержкой zero-copy. '
+        'Для сетевых транспортов передайте кодеки.',
+      );
     }
 
     // Режим сериализации: кодеки обязательны
     if (!isZeroCopy && (requestCodec == null || responseCodec == null)) {
-      throw ArgumentError('Кодеки обязательны для режима сериализации. '
-          'Для zero-copy не передавайте кодеки (null).');
+      throw ArgumentError(
+        'Кодеки обязательны для режима сериализации. '
+        'Для zero-copy не передавайте кодеки (null).',
+      );
     }
 
     _logger = logger?.child('BidirectionalCaller');
     _logger?.internal(
-        'Создание ${isZeroCopy ? "Zero-copy" : "Serialized"} BidirectionalStreamCaller для $serviceName.$methodName');
+      'Создание ${isZeroCopy ? "Zero-copy" : "Serialized"} BidirectionalStreamCaller для $serviceName.$methodName',
+    );
 
     _processor = CallProcessor<TRequest, TResponse>(
       transport: transport,
@@ -108,16 +112,19 @@ final class BidirectionalStreamCaller<TRequest extends Object,
 
       // Проверяем статус в метаданных
       if (response.metadata != null) {
-        final statusStr =
-            response.metadata!.getHeaderValue(RpcConstants.GRPC_STATUS_HEADER);
+        final statusStr = response.metadata!.getHeaderValue(
+          RpcConstants.GRPC_STATUS_HEADER,
+        );
         if (statusStr != null) {
           final status = int.tryParse(statusStr) ?? RpcStatus.UNKNOWN;
           if (status != RpcStatus.OK) {
-            final message = response.metadata!
-                    .getHeaderValue(RpcConstants.GRPC_MESSAGE_HEADER) ??
+            final message = response.metadata!.getHeaderValue(
+                  RpcConstants.GRPC_MESSAGE_HEADER,
+                ) ??
                 'Unknown error';
             _logger?.error(
-                'Bidirectional стрим завершился с ошибкой: $status - $message');
+              'Bidirectional стрим завершился с ошибкой: $status - $message',
+            );
             throw Exception('gRPC error $status: $message');
           }
         }
@@ -133,8 +140,9 @@ final class BidirectionalStreamCaller<TRequest extends Object,
       final controller = StreamController<TRequest>();
       controller.stream.listen(
         (request) async {
-          _logger
-              ?.internal('Отправка запроса в bidirectional стриме: $request');
+          _logger?.internal(
+            'Отправка запроса в bidirectional стриме: $request',
+          );
           await send(request);
         },
         onDone: () async {
@@ -142,8 +150,11 @@ final class BidirectionalStreamCaller<TRequest extends Object,
           await finishSending();
         },
         onError: (error, stackTrace) {
-          _logger?.error('Ошибка в потоке запросов',
-              error: error, stackTrace: stackTrace);
+          _logger?.error(
+            'Ошибка в потоке запросов',
+            error: error,
+            stackTrace: stackTrace,
+          );
         },
       );
       _requestSink = controller.sink;

--- a/packages/rpc_dart/lib/src/rpc/streams/bidirectional/responder.dart
+++ b/packages/rpc_dart/lib/src/rpc/streams/bidirectional/responder.dart
@@ -51,19 +51,23 @@ final class BidirectionalStreamResponder<TRequest extends Object,
     // Zero-copy режим: требуется RpcInMemoryTransport
     if (isZeroCopy && !transport.supportsZeroCopy) {
       throw ArgumentError(
-          'Zero-copy режим требует транспорт с поддержкой zero-copy. '
-          'Для сетевых транспортов передайте кодеки.');
+        'Zero-copy режим требует транспорт с поддержкой zero-copy. '
+        'Для сетевых транспортов передайте кодеки.',
+      );
     }
 
     // Режим сериализации: кодеки обязательны
     if (!isZeroCopy && (requestCodec == null || responseCodec == null)) {
-      throw ArgumentError('Кодеки обязательны для режима сериализации. '
-          'Для zero-copy не передавайте кодеки (null).');
+      throw ArgumentError(
+        'Кодеки обязательны для режима сериализации. '
+        'Для zero-copy не передавайте кодеки (null).',
+      );
     }
 
     _logger = logger?.child('BidirectionalResponder');
     _logger?.internal(
-        'Создание ${isZeroCopy ? "Zero-copy" : "Serialized"} BidirectionalStreamResponder для $serviceName.$methodName [id: $id]');
+      'Создание ${isZeroCopy ? "Zero-copy" : "Serialized"} BidirectionalStreamResponder для $serviceName.$methodName [id: $id]',
+    );
 
     _processor = StreamProcessor<TRequest, TResponse>(
       transport: transport,
@@ -107,7 +111,8 @@ final class BidirectionalStreamResponder<TRequest extends Object,
       (response) async {
         try {
           await _processor.send(
-              response); // Используем напрямую _processor, избегая циклической зависимости
+            response,
+          ); // Используем напрямую _processor, избегая циклической зависимости
           _logger?.internal('Ответ отправлен через responseSink [id: $id]');
         } catch (e, stackTrace) {
           _logger?.error(
@@ -122,8 +127,11 @@ final class BidirectionalStreamResponder<TRequest extends Object,
         await finishReceiving();
       },
       onError: (error, stackTrace) {
-        _logger?.error('Ошибка в потоке ответов [id: $id]',
-            error: error, stackTrace: stackTrace);
+        _logger?.error(
+          'Ошибка в потоке ответов [id: $id]',
+          error: error,
+          stackTrace: stackTrace,
+        );
       },
     );
   }
@@ -139,8 +147,9 @@ final class BidirectionalStreamResponder<TRequest extends Object,
   /// [response] Ответ для отправки клиенту
   Future<void> send(TResponse response) async {
     if (!_isActive) {
-      _logger
-          ?.warning('Попытка отправить ответ в неактивный респондер [id: $id]');
+      _logger?.warning(
+        'Попытка отправить ответ в неактивный респондер [id: $id]',
+      );
       return;
     }
 

--- a/packages/rpc_dart/lib/src/rpc/streams/client/caller.dart
+++ b/packages/rpc_dart/lib/src/rpc/streams/client/caller.dart
@@ -74,19 +74,23 @@ final class ClientStreamCaller<TRequest extends Object,
     // Zero-copy режим: требуется RpcInMemoryTransport
     if (isZeroCopy && !transport.supportsZeroCopy) {
       throw ArgumentError(
-          'Zero-copy режим требует транспорт с поддержкой zero-copy. '
-          'Для сетевых транспортов передайте кодеки.');
+        'Zero-copy режим требует транспорт с поддержкой zero-copy. '
+        'Для сетевых транспортов передайте кодеки.',
+      );
     }
 
     // Режим сериализации: кодеки обязательны
     if (!isZeroCopy && (requestCodec == null || responseCodec == null)) {
-      throw ArgumentError('Кодеки обязательны для режима сериализации. '
-          'Для zero-copy не передавайте кодеки (null).');
+      throw ArgumentError(
+        'Кодеки обязательны для режима сериализации. '
+        'Для zero-copy не передавайте кодеки (null).',
+      );
     }
 
     _logger = logger?.child('ClientCaller');
     _logger?.internal(
-        'Создание ${isZeroCopy ? "Zero-copy" : "Serialized"} ClientStreamCaller для $serviceName.$methodName');
+      'Создание ${isZeroCopy ? "Zero-copy" : "Serialized"} ClientStreamCaller для $serviceName.$methodName',
+    );
 
     _processor = CallProcessor<TRequest, TResponse>(
       transport: transport,
@@ -106,24 +110,29 @@ final class ClientStreamCaller<TRequest extends Object,
     _subscription = _processor.responses.listen(
       (rpcMessage) {
         _logger?.internal(
-            'Получен ответ от сервера: isMetadataOnly=${rpcMessage.isMetadataOnly}, isEndOfStream=${rpcMessage.isEndOfStream}');
+          'Получен ответ от сервера: isMetadataOnly=${rpcMessage.isMetadataOnly}, isEndOfStream=${rpcMessage.isEndOfStream}',
+        );
 
         // Проверяем на ошибки в метаданных (трейлерах)
         if (rpcMessage.isMetadataOnly && rpcMessage.metadata != null) {
-          final statusCode = rpcMessage.metadata!
-              .getHeaderValue(RpcConstants.GRPC_STATUS_HEADER);
+          final statusCode = rpcMessage.metadata!.getHeaderValue(
+            RpcConstants.GRPC_STATUS_HEADER,
+          );
           _logger?.internal('Статус-код из метаданных: $statusCode');
 
           if (statusCode != null && statusCode != '0') {
-            final errorMessage = rpcMessage.metadata!
-                    .getHeaderValue(RpcConstants.GRPC_MESSAGE_HEADER) ??
+            final errorMessage = rpcMessage.metadata!.getHeaderValue(
+                  RpcConstants.GRPC_MESSAGE_HEADER,
+                ) ??
                 '';
             _logger?.error(
-                'Получен ошибочный статус-код: $statusCode - $errorMessage');
+              'Получен ошибочный статус-код: $statusCode - $errorMessage',
+            );
 
             if (!_responseCompleter.isCompleted) {
               _responseCompleter.completeError(
-                  Exception('gRPC error $statusCode: $errorMessage'));
+                Exception('gRPC error $statusCode: $errorMessage'),
+              );
             }
             return;
           }
@@ -134,8 +143,9 @@ final class ClientStreamCaller<TRequest extends Object,
               rpcMessage.isEndOfStream &&
               !_responseCompleter.isCompleted) {
             _logger?.warning('Получен статус OK, но нет данных в ответе');
-            _responseCompleter
-                .completeError(Exception('Стрим завершен без данных в ответе'));
+            _responseCompleter.completeError(
+              Exception('Стрим завершен без данных в ответе'),
+            );
           }
         }
 
@@ -143,14 +153,18 @@ final class ClientStreamCaller<TRequest extends Object,
         if (!rpcMessage.isMetadataOnly &&
             !_responseCompleter.isCompleted &&
             rpcMessage.payload != null) {
-          _logger
-              ?.internal('Получена полезная нагрузка: ${rpcMessage.payload}');
+          _logger?.internal(
+            'Получена полезная нагрузка: ${rpcMessage.payload}',
+          );
           _responseCompleter.complete(rpcMessage.payload!);
         }
       },
       onError: (error, stackTrace) {
-        _logger?.error('Ошибка в потоке ответов',
-            error: error, stackTrace: stackTrace);
+        _logger?.error(
+          'Ошибка в потоке ответов',
+          error: error,
+          stackTrace: stackTrace,
+        );
         if (!_responseCompleter.isCompleted) {
           _responseCompleter.completeError(error, stackTrace);
         }
@@ -160,8 +174,9 @@ final class ClientStreamCaller<TRequest extends Object,
         if (!_responseCompleter.isCompleted) {
           // Проверяем, не было ли это вызвано закрытием транспорта
           try {
-            _responseCompleter
-                .completeError(Exception('Стрим закрыт без получения ответа'));
+            _responseCompleter.completeError(
+              Exception('Стрим закрыт без получения ответа'),
+            );
           } catch (e) {
             // Если completer уже завершен, ничего не делаем
             _logger?.internal('Completer уже завершен, пропускаем ошибку: $e');
@@ -178,8 +193,10 @@ final class ClientStreamCaller<TRequest extends Object,
   /// Throws [StateError] если отправка уже завершена
   Future<void> send(TRequest request) async {
     if (_sendingFinished) {
-      throw StateError('Отправка запросов уже завершена! '
-          'Вызовите finishSending() для получения ответа.');
+      throw StateError(
+        'Отправка запросов уже завершена! '
+        'Вызовите finishSending() для получения ответа.',
+      );
     }
 
     _logger?.internal('Отправка запроса в клиентский стрим: $request');
@@ -214,12 +231,17 @@ final class ClientStreamCaller<TRequest extends Object,
           // Освобождаем ресурсы при таймауте
           unawaited(close());
           throw TimeoutException(
-              'Таймаут ожидания ответа от сервера', Duration(seconds: 30));
+            'Таймаут ожидания ответа от сервера',
+            Duration(seconds: 30),
+          );
         },
       );
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при завершении отправки',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при завершении отправки',
+        error: e,
+        stackTrace: stackTrace,
+      );
 
       if (!_responseCompleter.isCompleted) {
         _responseCompleter.completeError(e, stackTrace);

--- a/packages/rpc_dart/lib/src/rpc/streams/client/responder.dart
+++ b/packages/rpc_dart/lib/src/rpc/streams/client/responder.dart
@@ -51,19 +51,23 @@ final class ClientStreamResponder<TRequest extends Object,
     // Zero-copy режим: требуется RpcInMemoryTransport
     if (isZeroCopy && !transport.supportsZeroCopy) {
       throw ArgumentError(
-          'Zero-copy режим требует транспорт с поддержкой zero-copy. '
-          'Для сетевых транспортов передайте кодеки.');
+        'Zero-copy режим требует транспорт с поддержкой zero-copy. '
+        'Для сетевых транспортов передайте кодеки.',
+      );
     }
 
     // Режим сериализации: кодеки обязательны
     if (!isZeroCopy && (requestCodec == null || responseCodec == null)) {
-      throw ArgumentError('Кодеки обязательны для режима сериализации. '
-          'Для zero-copy не передавайте кодеки (null).');
+      throw ArgumentError(
+        'Кодеки обязательны для режима сериализации. '
+        'Для zero-copy не передавайте кодеки (null).',
+      );
     }
 
     _logger = logger?.child('ClientResponder');
     _logger?.internal(
-        'Создание ${isZeroCopy ? "Zero-copy" : "Serialized"} ClientStreamResponder для $serviceName.$methodName [id: $id]');
+      'Создание ${isZeroCopy ? "Zero-copy" : "Serialized"} ClientStreamResponder для $serviceName.$methodName [id: $id]',
+    );
 
     _processor = StreamProcessor<TRequest, TResponse>(
       transport: transport,
@@ -95,12 +99,14 @@ final class ClientStreamResponder<TRequest extends Object,
 
     _handlerStarted = true;
     _logger?.internal(
-        'Настройка обработчика запросов для клиентского стрима [id: $id]');
+      'Настройка обработчика запросов для клиентского стрима [id: $id]',
+    );
 
     // Вызываем обработчик напрямую с потоком запросов
     handler(_processor.requests).then((response) async {
       _logger?.internal(
-          'Обработчик завершен, отправляем ответ: $response [id: $id]');
+        'Обработчик завершен, отправляем ответ: $response [id: $id]',
+      );
 
       try {
         await _processor.send(response);

--- a/packages/rpc_dart/lib/src/rpc/streams/server/caller.dart
+++ b/packages/rpc_dart/lib/src/rpc/streams/server/caller.dart
@@ -68,19 +68,23 @@ final class ServerStreamCaller<TRequest extends Object,
     // Zero-copy режим: требуется RpcInMemoryTransport
     if (isZeroCopy && !transport.supportsZeroCopy) {
       throw ArgumentError(
-          'Zero-copy режим требует транспорт с поддержкой zero-copy. '
-          'Для сетевых транспортов передайте кодеки.');
+        'Zero-copy режим требует транспорт с поддержкой zero-copy. '
+        'Для сетевых транспортов передайте кодеки.',
+      );
     }
 
     // Режим сериализации: кодеки обязательны
     if (!isZeroCopy && (requestCodec == null || responseCodec == null)) {
-      throw ArgumentError('Кодеки обязательны для режима сериализации. '
-          'Для zero-copy не передавайте кодеки (null).');
+      throw ArgumentError(
+        'Кодеки обязательны для режима сериализации. '
+        'Для zero-copy не передавайте кодеки (null).',
+      );
     }
 
     _logger = logger?.child('ServerCaller');
     _logger?.internal(
-        'Создание ${isZeroCopy ? "Zero-copy" : "Serialized"} ServerStreamCaller для $serviceName.$methodName');
+      'Создание ${isZeroCopy ? "Zero-copy" : "Serialized"} ServerStreamCaller для $serviceName.$methodName',
+    );
 
     _processor = CallProcessor<TRequest, TResponse>(
       transport: transport,
@@ -109,12 +113,15 @@ final class ServerStreamCaller<TRequest extends Object,
   /// Throws [StateError] если запрос уже был отправлен
   Future<void> send(TRequest request) async {
     if (_requestSent) {
-      throw StateError('ServerStream позволяет отправить только один запрос! '
-          'Запрос уже был отправлен.');
+      throw StateError(
+        'ServerStream позволяет отправить только один запрос! '
+        'Запрос уже был отправлен.',
+      );
     }
 
     _logger?.internal(
-        'Отправка единственного запроса в серверный стрим: $request');
+      'Отправка единственного запроса в серверный стрим: $request',
+    );
 
     try {
       _requestSent =
@@ -128,8 +135,11 @@ final class ServerStreamCaller<TRequest extends Object,
       // что у нас только один запрос (семантика серверного стрима)
       await _processor.finishSending();
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при отправке запроса в серверный стрим',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при отправке запроса в серверный стрим',
+        error: e,
+        stackTrace: stackTrace,
+      );
       rethrow;
     }
   }
@@ -159,16 +169,19 @@ final class ServerStreamCaller<TRequest extends Object,
 
         // Проверяем статус в метаданных
         if (response.metadata != null) {
-          final statusStr = response.metadata!
-              .getHeaderValue(RpcConstants.GRPC_STATUS_HEADER);
+          final statusStr = response.metadata!.getHeaderValue(
+            RpcConstants.GRPC_STATUS_HEADER,
+          );
           if (statusStr != null) {
             final status = int.tryParse(statusStr) ?? RpcStatus.UNKNOWN;
             if (status != RpcStatus.OK) {
-              final message = response.metadata!
-                      .getHeaderValue(RpcConstants.GRPC_MESSAGE_HEADER) ??
+              final message = response.metadata!.getHeaderValue(
+                    RpcConstants.GRPC_MESSAGE_HEADER,
+                  ) ??
                   'Unknown error';
               _logger?.error(
-                  'Серверный стрим завершился с ошибкой: $status - $message');
+                'Серверный стрим завершился с ошибкой: $status - $message',
+              );
               throw Exception('gRPC error $status: $message');
             }
           }

--- a/packages/rpc_dart/lib/src/rpc/streams/server/responder.dart
+++ b/packages/rpc_dart/lib/src/rpc/streams/server/responder.dart
@@ -55,19 +55,23 @@ final class ServerStreamResponder<TRequest extends Object,
     // Zero-copy режим: требуется RpcInMemoryTransport
     if (isZeroCopy && !transport.supportsZeroCopy) {
       throw ArgumentError(
-          'Zero-copy режим требует транспорт с поддержкой zero-copy. '
-          'Для сетевых транспортов передайте кодеки.');
+        'Zero-copy режим требует транспорт с поддержкой zero-copy. '
+        'Для сетевых транспортов передайте кодеки.',
+      );
     }
 
     // Режим сериализации: кодеки обязательны
     if (!isZeroCopy && (requestCodec == null || responseCodec == null)) {
-      throw ArgumentError('Кодеки обязательны для режима сериализации. '
-          'Для zero-copy не передавайте кодеки (null).');
+      throw ArgumentError(
+        'Кодеки обязательны для режима сериализации. '
+        'Для zero-copy не передавайте кодеки (null).',
+      );
     }
 
     _logger = logger?.child('ServerResponder');
     _logger?.internal(
-        'Создание ${isZeroCopy ? "Zero-copy" : "Serialized"} ServerStreamResponder для $serviceName.$methodName [id: $id]');
+      'Создание ${isZeroCopy ? "Zero-copy" : "Serialized"} ServerStreamResponder для $serviceName.$methodName [id: $id]',
+    );
 
     _processor = StreamProcessor<TRequest, TResponse>(
       transport: transport,
@@ -94,69 +98,85 @@ final class ServerStreamResponder<TRequest extends Object,
     Stream<TResponse> Function(TRequest request) handler,
   ) {
     _logger?.internal(
-        'Настройка обработчика запросов для серверного стрима [id: $id]');
+      'Настройка обработчика запросов для серверного стрима [id: $id]',
+    );
 
-    _subscription = _processor.requests.listen((request) async {
-      _logger?.internal(
-          'Получен запрос для серверного стрима: $request [id: $id]');
-
-      if (!_requestHandled) {
+    _subscription = _processor.requests.listen(
+      (request) async {
         _logger?.internal(
-            'Обработка первого запроса для серверного стрима [id: $id]');
-        _requestHandled = true;
+          'Получен запрос для серверного стрима: $request [id: $id]',
+        );
 
-        try {
-          _logger?.internal('Вызов обработчика запроса [id: $id]');
-          final handlerStream = handler(request);
+        if (!_requestHandled) {
           _logger?.internal(
-              'Обработчик успешно вызван, получен стрим ответов [id: $id]');
-
-          _logger?.internal(
-              'Начинаем обработку потока ответов от обработчика [id: $id]');
-
-          int responseCount = 0;
-          await for (var response in handlerStream) {
-            responseCount++;
-            _logger?.internal(
-                'Получен ответ #$responseCount от обработчика: $response [id: $id]');
-
-            try {
-              await _processor.send(response);
-              _logger?.internal(
-                  'Ответ #$responseCount успешно отправлен клиенту [id: $id]');
-            } catch (e, stackTrace) {
-              _logger?.error(
-                'Ошибка при отправке ответа #$responseCount клиенту [id: $id]',
-                error: e,
-                stackTrace: stackTrace,
-              );
-            }
-          }
-
-          _logger?.internal(
-              'Поток ответов от обработчика завершен, всего ответов: $responseCount [id: $id]');
-
-          // Завершаем отправку ответов
-          await _processor.finishSending();
-          _logger?.internal('Отправка ответов завершена [id: $id]');
-        } catch (error, trace) {
-          _logger?.error(
-            'Ошибка при обработке запроса [id: $id]',
-            error: error,
-            stackTrace: trace,
+            'Обработка первого запроса для серверного стрима [id: $id]',
           );
-          await _processor.sendError(RpcStatus.INTERNAL, error.toString());
+          _requestHandled = true;
+
+          try {
+            _logger?.internal('Вызов обработчика запроса [id: $id]');
+            final handlerStream = handler(request);
+            _logger?.internal(
+              'Обработчик успешно вызван, получен стрим ответов [id: $id]',
+            );
+
+            _logger?.internal(
+              'Начинаем обработку потока ответов от обработчика [id: $id]',
+            );
+
+            int responseCount = 0;
+            await for (var response in handlerStream) {
+              responseCount++;
+              _logger?.internal(
+                'Получен ответ #$responseCount от обработчика: $response [id: $id]',
+              );
+
+              try {
+                await _processor.send(response);
+                _logger?.internal(
+                  'Ответ #$responseCount успешно отправлен клиенту [id: $id]',
+                );
+              } catch (e, stackTrace) {
+                _logger?.error(
+                  'Ошибка при отправке ответа #$responseCount клиенту [id: $id]',
+                  error: e,
+                  stackTrace: stackTrace,
+                );
+              }
+            }
+
+            _logger?.internal(
+              'Поток ответов от обработчика завершен, всего ответов: $responseCount [id: $id]',
+            );
+
+            // Завершаем отправку ответов
+            await _processor.finishSending();
+            _logger?.internal('Отправка ответов завершена [id: $id]');
+          } catch (error, trace) {
+            _logger?.error(
+              'Ошибка при обработке запроса [id: $id]',
+              error: error,
+              stackTrace: trace,
+            );
+            await _processor.sendError(RpcStatus.INTERNAL, error.toString());
+          }
+        } else {
+          _logger?.internal(
+            'Игнорирование дополнительного запроса (первый уже обработан) [id: $id]',
+          );
         }
-      } else {
-        _logger?.internal(
-            'Игнорирование дополнительного запроса (первый уже обработан) [id: $id]');
-      }
-    }, onError: (error, stackTrace) {
-      _logger?.error('Ошибка в потоке запросов [id: $id]',
-          error: error, stackTrace: stackTrace);
-    }, onDone: () {
-      _logger?.internal('Поток запросов завершен [id: $id]');
-    });
+      },
+      onError: (error, stackTrace) {
+        _logger?.error(
+          'Ошибка в потоке запросов [id: $id]',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      },
+      onDone: () {
+        _logger?.internal('Поток запросов завершен [id: $id]');
+      },
+    );
   }
 
   /// Закрывает стрим и освобождает ресурсы

--- a/packages/rpc_dart/lib/src/rpc/streams/unary/caller.dart
+++ b/packages/rpc_dart/lib/src/rpc/streams/unary/caller.dart
@@ -80,7 +80,8 @@ final class UnaryCaller<TRequest, TResponse> {
     _parser = RpcMessageParser(logger: _logger);
     _methodPath = '/$_serviceName/$_methodName';
     _logger?.internal(
-        'Создан унарный клиент для $_methodPath${_context != null ? ' с контекстом' : ''}');
+      'Создан унарный клиент для $_methodPath${_context != null ? ' с контекстом' : ''}',
+    );
   }
 
   /// Выполняет унарный вызов
@@ -100,9 +101,7 @@ final class UnaryCaller<TRequest, TResponse> {
     // Создаем новый stream для этого вызова
     final streamId = _transport.createStream();
 
-    _logger?.internal(
-      'Унарный вызов $_methodPath начат [streamId: $streamId]',
-    );
+    _logger?.internal('Унарный вызов $_methodPath начат [streamId: $streamId]');
 
     final completer = Completer<TResponse>();
     StreamSubscription? subscription;
@@ -115,10 +114,14 @@ final class UnaryCaller<TRequest, TResponse> {
             _context!.cancellationToken!.cancelled.asStream().listen((_) {
           if (!completer.isCompleted) {
             _logger?.warning(
-                'Операция отменена по cancellation token [streamId: $streamId]');
-            completer.completeError(RpcCancelledException(
+              'Операция отменена по cancellation token [streamId: $streamId]',
+            );
+            completer.completeError(
+              RpcCancelledException(
                 _context!.cancellationToken!.reason ??
-                    'Operation was cancelled'));
+                    'Operation was cancelled',
+              ),
+            );
           }
         });
       }
@@ -136,18 +139,21 @@ final class UnaryCaller<TRequest, TResponse> {
               final response = message.directPayload as TResponse;
               if (!completer.isCompleted) {
                 _logger?.internal(
-                    'Zero-copy унарный вызов $_methodPath успешно завершен [streamId: $streamId]');
+                  'Zero-copy унарный вызов $_methodPath успешно завершен [streamId: $streamId]',
+                );
                 completer.complete(response);
               } else {
                 _logger?.warning(
-                    'Получен лишний zero-copy ответ после завершения вызова [streamId: $streamId]');
+                  'Получен лишний zero-copy ответ после завершения вызова [streamId: $streamId]',
+                );
               }
             } catch (e, stackTrace) {
               if (!completer.isCompleted) {
                 _logger?.error(
-                    'Ошибка при обработке zero-copy ответа [streamId: $streamId]',
-                    error: e,
-                    stackTrace: stackTrace);
+                  'Ошибка при обработке zero-copy ответа [streamId: $streamId]',
+                  error: e,
+                  stackTrace: stackTrace,
+                );
                 completer.completeError(e);
               }
             }
@@ -160,56 +166,69 @@ final class UnaryCaller<TRequest, TResponse> {
               // Используем парсер для извлечения сообщений из фрейма с префиксом
               final messages = _parser(message.payload!);
               _logger?.internal(
-                  'Парсер извлек ${messages.length} сообщений из фрейма [streamId: $streamId]');
+                'Парсер извлек ${messages.length} сообщений из фрейма [streamId: $streamId]',
+              );
 
               for (final msgBytes in messages) {
                 _logger?.internal(
-                    'Десериализация ответа размером ${msgBytes.length} байт [streamId: $streamId]');
+                  'Десериализация ответа размером ${msgBytes.length} байт [streamId: $streamId]',
+                );
                 final response = _responseSerializer.deserialize(msgBytes);
                 if (!completer.isCompleted) {
                   _logger?.internal(
-                      'Унарный вызов $_methodPath успешно завершен [streamId: $streamId]');
+                    'Унарный вызов $_methodPath успешно завершен [streamId: $streamId]',
+                  );
                   completer.complete(response);
                   break; // Для унарного вызова нужен только первый ответ
                 } else {
                   _logger?.warning(
-                      'Получен лишний ответ после завершения вызова [streamId: $streamId]');
+                    'Получен лишний ответ после завершения вызова [streamId: $streamId]',
+                  );
                 }
               }
             } catch (e, stackTrace) {
               if (!completer.isCompleted) {
                 _logger?.error(
-                    'Ошибка при обработке ответа [streamId: $streamId]',
-                    error: e,
-                    stackTrace: stackTrace);
+                  'Ошибка при обработке ответа [streamId: $streamId]',
+                  error: e,
+                  stackTrace: stackTrace,
+                );
                 completer.completeError(e);
               }
             }
           } else if (message.isMetadataOnly && message.metadata != null) {
             // Получили метаданные (возможно трейлеры)
             _logger?.internal('Получены метаданные [streamId: $streamId]');
-            final statusCode = message.metadata!
-                .getHeaderValue(RpcConstants.GRPC_STATUS_HEADER);
+            final statusCode = message.metadata!.getHeaderValue(
+              RpcConstants.GRPC_STATUS_HEADER,
+            );
 
             if (statusCode != null && message.isEndOfStream) {
               final code = int.parse(statusCode);
               _logger?.internal(
-                  'Получен статус завершения: $code [streamId: $streamId]');
+                'Получен статус завершения: $code [streamId: $streamId]',
+              );
               if (code != RpcStatus.OK && !completer.isCompleted) {
-                final errorMessage = message.metadata!
-                        .getHeaderValue(RpcConstants.GRPC_MESSAGE_HEADER) ??
+                final errorMessage = message.metadata!.getHeaderValue(
+                      RpcConstants.GRPC_MESSAGE_HEADER,
+                    ) ??
                     '';
                 _logger?.error(
-                    'Ошибка gRPC: $code - $errorMessage [streamId: $streamId]');
+                  'Ошибка gRPC: $code - $errorMessage [streamId: $streamId]',
+                );
                 completer.completeError(
-                    Exception('gRPC error $code: $errorMessage'));
+                  Exception('gRPC error $code: $errorMessage'),
+                );
               }
             }
           }
         },
         onError: (error, stackTrace) {
-          _logger?.error('Ошибка от транспорта [streamId: $streamId]',
-              error: error, stackTrace: stackTrace);
+          _logger?.error(
+            'Ошибка от транспорта [streamId: $streamId]',
+            error: error,
+            stackTrace: stackTrace,
+          );
           if (!completer.isCompleted) {
             completer.completeError(error);
           }
@@ -218,8 +237,10 @@ final class UnaryCaller<TRequest, TResponse> {
 
       // Отправляем метаданные инициализации с заголовками из контекста
       _logger?.internal('Отправка начальных метаданных [streamId: $streamId]');
-      final baseMetadata =
-          RpcMetadata.forClientRequest(_serviceName, _methodName);
+      final baseMetadata = RpcMetadata.forClientRequest(
+        _serviceName,
+        _methodName,
+      );
 
       // Создаем новые метаданные с заголовками из контекста
       final headers = List<RpcHeader>.from(baseMetadata.headers);
@@ -238,12 +259,17 @@ final class UnaryCaller<TRequest, TResponse> {
 
         // Передаем deadline серверу
         if (_context!.deadline != null) {
-          headers.add(RpcHeader('x-deadline',
-              _context!.deadline!.millisecondsSinceEpoch.toString()));
+          headers.add(
+            RpcHeader(
+              'x-deadline',
+              _context!.deadline!.millisecondsSinceEpoch.toString(),
+            ),
+          );
         }
 
         _logger?.internal(
-            'Добавлены заголовки контекста: ${_context!.headers.length} пользовательских + системные');
+          'Добавлены заголовки контекста: ${_context!.headers.length} пользовательских + системные',
+        );
       }
 
       final metadata = RpcMetadata(headers);
@@ -262,15 +288,13 @@ final class UnaryCaller<TRequest, TResponse> {
         _logger?.internal('Сериализация запроса [streamId: $streamId]');
         final serializedRequest = _requestSerializer.serialize(request);
         _logger?.internal(
-            'Запрос сериализован, размер: ${serializedRequest.length} байт [streamId: $streamId]');
+          'Запрос сериализован, размер: ${serializedRequest.length} байт [streamId: $streamId]',
+        );
         final framedRequest = RpcMessageFrame.encode(serializedRequest);
         _logger?.internal(
-            'Отправка запроса и закрытие потока запросов [streamId: $streamId]');
-        await _transport.sendMessage(
-          streamId,
-          framedRequest,
-          endStream: true,
+          'Отправка запроса и закрытие потока запросов [streamId: $streamId]',
         );
+        await _transport.sendMessage(streamId, framedRequest, endStream: true);
       }
 
       // Ждем ответ с таймаутом, если указан
@@ -284,14 +308,17 @@ final class UnaryCaller<TRequest, TResponse> {
             'Тайм-аут ожидания ответа: $effectiveTimeout [streamId: $streamId]',
           );
           throw TimeoutException(
-              'Call timeout: $effectiveTimeout', effectiveTimeout);
+            'Call timeout: $effectiveTimeout',
+            effectiveTimeout,
+          );
         },
       );
     } catch (e, stackTrace) {
       _logger?.error(
-          'Ошибка при выполнении унарного вызова $_methodPath [streamId: $streamId]',
-          error: e,
-          stackTrace: stackTrace);
+        'Ошибка при выполнении унарного вызова $_methodPath [streamId: $streamId]',
+        error: e,
+        stackTrace: stackTrace,
+      );
       rethrow;
     } finally {
       // В любом случае отписываемся от потока ответов
@@ -319,13 +346,11 @@ final class UnaryCaller<TRequest, TResponse> {
 
     // Проверяем deadline
     if (_context!.isExpired) {
-      throw RpcDeadlineExceededException(
-        _context!.deadline!,
-        Duration.zero,
-      );
+      throw RpcDeadlineExceededException(_context!.deadline!, Duration.zero);
     }
 
     _logger?.internal(
-        'Контекст проверен: requestId=${_context!.requestId}, traceId=${_context!.traceId}');
+      'Контекст проверен: requestId=${_context!.requestId}, traceId=${_context!.traceId}',
+    );
   }
 }

--- a/packages/rpc_dart/lib/src/rpc/streams/unary/responder.dart
+++ b/packages/rpc_dart/lib/src/rpc/streams/unary/responder.dart
@@ -99,7 +99,8 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
     _parser = RpcMessageParser(logger: _logger);
     _methodPath = '/$_serviceName/$_methodName';
     _logger?.internal(
-        'Создан унарный сервер для $_methodPath${_context?.cancellationToken != null ? " с cancellation token" : ""}');
+      'Создан унарный сервер для $_methodPath${_context?.cancellationToken != null ? " с cancellation token" : ""}',
+    );
 
     // Регистрируем поток как принадлежащий этому методу
     _streamBelongsToThisMethod[id] = true;
@@ -155,7 +156,8 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
           if (message.methodPath == _methodPath) {
             _streamBelongsToThisMethod[streamId] = true;
             _logger?.internal(
-                'Унарный сервер: stream $streamId привязан к методу $_methodPath');
+              'Унарный сервер: stream $streamId привязан к методу $_methodPath',
+            );
           }
           return; // Метаданные только регистрируем, но не обрабатываем
         }
@@ -168,7 +170,8 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
         if (_streamRequestHandled[streamId] == true) {
           // Игнорируем дополнительные сообщения после обработки первого запроса
           _logger?.internal(
-              'Игнорируем дополнительное сообщение для stream $streamId (запрос уже обработан)');
+            'Игнорируем дополнительное сообщение для stream $streamId (запрос уже обработан)',
+          );
           return;
         }
 
@@ -195,7 +198,8 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
             _streamRequestHandled[streamId] != true) {
           _streamRequestHandled[streamId] = true;
           _logger?.warning(
-              'Клиент закрыл поток без отправки данных [streamId: $streamId]');
+            'Клиент закрыл поток без отправки данных [streamId: $streamId]',
+          );
 
           // Отправляем трейлер с ошибкой
           await _transport.sendMetadata(
@@ -236,9 +240,7 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
     try {
       _checkCancellation();
     } catch (e) {
-      _logger?.internal(
-        'Обработка сообщения отменена [streamId: $streamId]',
-      );
+      _logger?.internal('Обработка сообщения отменена [streamId: $streamId]');
       return;
     }
 
@@ -246,13 +248,15 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
     // Для id=0 (значение по умолчанию) принимаем любые сообщения, это нужно для тестов
     if (id != 0 && streamId != id) {
       _logger?.internal(
-          'Сообщение для stream $streamId не принадлежит этому респондеру (id=$id), пропускаем');
+        'Сообщение для stream $streamId не принадлежит этому респондеру (id=$id), пропускаем',
+      );
       return;
     }
 
     if (_streamRequestHandled[streamId] == true) {
       _logger?.internal(
-          'Сообщение для stream $streamId уже обработано, пропускаем');
+        'Сообщение для stream $streamId уже обработано, пропускаем',
+      );
       return;
     }
 
@@ -263,14 +267,16 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
 
     // Сразу помечаем запрос как обрабатываемый, чтобы предотвратить повторную обработку
     _streamRequestHandled[streamId] = true;
-    _logger
-        ?.internal('Обработка запроса для $_methodPath [streamId: $streamId]');
+    _logger?.internal(
+      'Обработка запроса для $_methodPath [streamId: $streamId]',
+    );
 
     try {
       // Отправляем начальные заголовки, если еще не отправляли
       if (_streamInitialHeadersSent[streamId] != true) {
-        _logger
-            ?.internal('Отправка начальных заголовков [streamId: $streamId]');
+        _logger?.internal(
+          'Отправка начальных заголовков [streamId: $streamId]',
+        );
         await _transport.sendMetadata(
           streamId,
           RpcMetadata.forServerInitialResponse(),
@@ -281,11 +287,13 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
       // Десериализуем запрос
       // Используем парсер для извлечения сообщений из фрейма с префиксом
       _logger?.internal(
-          'Парсинг фрейма запроса размером ${message.payload!.length} байт [streamId: $streamId]');
+        'Парсинг фрейма запроса размером ${message.payload!.length} байт [streamId: $streamId]',
+      );
       final messages = _parser(message.payload!);
       if (messages.isEmpty) {
         _logger?.error(
-            'Не удалось извлечь сообщение из payload [streamId: $streamId]');
+          'Не удалось извлечь сообщение из payload [streamId: $streamId]',
+        );
         throw Exception('Не удалось извлечь сообщение из payload');
       }
 
@@ -293,28 +301,29 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
       final request = _requestSerializer.deserialize(messages.first);
 
       _logger?.internal(
-          'Обработка запроса для $_methodPath [streamId: $streamId]');
+        'Обработка запроса для $_methodPath [streamId: $streamId]',
+      );
 
       // Обрабатываем запрос
       final response = await _handler(request);
       _logger?.internal(
-          'Запрос обработан, подготовка ответа [streamId: $streamId]');
+        'Запрос обработан, подготовка ответа [streamId: $streamId]',
+      );
 
       // Сериализуем и отправляем ответ
       _logger?.internal('Сериализация ответа [streamId: $streamId]');
       final serializedResponse = _responseSerializer.serialize(response);
       _logger?.internal(
-          'Ответ сериализован, размер: ${serializedResponse.length} байт [streamId: $streamId]');
+        'Ответ сериализован, размер: ${serializedResponse.length} байт [streamId: $streamId]',
+      );
       final framedResponse = RpcMessageFrame.encode(serializedResponse);
       _logger?.internal('Отправка ответа [streamId: $streamId]');
-      await _transport.sendMessage(
-        streamId,
-        framedResponse,
-      );
+      await _transport.sendMessage(streamId, framedResponse);
 
       // Отправляем трейлер с успешным статусом
       _logger?.internal(
-          'Отправка трейлера с успешным статусом [streamId: $streamId]');
+        'Отправка трейлера с успешным статусом [streamId: $streamId]',
+      );
       await _transport.sendMetadata(
         streamId,
         RpcMetadata.forTrailer(RpcStatus.OK),
@@ -322,7 +331,8 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
       );
 
       _logger?.internal(
-          'Ответ успешно отправлен для $_methodPath [streamId: $streamId]');
+        'Ответ успешно отправлен для $_methodPath [streamId: $streamId]',
+      );
     } catch (e, stackTrace) {
       _logger?.error(
         'Ошибка при обработке запроса [streamId: $streamId]',
@@ -375,26 +385,30 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
     // Проверяем, что сообщение предназначено для этого экземпляра респондера
     if (id != 0 && streamId != id) {
       _logger?.internal(
-          'Zero-copy сообщение для stream $streamId не принадлежит этому респондеру (id=$id), пропускаем');
+        'Zero-copy сообщение для stream $streamId не принадлежит этому респондеру (id=$id), пропускаем',
+      );
       return;
     }
 
     if (_streamRequestHandled[streamId] == true) {
       _logger?.internal(
-          'Zero-copy сообщение для stream $streamId уже обработано, пропускаем');
+        'Zero-copy сообщение для stream $streamId уже обработано, пропускаем',
+      );
       return;
     }
 
     // Сразу помечаем запрос как обрабатываемый
     _streamRequestHandled[streamId] = true;
     _logger?.internal(
-        'Zero-copy request processing for $_methodPath [streamId: $streamId]');
+      'Zero-copy request processing for $_methodPath [streamId: $streamId]',
+    );
 
     try {
       // Отправляем начальные заголовки, если еще не отправляли
       if (_streamInitialHeadersSent[streamId] != true) {
-        _logger
-            ?.internal('Отправка начальных заголовков [streamId: $streamId]');
+        _logger?.internal(
+          'Отправка начальных заголовков [streamId: $streamId]',
+        );
         await _transport.sendMetadata(
           streamId,
           RpcMetadata.forServerInitialResponse(),
@@ -407,20 +421,19 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
       final request = message.directPayload as TRequest;
 
       _logger?.internal(
-          'Zero-copy request handling for $_methodPath [streamId: $streamId]');
+        'Zero-copy request handling for $_methodPath [streamId: $streamId]',
+      );
 
       // Обрабатываем запрос
       final response = await _handler(request);
       _logger?.internal(
-          'Zero-copy request completed, preparing response [streamId: $streamId]');
+        'Zero-copy request completed, preparing response [streamId: $streamId]',
+      );
 
       // Zero-copy: отправляем ответ напрямую если транспорт поддерживает
       if (_transport.supportsZeroCopy) {
         _logger?.internal('Zero-copy response sending [streamId: $streamId]');
-        await _transport.sendDirectObject(
-          streamId,
-          response as Object,
-        );
+        await _transport.sendDirectObject(streamId, response as Object);
       } else {
         // Fallback на стандартную сериализацию для других транспортов
         _logger?.internal('Fallback сериализация ответа [streamId: $streamId]');
@@ -430,8 +443,9 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
       }
 
       // Отправляем трейлер с успешным статусом
-      _logger
-          ?.internal('Zero-copy sending success trailer [streamId: $streamId]');
+      _logger?.internal(
+        'Zero-copy sending success trailer [streamId: $streamId]',
+      );
       await _transport.sendMetadata(
         streamId,
         RpcMetadata.forTrailer(RpcStatus.OK),
@@ -439,7 +453,8 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
       );
 
       _logger?.internal(
-          'Zero-copy response completed for $_methodPath [streamId: $streamId]');
+        'Zero-copy response completed for $_methodPath [streamId: $streamId]',
+      );
     } catch (e, stackTrace) {
       _logger?.error(
         'Zero-copy request processing error [streamId: $streamId]',
@@ -459,10 +474,7 @@ final class UnaryResponder<TRequest, TResponse> implements IRpcResponder {
       // При ошибке отправляем трейлер с кодом ошибки
       await _transport.sendMetadata(
         streamId,
-        RpcMetadata.forTrailer(
-          RpcStatus.INTERNAL,
-          message: e.toString(),
-        ),
+        RpcMetadata.forTrailer(RpcStatus.INTERNAL, message: e.toString()),
         endStream: true,
       );
     } finally {

--- a/packages/rpc_dart/lib/src/rpc/transports/in_memory_transport.dart
+++ b/packages/rpc_dart/lib/src/rpc/transports/in_memory_transport.dart
@@ -195,6 +195,69 @@ class RpcInMemoryTransport implements IRpcTransport {
     }
   }
 
+  Map<String, Object?> _collectHealthDetails() {
+    return {
+      'isClosed': _closed,
+      'activeStreams': _activeStreams.length,
+      'incomingControllerClosed': _incomingController.isClosed,
+      'outgoingControllerClosed': _outgoingController.isClosed,
+      'partnerAttached': _partner != null,
+      'partnerClosed': _partner?._closed,
+    };
+  }
+
+  @override
+  Future<RpcHealthStatus> health() async {
+    if (_closed) {
+      return RpcHealthStatus.closed(
+        component: runtimeType.toString(),
+        message: 'In-memory transport is closed',
+        details: _collectHealthDetails(),
+      );
+    }
+
+    final partnerClosed = _partner?._closed ?? false;
+    if (partnerClosed) {
+      return RpcHealthStatus.degraded(
+        component: runtimeType.toString(),
+        message: 'Partner transport is closed',
+        details: _collectHealthDetails(),
+      );
+    }
+
+    return RpcHealthStatus.healthy(
+      component: runtimeType.toString(),
+      message: 'In-memory transport ready',
+      details: _collectHealthDetails(),
+    );
+  }
+
+  @override
+  Future<RpcHealthStatus> reconnect() async {
+    if (_closed) {
+      return RpcHealthStatus.unhealthy(
+        component: runtimeType.toString(),
+        message:
+            'RpcInMemoryTransport cannot be reconnected after close(). Create a new pair instead.',
+        details: {..._collectHealthDetails(), 'supported': false},
+      );
+    }
+
+    if (_partner?._closed ?? false) {
+      return RpcHealthStatus.degraded(
+        component: runtimeType.toString(),
+        message: 'Partner transport is closed and requires recreation',
+        details: {..._collectHealthDetails(), 'supported': false},
+      );
+    }
+
+    return RpcHealthStatus.healthy(
+      component: runtimeType.toString(),
+      message: 'Reconnect is a no-op for in-memory transport',
+      details: {..._collectHealthDetails(), 'supported': false},
+    );
+  }
+
   @override
   Future<void> close() async {
     if (_closed) return;

--- a/packages/rpc_dart/lib/src/rpc/transports/transport_router.dart
+++ b/packages/rpc_dart/lib/src/rpc/transports/transport_router.dart
@@ -13,10 +13,7 @@ part of '../_index.dart';
 ///
 /// Возвращает true, если правило должно применяться к данному вызову
 typedef RpcRoutingCondition = bool Function(
-  String? serviceName,
-  String? methodPath,
-  RpcContext? context,
-);
+    String? serviceName, String? methodPath, RpcContext? context);
 
 /// Правило роутинга с приоритетом
 typedef PrioritizedRoutingRule = ({
@@ -69,7 +66,8 @@ final class RpcTransportRouter implements IRpcTransport {
     _routingRules.sort((a, b) => b.priority.compareTo(a.priority));
 
     _logger.internal(
-        'Transport Router создан с ${_routingRules.length} правилами:');
+      'Transport Router создан с ${_routingRules.length} правилами:',
+    );
     for (int i = 0; i < _routingRules.length; i++) {
       final rule = _routingRules[i];
       _logger.internal('  ${i + 1}. [P${rule.priority}] ${rule.description}');
@@ -79,9 +77,13 @@ final class RpcTransportRouter implements IRpcTransport {
 
   /// Создает подписку на ответы для конкретного stream'а
   void _subscribeToResponsesForStream(
-      int clientStreamId, int serverStreamId, IRpcTransport transport) {
+    int clientStreamId,
+    int serverStreamId,
+    IRpcTransport transport,
+  ) {
     _logger.internal(
-        '🔔 Подписываемся на ответы: клиент[$clientStreamId] <- сервер[$serverStreamId] через $transport');
+      '🔔 Подписываемся на ответы: клиент[$clientStreamId] <- сервер[$serverStreamId] через $transport',
+    );
 
     // 🔥 ИСПРАВЛЕНИЕ: Слушаем ВХОДЯЩИЕ сообщения от транспорта, а не исходящие!
     // Когда роутер отправляет в transport, ответы придут через transport.incomingMessages
@@ -90,7 +92,8 @@ final class RpcTransportRouter implements IRpcTransport {
         .listen(
       (message) {
         _logger.internal(
-            '🔄 ПОЛУЧЕН ответ от transport: сервер[$serverStreamId] -> клиент[$clientStreamId], payload=${message.payload != null ? "есть" : "нет"}, isEndOfStream=${message.isEndOfStream}');
+          '🔄 ПОЛУЧЕН ответ от transport: сервер[$serverStreamId] -> клиент[$clientStreamId], payload=${message.payload != null ? "есть" : "нет"}, isEndOfStream=${message.isEndOfStream}',
+        );
 
         // 🔄 КЛЮЧЕВАЯ ЛОГИКА: Перенаправляем ответы с правильным stream ID
         final redirectedMessage = RpcTransportMessage(
@@ -104,21 +107,25 @@ final class RpcTransportRouter implements IRpcTransport {
         );
 
         _logger.internal(
-            '🔄 Перенаправляем ответ: сервер[$serverStreamId] -> клиент[$clientStreamId]');
+          '🔄 Перенаправляем ответ: сервер[$serverStreamId] -> клиент[$clientStreamId]',
+        );
         _incomingController.add(redirectedMessage);
 
         // ❌ НЕ ОЧИЩАЕМ здесь! Очистка будет в onDone
         // Для предотвращения двойной очистки (и при isEndOfStream, и при onDone)
       },
       onError: (error) {
-        _logger.error('❌ ОШИБКА в транспорте stream $serverStreamId',
-            error: error);
+        _logger.error(
+          '❌ ОШИБКА в транспорте stream $serverStreamId',
+          error: error,
+        );
         // При ошибке тоже нужна очистка
         _cleanupStream(clientStreamId, serverStreamId);
       },
       onDone: () {
-        _logger
-            .internal('Response stream completed for stream $serverStreamId');
+        _logger.internal(
+          'Response stream completed for stream $serverStreamId',
+        );
         _cleanupStream(clientStreamId, serverStreamId);
       },
     );
@@ -126,7 +133,8 @@ final class RpcTransportRouter implements IRpcTransport {
     _responseSubscriptions[clientStreamId] = subscription;
 
     _logger.internal(
-        'Subscription created: client[$clientStreamId] -> server[$serverStreamId]');
+      'Subscription created: client[$clientStreamId] -> server[$serverStreamId]',
+    );
   }
 
   /// Очищает ресурсы для завершенного stream'а
@@ -136,12 +144,14 @@ final class RpcTransportRouter implements IRpcTransport {
         !_clientToServerStreamMapping.containsKey(clientStreamId) &&
         !_responseSubscriptions.containsKey(clientStreamId)) {
       _logger.debug(
-          'Cleanup skipped: client stream [$clientStreamId] already cleaned');
+        'Cleanup skipped: client stream [$clientStreamId] already cleaned',
+      );
       return;
     }
 
     _logger.internal(
-        'Starting cleanup: client[$clientStreamId] -> server[$serverStreamId]');
+      'Starting cleanup: client[$clientStreamId] -> server[$serverStreamId]',
+    );
 
     _streamTransports.remove(clientStreamId);
     _clientToServerStreamMapping.remove(clientStreamId);
@@ -149,12 +159,14 @@ final class RpcTransportRouter implements IRpcTransport {
     final subscription = _responseSubscriptions.remove(clientStreamId);
     if (subscription != null) {
       _logger.internal(
-          'Cancelling response subscription for client[$clientStreamId]');
+        'Cancelling response subscription for client[$clientStreamId]',
+      );
       subscription.cancel();
     }
 
     _logger.internal(
-        'Cleanup completed for stream: client[$clientStreamId] -> server[$serverStreamId]');
+      'Cleanup completed for stream: client[$clientStreamId] -> server[$serverStreamId]',
+    );
   }
 
   /// Извлекает RpcContext из метаданных сообщения
@@ -175,26 +187,30 @@ final class RpcTransportRouter implements IRpcTransport {
     final serviceName = context?.getHeader('x-route-service');
     final methodPath = message.methodPath;
 
-    _logger
-        .internal('Роутинг для service="$serviceName", method="$methodPath"');
+    _logger.internal(
+      'Роутинг для service="$serviceName", method="$methodPath"',
+    );
     _logger.internal('Все заголовки контекста: ${context?.headers}');
 
     // Проверяем правила в порядке убывания приоритета
     for (final rule in _routingRules) {
-      _logger
-          .debug('Проверяем правило [P${rule.priority}]: ${rule.description}');
+      _logger.debug(
+        'Проверяем правило [P${rule.priority}]: ${rule.description}',
+      );
 
       if (rule.matches(serviceName, methodPath, context)) {
         _logger.internal(
-            '✓ Найдено совпадение [P${rule.priority}]: ${rule.description}');
+          '✓ Найдено совпадение [P${rule.priority}]: ${rule.description}',
+        );
         return rule.transport;
       }
     }
 
     // Если ни одно правило не сработало - явная ошибка
     throw RpcException(
-        'Не найден транспорт для роутинга: service="$serviceName", method="$methodPath". '
-        'Убедитесь, что добавлено соответствующее правило роутинга.');
+      'Не найден транспорт для роутинга: service="$serviceName", method="$methodPath". '
+      'Убедитесь, что добавлено соответствующее правило роутинга.',
+    );
   }
 
   @override
@@ -221,11 +237,13 @@ final class RpcTransportRouter implements IRpcTransport {
   }) async {
     if (_closed) throw StateError('TransportRouter is closed');
 
-    _logger
-        .internal('Sending metadata: streamId=$streamId, endStream=$endStream');
+    _logger.internal(
+      'Sending metadata: streamId=$streamId, endStream=$endStream',
+    );
     _logger.internal('Metadata method path: ${metadata.methodPath}');
     _logger.internal(
-        'Metadata headers: ${metadata.headers.map((h) => '${h.name}=${h.value}').join(', ')}');
+      'Metadata headers: ${metadata.headers.map((h) => '${h.name}=${h.value}').join(', ')}',
+    );
 
     // Создаем временное сообщение для роутинга
     final routingMessage = RpcTransportMessage(
@@ -246,14 +264,16 @@ final class RpcTransportRouter implements IRpcTransport {
     final serverStreamId = transport.createStream();
 
     _logger.internal(
-        'Created stream IDs: client[$streamId] -> server[$serverStreamId]');
+      'Created stream IDs: client[$streamId] -> server[$serverStreamId]',
+    );
 
     // Сохраняем все маппинги
     _streamTransports[streamId] = transport;
     _clientToServerStreamMapping[streamId] = serverStreamId;
 
     _logger.internal(
-        'Stream ID mapping: client[$streamId] -> server[$serverStreamId]');
+      'Stream ID mapping: client[$streamId] -> server[$serverStreamId]',
+    );
 
     // Подписываемся на ответы для этого конкретного stream'а
     _logger.internal('Creating response subscription...');
@@ -261,8 +281,11 @@ final class RpcTransportRouter implements IRpcTransport {
 
     // Перенаправляем вызов с НОВЫМ stream ID
     _logger.internal('Sending metadata to target transport...');
-    await transport.sendMetadata(serverStreamId, metadata,
-        endStream: endStream);
+    await transport.sendMetadata(
+      serverStreamId,
+      metadata,
+      endStream: endStream,
+    );
 
     _logger.internal('sendMetadata completed successfully');
   }
@@ -278,15 +301,18 @@ final class RpcTransportRouter implements IRpcTransport {
     // Используем сохраненный транспорт для данного stream
     final transport = _streamTransports[streamId];
     if (transport == null) {
-      throw StateError('Транспорт не найден для stream $streamId. '
-          'Возможно, метаданные не были отправлены сначала.');
+      throw StateError(
+        'Транспорт не найден для stream $streamId. '
+        'Возможно, метаданные не были отправлены сначала.',
+      );
     }
 
     // Получаем серверный stream ID
     final serverStreamId = _clientToServerStreamMapping[streamId];
     if (serverStreamId == null) {
       throw StateError(
-          'Серверный stream ID не найден для клиентского stream $streamId');
+        'Серверный stream ID не найден для клиентского stream $streamId',
+      );
     }
 
     await transport.sendMessage(serverStreamId, data, endStream: endStream);
@@ -306,20 +332,26 @@ final class RpcTransportRouter implements IRpcTransport {
     // Используем сохраненный транспорт для данного stream
     final transport = _streamTransports[streamId];
     if (transport == null) {
-      throw StateError('Транспорт не найден для stream $streamId. '
-          'Возможно, метаданные не были отправлены сначала.');
+      throw StateError(
+        'Транспорт не найден для stream $streamId. '
+        'Возможно, метаданные не были отправлены сначала.',
+      );
     }
 
     // Получаем серверный stream ID
     final serverStreamId = _clientToServerStreamMapping[streamId];
     if (serverStreamId == null) {
       throw StateError(
-          'Серверный stream ID не найден для клиентского stream $streamId');
+        'Серверный stream ID не найден для клиентского stream $streamId',
+      );
     }
 
     // Проксируем zero-copy вызов в целевой транспорт
-    await transport.sendDirectObject(serverStreamId, object,
-        endStream: endStream);
+    await transport.sendDirectObject(
+      serverStreamId,
+      object,
+      endStream: endStream,
+    );
   }
 
   @override
@@ -342,6 +374,140 @@ final class RpcTransportRouter implements IRpcTransport {
   @override
   Stream<RpcTransportMessage> getMessagesForStream(int streamId) {
     return incomingMessages.where((message) => message.streamId == streamId);
+  }
+
+  @override
+  Future<RpcHealthStatus> health() async {
+    if (_closed) {
+      return RpcHealthStatus.closed(
+        component: runtimeType.toString(),
+        message: 'Transport router is closed',
+        details: {
+          'closed': true,
+          'routingRules': _routingRules.length,
+          'activeStreams': _streamTransports.length,
+        },
+      );
+    }
+
+    final seenTransports = <IRpcTransport>{};
+    final dependencyStatuses = <Map<String, Object?>>[];
+    var aggregatedLevel = RpcHealthLevel.healthy;
+
+    for (final rule in _routingRules) {
+      final transport = rule.transport;
+      if (!seenTransports.add(transport)) continue;
+
+      RpcHealthStatus status;
+      try {
+        status = await transport.health();
+      } catch (error, stackTrace) {
+        await _logger.error(
+          'Failed to fetch health from transport ${transport.runtimeType}: $error',
+          error: error,
+          stackTrace: stackTrace,
+        );
+        status = RpcHealthStatus.unhealthy(
+          component: transport.runtimeType.toString(),
+          message: 'Health check failed: $error',
+          details: {'error': error.toString()},
+        );
+      }
+
+      if (status.level.severity > aggregatedLevel.severity) {
+        aggregatedLevel = status.level;
+      }
+
+      dependencyStatuses.add({
+        'component': status.component,
+        'level': status.level.name,
+        'message': status.message,
+        'details': status.details,
+      });
+    }
+
+    final message = aggregatedLevel == RpcHealthLevel.healthy
+        ? 'Transport router ready'
+        : 'Transport router degraded due to dependency state';
+
+    return RpcHealthStatus(
+      component: runtimeType.toString(),
+      level: aggregatedLevel,
+      message: message,
+      details: {
+        'closed': _closed,
+        'routingRules': _routingRules.length,
+        'activeStreams': _streamTransports.length,
+        'dependencies': dependencyStatuses,
+      },
+    );
+  }
+
+  @override
+  Future<RpcHealthStatus> reconnect() async {
+    if (_closed) {
+      return RpcHealthStatus.closed(
+        component: runtimeType.toString(),
+        message: 'Transport router is closed',
+        details: {
+          'closed': true,
+          'routingRules': _routingRules.length,
+          'activeStreams': _streamTransports.length,
+        },
+      );
+    }
+
+    final seenTransports = <IRpcTransport>{};
+    final dependencyStatuses = <Map<String, Object?>>[];
+    var aggregatedLevel = RpcHealthLevel.healthy;
+
+    for (final rule in _routingRules) {
+      final transport = rule.transport;
+      if (!seenTransports.add(transport)) continue;
+
+      RpcHealthStatus status;
+      try {
+        status = await transport.reconnect();
+      } catch (error, stackTrace) {
+        await _logger.error(
+          'Failed to reconnect transport ${transport.runtimeType}: $error',
+          error: error,
+          stackTrace: stackTrace,
+        );
+        status = RpcHealthStatus.unhealthy(
+          component: transport.runtimeType.toString(),
+          message: 'Reconnect failed: $error',
+          details: {'error': error.toString()},
+        );
+      }
+
+      if (status.level.severity > aggregatedLevel.severity) {
+        aggregatedLevel = status.level;
+      }
+
+      dependencyStatuses.add({
+        'component': status.component,
+        'level': status.level.name,
+        'message': status.message,
+        'details': status.details,
+      });
+    }
+
+    final message = aggregatedLevel == RpcHealthLevel.healthy
+        ? 'Transport router dependencies are ready'
+        : 'Transport router dependencies reported issues during reconnect';
+
+    return RpcHealthStatus(
+      component: runtimeType.toString(),
+      level: aggregatedLevel,
+      message: message,
+      details: {
+        'closed': _closed,
+        'routingRules': _routingRules.length,
+        'activeStreams': _streamTransports.length,
+        'dependencies': dependencyStatuses,
+      },
+    );
   }
 
   @override
@@ -371,7 +537,7 @@ final class RpcTransportRouter implements IRpcTransport {
   Map<String, dynamic> get statistics => {
         'totalRules': _routingRules.length,
         'rulesByPriority': {
-          for (final rule in _routingRules) rule.priority: rule.description
+          for (final rule in _routingRules) rule.priority: rule.description,
         },
         'activeStreams': _streamTransports.length,
         'closed': _closed,
@@ -440,9 +606,11 @@ final class RpcTransportRouterBuilder {
 
     // Router всегда требует клиентские транспорты
     if (!isTransportClient) {
-      throw ArgumentError('Неправильная роль транспорта! '
-          'Router требует клиентские транспорты (Stream ID: нечетные), '
-          'но передан серверный транспорт (Stream ID: $testStreamId).');
+      throw ArgumentError(
+        'Неправильная роль транспорта! '
+        'Router требует клиентские транспорты (Stream ID: нечетные), '
+        'но передан серверный транспорт (Stream ID: $testStreamId).',
+      );
     }
   }
 
@@ -508,13 +676,11 @@ final class RpcTransportRouterBuilder {
   RpcTransportRouter build() {
     if (_routingRules.isEmpty) {
       throw ArgumentError(
-          'Transport Router должен иметь как минимум одно правило роутинга. '
-          'Добавьте правила через routeCall или routeWhen.');
+        'Transport Router должен иметь как минимум одно правило роутинга. '
+        'Добавьте правила через routeCall или routeWhen.',
+      );
     }
 
-    return RpcTransportRouter._(
-      routingRules: _routingRules,
-      logger: _logger,
-    );
+    return RpcTransportRouter._(routingRules: _routingRules, logger: _logger);
   }
 }

--- a/packages/rpc_dart/lib/src/rpc/transports/transport_toolkit.dart
+++ b/packages/rpc_dart/lib/src/rpc/transports/transport_toolkit.dart
@@ -42,10 +42,8 @@ abstract class RpcBaseTransport implements IRpcTransport {
   ///
   /// [isClient] Флаг клиентского транспорта (влияет на Stream ID)
   /// [logger] Опциональный логгер для отладки
-  RpcBaseTransport({
-    required bool isClient,
-    RpcLogger? logger,
-  })  : _idManager = RpcStreamIdManager(isClient: isClient),
+  RpcBaseTransport({required bool isClient, RpcLogger? logger})
+      : _idManager = RpcStreamIdManager(isClient: isClient),
         _logger = logger;
 
   @override
@@ -91,6 +89,52 @@ abstract class RpcBaseTransport implements IRpcTransport {
     _log('Transport closed');
   }
 
+  @override
+  Future<RpcHealthStatus> health() async {
+    final details = {
+      'isClosed': _closed,
+      'activeStreams': _activeStreams.length,
+      'supportsZeroCopy': supportsZeroCopy,
+    };
+
+    return _closed
+        ? RpcHealthStatus.closed(
+            component: runtimeType.toString(),
+            message: 'Transport closed',
+            details: details,
+          )
+        : RpcHealthStatus.healthy(
+            component: runtimeType.toString(),
+            message: 'Transport active',
+            details: details,
+          );
+  }
+
+  @override
+  Future<RpcHealthStatus> reconnect() async {
+    if (_closed) {
+      return RpcHealthStatus.closed(
+        component: runtimeType.toString(),
+        message: 'Transport closed – create a new instance',
+        details: {
+          'isClosed': _closed,
+          'supportsZeroCopy': supportsZeroCopy,
+          'supported': false,
+        },
+      );
+    }
+
+    return RpcHealthStatus.degraded(
+      component: runtimeType.toString(),
+      message: 'Reconnect is not implemented for this transport',
+      details: {
+        'isClosed': _closed,
+        'supportsZeroCopy': supportsZeroCopy,
+        'supported': false,
+      },
+    );
+  }
+
   /// Отправляет сообщение через конкретный транспорт
   ///
   /// Должен быть реализован в подклассах для специфичной логики отправки
@@ -122,11 +166,17 @@ abstract class RpcBaseTransport implements IRpcTransport {
     }
 
     if (message.payload != null) {
-      await sendMessage(message.streamId, message.payload!,
-          endStream: message.isEndOfStream);
+      await sendMessage(
+        message.streamId,
+        message.payload!,
+        endStream: message.isEndOfStream,
+      );
     } else if (message.isDirect && supportsZeroCopy) {
-      await sendDirectObject(message.streamId, message.directPayload!,
-          endStream: message.isEndOfStream);
+      await sendDirectObject(
+        message.streamId,
+        message.directPayload!,
+        endStream: message.isEndOfStream,
+      );
     }
 
     if (message.isEndOfStream) {
@@ -212,8 +262,11 @@ class RpcTransportUtils {
   /// Создает WebSocket фрейм с Stream ID
   ///
   /// Формат: [streamId:4байта][flags:1байт][данные...]
-  static List<int> createWebSocketFrame(int streamId, List<int> data,
-      {int flags = 0}) {
+  static List<int> createWebSocketFrame(
+    int streamId,
+    List<int> data, {
+    int flags = 0,
+  }) {
     return <int>[
       (streamId >> 24) & 0xFF,
       (streamId >> 16) & 0xFF,
@@ -236,11 +289,7 @@ class RpcTransportUtils {
     final flags = buffer[4];
     final data = buffer.sublist(5);
 
-    return {
-      'streamId': streamId,
-      'flags': flags,
-      'data': data,
-    };
+    return {'streamId': streamId, 'flags': flags, 'data': data};
   }
 }
 

--- a/packages/rpc_dart/lib/src/utils/stream_distributor.dart
+++ b/packages/rpc_dart/lib/src/utils/stream_distributor.dart
@@ -47,10 +47,8 @@ class StreamDistributor<T extends IRpcSerializable> {
   /// Создает новый экземпляр [StreamDistributor]
   ///
   /// [config] позволяет настроить поведение дистрибьютора
-  StreamDistributor({
-    StreamDistributorConfig? config,
-    RpcLogger? logger,
-  })  : _mainController = StreamController<_StreamMessage<T>>.broadcast(),
+  StreamDistributor({StreamDistributorConfig? config, RpcLogger? logger})
+      : _mainController = StreamController<_StreamMessage<T>>.broadcast(),
         _clientStreams = <String, _ClientStreamWrapper<T>>{},
         _logger = logger,
         _config = config ?? StreamDistributorConfig() {
@@ -77,9 +75,7 @@ class StreamDistributor<T extends IRpcSerializable> {
   /// Возвращает количество клиентов, которым было доставлено сообщение.
   int publish(T event, {Map<String, dynamic>? metadata}) {
     if (_isDisposed || _mainController.isClosed) {
-      _logger?.warning(
-        'Попытка публикации в закрытый дистрибьютор',
-      );
+      _logger?.warning('Попытка публикации в закрытый дистрибьютор');
       return 0;
     }
 
@@ -124,8 +120,10 @@ class StreamDistributor<T extends IRpcSerializable> {
 
     // Фильтруем клиентов
     final targetClients = _clientStreams.values
-        .where((client) =>
-            !client.controller.isClosed && !client.isPaused && filter(client))
+        .where(
+          (client) =>
+              !client.controller.isClosed && !client.isPaused && filter(client),
+        )
         .toList();
 
     // Если нет подходящих клиентов, не публикуем
@@ -142,9 +140,7 @@ class StreamDistributor<T extends IRpcSerializable> {
       metadata: enrichedMetadata,
     );
 
-    _logger?.internal(
-      'Публикация фильтрованных данных: $wrappedEvent',
-    );
+    _logger?.internal('Публикация фильтрованных данных: $wrappedEvent');
     _mainController.add(wrappedEvent);
 
     // Обновляем метрики
@@ -184,8 +180,10 @@ class StreamDistributor<T extends IRpcSerializable> {
   /// Создание нового стрима для клиента с указанным ID
   ///
   /// Позволяет явно задать ID клиента для удобства отслеживания
-  Stream<T> createClientStreamWithId(String clientId,
-      {void Function()? onCancel}) {
+  Stream<T> createClientStreamWithId(
+    String clientId, {
+    void Function()? onCancel,
+  }) {
     _checkNotDisposed();
 
     // Проверяем, не существует ли уже стрим с таким ID
@@ -194,9 +192,7 @@ class StreamDistributor<T extends IRpcSerializable> {
         'Стрим с ID $clientId уже существует, создается дублирующий стрим',
       );
     } else {
-      _logger?.info(
-        'Создание нового стрима для клиента: $clientId',
-      );
+      _logger?.info('Создание нового стрима для клиента: $clientId');
     }
 
     // Создаем контроллер с поддержкой паузы/возобновления
@@ -216,8 +212,10 @@ class StreamDistributor<T extends IRpcSerializable> {
     );
 
     // Создаем подписку на основной стрим
-    final subscription =
-        _subscribeClientToMainStream(clientId, clientController);
+    final subscription = _subscribeClientToMainStream(
+      clientId,
+      clientController,
+    );
 
     // Сохраняем информацию о клиентском стриме
     _clientStreams[clientId] = _ClientStreamWrapper(
@@ -270,25 +268,19 @@ class StreamDistributor<T extends IRpcSerializable> {
     // Получаем информацию о клиенте
     final wrapper = _clientStreams[clientId];
     if (wrapper == null) {
-      _logger?.warning(
-        'Стрим-обертка для клиента $clientId не найдена',
-      );
+      _logger?.warning('Стрим-обертка для клиента $clientId не найдена');
       return;
     }
 
     // Пропускаем сообщения, если клиент на паузе
     if (wrapper.isPaused) {
-      _logger?.internal(
-        'Клиент $clientId на паузе, сообщение пропущено',
-      );
+      _logger?.internal('Клиент $clientId на паузе, сообщение пропущено');
       return;
     }
 
     // Проверяем, относится ли сообщение к этому клиенту
     if (!_isMessageForClient(clientId, wrappedEvent)) {
-      _logger?.internal(
-        'Сообщение не предназначено для клиента $clientId',
-      );
+      _logger?.internal('Сообщение не предназначено для клиента $clientId');
       return;
     }
 
@@ -376,9 +368,7 @@ class StreamDistributor<T extends IRpcSerializable> {
     if (wrapper == null || wrapper.controller.isClosed) return false;
 
     wrapper.isPaused = true;
-    _logger?.internal(
-      'Клиентский стрим $clientId поставлен на паузу',
-    );
+    _logger?.internal('Клиентский стрим $clientId поставлен на паузу');
     return true;
   }
 
@@ -389,9 +379,7 @@ class StreamDistributor<T extends IRpcSerializable> {
 
     wrapper.isPaused = false;
     wrapper.updateLastActivity();
-    _logger?.internal(
-      'Клиентский стрим $clientId возобновлен',
-    );
+    _logger?.internal('Клиентский стрим $clientId возобновлен');
     return true;
   }
 
@@ -400,8 +388,11 @@ class StreamDistributor<T extends IRpcSerializable> {
   /// Сообщение автоматически оборачивается в [_StreamMessage] с ID клиента.
   ///
   /// Возвращает true, если сообщение было доставлено клиенту
-  bool publishToClient(String clientId, T event,
-      {Map<String, dynamic>? metadata}) {
+  bool publishToClient(
+    String clientId,
+    T event, {
+    Map<String, dynamic>? metadata,
+  }) {
     if (_isDisposed) return false;
 
     final wrapper = _clientStreams[clientId];
@@ -409,9 +400,7 @@ class StreamDistributor<T extends IRpcSerializable> {
 
     // Пропускаем сообщения, если клиент на паузе
     if (wrapper.isPaused) {
-      _logger?.internal(
-        'Клиент $clientId на паузе, публикация пропущена',
-      );
+      _logger?.internal('Клиент $clientId на паузе, публикация пропущена');
       return false;
     }
 
@@ -437,8 +426,10 @@ class StreamDistributor<T extends IRpcSerializable> {
         return true;
       }
     } catch (e) {
-      _logger?.error('Ошибка при публикации данных клиенту $clientId',
-          error: e);
+      _logger?.error(
+        'Ошибка при публикации данных клиенту $clientId',
+        error: e,
+      );
       _metrics.incrementErrors();
     }
 
@@ -484,8 +475,9 @@ class StreamDistributor<T extends IRpcSerializable> {
   /// Получение информации о всех клиентских стримах
   Map<String, Map<String, dynamic>> getAllClientsInfo() {
     return Map.fromEntries(
-      _clientStreams.entries
-          .map((entry) => MapEntry(entry.key, getClientInfo(entry.key)!)),
+      _clientStreams.entries.map(
+        (entry) => MapEntry(entry.key, getClientInfo(entry.key)!),
+      ),
     );
   }
 
@@ -516,9 +508,7 @@ class StreamDistributor<T extends IRpcSerializable> {
     if (wrapper != null) {
       await wrapper.dispose();
       _metrics.decrementCurrentStreams();
-      _logger?.internal(
-        'Клиентский стрим $clientId закрыт',
-      );
+      _logger?.internal('Клиентский стрим $clientId закрыт');
       return true;
     }
 
@@ -535,9 +525,7 @@ class StreamDistributor<T extends IRpcSerializable> {
       await closeClientStream(clientId);
     }
 
-    _logger?.internal(
-      'Закрыты все клиентские стримы ($clientCount)',
-    );
+    _logger?.internal('Закрыты все клиентские стримы ($clientCount)');
   }
 
   /// Закрытие неактивных соединений
@@ -553,9 +541,7 @@ class StreamDistributor<T extends IRpcSerializable> {
     }
 
     if (inactiveIds.isNotEmpty) {
-      _logger?.internal(
-        'Закрыто ${inactiveIds.length} неактивных стримов',
-      );
+      _logger?.internal('Закрыто ${inactiveIds.length} неактивных стримов');
     }
 
     return inactiveIds.length;
@@ -570,18 +556,15 @@ class StreamDistributor<T extends IRpcSerializable> {
 
     _cleanupTimer = Timer.periodic(_config.cleanupInterval, (_) async {
       if (_isDisposed) {
-        _logger?.internal(
-          'Дистрибьютор закрыт, очистка отменена',
-        );
+        _logger?.internal('Дистрибьютор закрыт, очистка отменена');
         return;
       }
 
       try {
-        _logger?.internal(
-          'Запуск периодической очистки неактивных стримов',
+        _logger?.internal('Запуск периодической очистки неактивных стримов');
+        final removedCount = await closeInactiveStreams(
+          _config.inactivityThreshold,
         );
-        final removedCount =
-            await closeInactiveStreams(_config.inactivityThreshold);
         if (removedCount > 0) {
           _logger?.info(
             'Автоматическая очистка удалила $removedCount неактивных стримов (осталось: ${_clientStreams.length})',
@@ -604,18 +587,14 @@ class StreamDistributor<T extends IRpcSerializable> {
   /// Проверяет, что дистрибьютор не закрыт
   void _checkNotDisposed() {
     if (_isDisposed) {
-      throw StateError(
-        'StreamDistributor уже закрыт',
-      );
+      throw StateError('StreamDistributor уже закрыт');
     }
   }
 
   /// Освобождение всех ресурсов менеджера
   Future<void> dispose() async {
     if (_isDisposed) {
-      _logger?.internal(
-        'Повторный вызов dispose() игнорируется',
-      );
+      _logger?.internal('Повторный вызов dispose() игнорируется');
       return;
     }
 
@@ -631,21 +610,20 @@ class StreamDistributor<T extends IRpcSerializable> {
     // Закрываем все клиентские контроллеры
     final clientCount = _clientStreams.length;
     await closeAllClientStreams();
-    _logger?.internal(
-      'Закрыты все клиентские стримы ($clientCount)',
-    );
+    _logger?.internal('Закрыты все клиентские стримы ($clientCount)');
 
     // Закрываем основной контроллер
     try {
       if (!_mainController.isClosed) {
         await _mainController.close();
-        _logger?.internal(
-          'Основной контроллер закрыт',
-        );
+        _logger?.internal('Основной контроллер закрыт');
       }
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при закрытии основного контроллера',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при закрытии основного контроллера',
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
 
     _logger?.info(

--- a/packages/rpc_dart/pubspec.yaml
+++ b/packages/rpc_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rpc_dart
 description: Transport-agnostic RPC framework with contracts, streaming and included transports.
-version: 2.2.2
+version: 2.3.0
 repository: https://github.com/nogipx/rpc_dart.git
 homepage: https://rpc.nogipx.dev
 issue_tracker: https://github.com/nogipx/rpc_dart/issues

--- a/packages/rpc_dart/test/core/rpc_context_integration_test.dart
+++ b/packages/rpc_dart/test/core/rpc_context_integration_test.dart
@@ -87,8 +87,9 @@ void main() {
         serverEndpoint.start();
 
         final authContext = RpcContextUtils.withBearerToken('auth-token');
-        final tracingContext =
-            RpcContextUtils.withTracing(traceId: 'combined-trace');
+        final tracingContext = RpcContextUtils.withTracing(
+          traceId: 'combined-trace',
+        );
         final userContext = RpcContext.withHeaders({'user-id': 'user-456'});
 
         final combinedContext = RpcContextUtils.merge(
@@ -143,8 +144,10 @@ void main() {
 
         // Assert
         expect(responses.length, equals(3));
-        expect(responses.every((r) => r.value.contains('stream-user-123')),
-            isTrue);
+        expect(
+          responses.every((r) => r.value.contains('stream-user-123')),
+          isTrue,
+        );
         expect(responses.every((r) => r.value.contains('test')), isTrue);
       });
 
@@ -310,10 +313,14 @@ void main() {
         // Assert
         expect(receivedResponses.length, greaterThanOrEqualTo(1));
         expect(
-            receivedResponses[0].value, equals('TEST: ECHO-SESSION-789: MSG1'));
+          receivedResponses[0].value,
+          equals('TEST: ECHO-SESSION-789: MSG1'),
+        );
         if (receivedResponses.length > 1) {
-          expect(receivedResponses[1].value,
-              equals('TEST: ECHO-SESSION-789: MSG2'));
+          expect(
+            receivedResponses[1].value,
+            equals('TEST: ECHO-SESSION-789: MSG2'),
+          );
         }
       });
 
@@ -378,8 +385,10 @@ void main() {
         final context = RpcContextUtils.withBearerToken('contract-token');
 
         // Act
-        final response =
-            await callerContract.getUserData('contract-user'.rpc, context);
+        final response = await callerContract.getUserData(
+          'contract-user'.rpc,
+          context,
+        );
 
         // Assert
         expect(response.value, contains('Bearer contract-token'));
@@ -400,13 +409,17 @@ void main() {
         });
 
         // Act
-        final responses =
-            await callerContract.generateStream('contract-stream'.rpc, context);
+        final responses = await callerContract.generateStream(
+          'contract-stream'.rpc,
+          context,
+        );
 
         // Assert
         expect(responses.length, equals(2));
-        expect(responses.every((r) => r.value.contains('contract-stream-user')),
-            isTrue);
+        expect(
+          responses.every((r) => r.value.contains('contract-stream-user')),
+          isTrue,
+        );
         expect(responses.every((r) => r.value.contains('contract')), isTrue);
       });
     });
@@ -454,8 +467,10 @@ final class _TestServiceContract extends RpcResponderContract {
     );
   }
 
-  Future<RpcString> _getUserData(RpcString userId,
-      {RpcContext? context}) async {
+  Future<RpcString> _getUserData(
+    RpcString userId, {
+    RpcContext? context,
+  }) async {
     final authHeader = context?.getHeader('authorization');
     return 'User data for ${userId.value} (auth: $authHeader)'.rpc;
   }
@@ -475,8 +490,10 @@ final class _TracingServiceContract extends RpcResponderContract {
     );
   }
 
-  Future<RpcString> _tracedOperation(RpcString request,
-      {RpcContext? context}) async {
+  Future<RpcString> _tracedOperation(
+    RpcString request, {
+    RpcContext? context,
+  }) async {
     final traceId = context?.traceId;
     final spanId = context?.getHeader('x-span-id');
     final parentSpanId = context?.getHeader('x-parent-span-id');
@@ -500,8 +517,10 @@ final class _CombinedContextServiceContract extends RpcResponderContract {
     );
   }
 
-  Future<RpcString> _processWithFullContext(RpcString request,
-      {RpcContext? context}) async {
+  Future<RpcString> _processWithFullContext(
+    RpcString request, {
+    RpcContext? context,
+  }) async {
     final auth = context?.getHeader('authorization');
     final traceId = context?.traceId;
     final userId = context?.getHeader('user-id');
@@ -525,8 +544,10 @@ final class _StreamServiceContract extends RpcResponderContract {
     );
   }
 
-  Stream<RpcString> _generateStream(RpcString request,
-      {RpcContext? context}) async* {
+  Stream<RpcString> _generateStream(
+    RpcString request, {
+    RpcContext? context,
+  }) async* {
     final mode = context?.getHeader('streaming-mode');
     final userId = context?.getHeader('user-id');
     final countHeader = context?.getHeader('stream-count');
@@ -552,8 +573,10 @@ final class _AggregationServiceContract extends RpcResponderContract {
     );
   }
 
-  Future<RpcString> _aggregateData(Stream<RpcString> requests,
-      {RpcContext? context}) async {
+  Future<RpcString> _aggregateData(
+    Stream<RpcString> requests, {
+    RpcContext? context,
+  }) async {
     final aggregationType = context?.getHeader('aggregation-type');
     final userId = context?.getHeader('user-id');
     final auth = context?.getHeader('authorization');
@@ -579,8 +602,10 @@ final class _EchoServiceContract extends RpcResponderContract {
     );
   }
 
-  Stream<RpcString> _echoStream(Stream<RpcString> requests,
-      {RpcContext? context}) async* {
+  Stream<RpcString> _echoStream(
+    Stream<RpcString> requests, {
+    RpcContext? context,
+  }) async* {
     final prefix = context?.getHeader('echo-prefix');
     final sessionId = context?.getHeader('session-id');
     final uppercaseHeader = context?.getHeader('echo-uppercase');
@@ -607,8 +632,10 @@ final class _ErrorServiceContract extends RpcResponderContract {
     );
   }
 
-  Future<RpcString> _throwError(RpcString request,
-      {RpcContext? context}) async {
+  Future<RpcString> _throwError(
+    RpcString request, {
+    RpcContext? context,
+  }) async {
     final traceId = context?.traceId;
     throw Exception('Service error for ${request.value} [trace=$traceId]');
   }
@@ -636,7 +663,9 @@ final class _StreamServiceCallerContract extends RpcCallerContract {
       : super('StreamService', endpoint);
 
   Future<List<RpcString>> generateStream(
-      RpcString request, RpcContext? context) async {
+    RpcString request,
+    RpcContext? context,
+  ) async {
     final responses = <RpcString>[];
     await for (final response in callServerStream<RpcString, RpcString>(
       methodName: 'GenerateStream',

--- a/packages/rpc_dart/test/core/rpc_context_propagation_test.dart
+++ b/packages/rpc_dart/test/core/rpc_context_propagation_test.dart
@@ -63,8 +63,9 @@ void main() {
       final originalHeaders = {'x-user-id': '123'};
       final additionalHeaders = {'x-session': 'abc', 'x-trace': '456'};
 
-      final context = RpcContext.withHeaders(originalHeaders)
-          .withAdditionalHeaders(additionalHeaders);
+      final context = RpcContext.withHeaders(
+        originalHeaders,
+      ).withAdditionalHeaders(additionalHeaders);
 
       expect(context.headers['x-user-id'], equals('123'));
       expect(context.headers['x-session'], equals('abc'));
@@ -158,8 +159,10 @@ void main() {
     test('создает контекст с пользовательским заголовком API ключа', () {
       final apiKey = 'secret-key-123';
       final headerName = 'x-custom-key';
-      final context =
-          RpcContextUtils.withApiKey(apiKey, headerName: headerName);
+      final context = RpcContextUtils.withApiKey(
+        apiKey,
+        headerName: headerName,
+      );
 
       expect(context.getHeader(headerName), equals(apiKey));
       expect(context.getHeader('x-api-key'), isNull);
@@ -192,13 +195,13 @@ void main() {
     });
 
     test('объединяет контексты с приоритетом правого', () {
-      final leftContext = RpcContext.withHeaders({'x-left': 'left-value'})
-          .withTraceId('left-trace')
-          .withValue('shared-key', 'left-shared');
+      final leftContext = RpcContext.withHeaders({
+        'x-left': 'left-value',
+      }).withTraceId('left-trace').withValue('shared-key', 'left-shared');
 
-      final rightContext = RpcContext.withHeaders({'x-right': 'right-value'})
-          .withTraceId('right-trace')
-          .withValue('shared-key', 'right-shared');
+      final rightContext = RpcContext.withHeaders({
+        'x-right': 'right-value',
+      }).withTraceId('right-trace').withValue('shared-key', 'right-shared');
 
       final merged = RpcContextUtils.merge(leftContext, rightContext);
 
@@ -236,12 +239,13 @@ void main() {
     test('наследует от родительского контекста', () {
       final parentTraceId = 'parent-trace-123';
       final parentHeaders = {'x-session': 'parent-session'};
-      final parent =
-          RpcContext.withHeaders(parentHeaders).withTraceId(parentTraceId);
+      final parent = RpcContext.withHeaders(
+        parentHeaders,
+      ).withTraceId(parentTraceId);
 
-      final child = RpcContextBuilder.inheritFrom(parent)
-          .withHeader('x-user-id', '456')
-          .build();
+      final child = RpcContextBuilder.inheritFrom(
+        parent,
+      ).withHeader('x-user-id', '456').build();
 
       // Наследует trace ID
       expect(child.traceId, equals(parentTraceId));
@@ -337,8 +341,9 @@ void main() {
 
     test('создает контекст для междоменного вызова', () {
       final parentTraceId = 'parent-trace-123';
-      final parent = RpcContext.withTraceId(parentTraceId)
-          .withAdditionalHeaders({'x-user-id': '456'});
+      final parent = RpcContext.withTraceId(
+        parentTraceId,
+      ).withAdditionalHeaders({'x-user-id': '456'});
 
       final context = RpcContext.forDomainCall(
         parentContext: parent,
@@ -381,7 +386,8 @@ void main() {
     test('проверяет валидность контекста', () {
       final validContext = RpcContext.empty();
       final expiredContext = RpcContext.withDeadline(
-          DateTime.now().subtract(Duration(minutes: 1)));
+        DateTime.now().subtract(Duration(minutes: 1)),
+      );
       final cancelledToken = RpcCancellationToken.cancelled();
       final cancelledContext = RpcContext.withCancellation(cancelledToken);
 
@@ -414,10 +420,14 @@ void main() {
 
       // Проверяем, что каждый контекст имеет правильную метку шага
       expect(
-          chain['OrderDomain']!.getValue('cord.step'), equals('OrderDomain'));
+        chain['OrderDomain']!.getValue('cord.step'),
+        equals('OrderDomain'),
+      );
       expect(chain['UserDomain']!.getValue('cord.step'), equals('UserDomain'));
-      expect(chain['PaymentDomain']!.getValue('cord.step'),
-          equals('PaymentDomain'));
+      expect(
+        chain['PaymentDomain']!.getValue('cord.step'),
+        equals('PaymentDomain'),
+      );
     });
 
     test('санитизирует контекст', () {
@@ -503,8 +513,9 @@ void main() {
 
   group('RpcContextAware', () {
     test('миксин создает контекст для вызова', () {
-      final parentContext = RpcContext.withTraceId('parent-trace-123')
-          .withAdditionalHeaders({'x-user-id': '456'});
+      final parentContext = RpcContext.withTraceId(
+        'parent-trace-123',
+      ).withAdditionalHeaders({'x-user-id': '456'});
       final domain = TestDomain('TestDomain', parentContext);
 
       final callContext = domain.createCallContext(
@@ -516,8 +527,10 @@ void main() {
       expect(callContext.requestId, startsWith('req_'));
       expect(callContext.getHeader('x-user-id'), equals('456'));
       expect(callContext.getHeader('x-to-domain'), equals('PaymentService'));
-      expect(callContext.getHeader('x-domain-operation'),
-          equals('ProcessPayment'));
+      expect(
+        callContext.getHeader('x-domain-operation'),
+        equals('ProcessPayment'),
+      );
       expect(callContext.getHeader('x-from-domain'), equals('TestDomain'));
     });
   });
@@ -561,8 +574,9 @@ void main() {
       expect(userToPaymentContext.getHeader('x-user-id'), equals('123'));
 
       // Проверяем метаданные последнего вызова
-      final paymentMetadata =
-          RpcContext.extractDomainMetadata(userToPaymentContext);
+      final paymentMetadata = RpcContext.extractDomainMetadata(
+        userToPaymentContext,
+      );
       expect(paymentMetadata.userId, equals('123'));
       expect(paymentMetadata.toDomain, equals('PaymentDomain'));
       expect(paymentMetadata.operation, equals('ValidateCard'));
@@ -592,8 +606,10 @@ void main() {
       cancellationToken.cancel('User cancelled');
 
       expect(childContext.isCancelled, isTrue);
-      expect(() => childContext.cancellationToken!.throwIfCancelled(),
-          throwsA(isA<RpcCancelledException>()));
+      expect(
+        () => childContext.cancellationToken!.throwIfCancelled(),
+        throwsA(isA<RpcCancelledException>()),
+      );
     });
   });
 }

--- a/packages/rpc_dart/test/core/rpc_context_test.dart
+++ b/packages/rpc_dart/test/core/rpc_context_test.dart
@@ -66,11 +66,13 @@ void main() {
         final afterCreation = DateTime.now().add(timeout);
         expect(sut.deadline, isNotNull);
         expect(
-            sut.deadline!
-                .isAfter(beforeCreation.subtract(Duration(seconds: 1))),
-            isTrue);
-        expect(sut.deadline!.isBefore(afterCreation.add(Duration(seconds: 1))),
-            isTrue);
+          sut.deadline!.isAfter(beforeCreation.subtract(Duration(seconds: 1))),
+          isTrue,
+        );
+        expect(
+          sut.deadline!.isBefore(afterCreation.add(Duration(seconds: 1))),
+          isTrue,
+        );
       });
 
       test('создает_контекст_с_токеном_отмены', () {
@@ -101,8 +103,9 @@ void main() {
       late RpcContext baseSut;
 
       setUp(() {
-        baseSut = RpcContext.withHeaders({'existing': 'header'})
-            .withTraceId('base-trace');
+        baseSut = RpcContext.withHeaders({
+          'existing': 'header',
+        }).withTraceId('base-trace');
       });
 
       test('добавляет_дополнительные_заголовки_сохраняя_существующие', () {
@@ -146,8 +149,10 @@ void main() {
 
         // Assert
         expect(sut.deadline, equals(newDeadline));
-        expect(sut.getHeader('existing'),
-            equals('header')); // Остальные поля сохранены
+        expect(
+          sut.getHeader('existing'),
+          equals('header'),
+        ); // Остальные поля сохранены
         expect(sut.traceId, equals('base-trace'));
       });
 
@@ -163,11 +168,13 @@ void main() {
         final afterCreation = DateTime.now().add(timeout);
         expect(sut.deadline, isNotNull);
         expect(
-            sut.deadline!
-                .isAfter(beforeCreation.subtract(Duration(seconds: 1))),
-            isTrue);
-        expect(sut.deadline!.isBefore(afterCreation.add(Duration(seconds: 1))),
-            isTrue);
+          sut.deadline!.isAfter(beforeCreation.subtract(Duration(seconds: 1))),
+          isTrue,
+        );
+        expect(
+          sut.deadline!.isBefore(afterCreation.add(Duration(seconds: 1))),
+          isTrue,
+        );
       });
 
       test('устанавливает_токен_отмены', () {
@@ -179,8 +186,10 @@ void main() {
 
         // Assert
         expect(sut.cancellationToken, equals(cancellationToken));
-        expect(sut.getHeader('existing'),
-            equals('header')); // Остальные поля сохранены
+        expect(
+          sut.getHeader('existing'),
+          equals('header'),
+        ); // Остальные поля сохранены
       });
 
       test('устанавливает_новый_trace_id', () {
@@ -192,8 +201,10 @@ void main() {
 
         // Assert
         expect(sut.traceId, equals(newTraceId));
-        expect(sut.getHeader('existing'),
-            equals('header')); // Остальные поля сохранены
+        expect(
+          sut.getHeader('existing'),
+          equals('header'),
+        ); // Остальные поля сохранены
       });
 
       test('добавляет_значение_в_контекст', () {
@@ -207,8 +218,10 @@ void main() {
         // Assert
         expect(sut.getValue<String>(key), equals(value));
         expect(sut.getValue<int>('non-existent'), isNull);
-        expect(sut.getHeader('existing'),
-            equals('header')); // Остальные поля сохранены
+        expect(
+          sut.getHeader('existing'),
+          equals('header'),
+        ); // Остальные поля сохранены
       });
     });
 
@@ -294,7 +307,9 @@ void main() {
 
         // Проверяем что неправильный тип выбрасывает исключение при касте
         expect(
-            () => sut.getValue<String>('int-key'), throwsA(isA<TypeError>()));
+          () => sut.getValue<String>('int-key'),
+          throwsA(isA<TypeError>()),
+        );
       });
     });
 
@@ -465,7 +480,9 @@ void main() {
         // Assert
         expect(sut.isCancelled, isTrue);
         expect(
-            sut.reason, equals('Первая причина')); // Сохраняется первая причина
+          sut.reason,
+          equals('Первая причина'),
+        ); // Сохраняется первая причина
       });
 
       test('уведомляет_о_отмене_через_future', () async {
@@ -503,8 +520,13 @@ void main() {
         // Act & Assert
         expect(
           () => sut.throwIfCancelled(),
-          throwsA(isA<RpcCancelledException>()
-              .having((e) => e.message, 'message', contains(reason))),
+          throwsA(
+            isA<RpcCancelledException>().having(
+              (e) => e.message,
+              'message',
+              contains(reason),
+            ),
+          ),
         );
       });
 
@@ -516,8 +538,13 @@ void main() {
         // Act & Assert
         expect(
           () => sut.throwIfCancelled(),
-          throwsA(isA<RpcCancelledException>()
-              .having((e) => e.message, 'message', 'Operation was cancelled')),
+          throwsA(
+            isA<RpcCancelledException>().having(
+              (e) => e.message,
+              'message',
+              'Operation was cancelled',
+            ),
+          ),
         );
       });
     });
@@ -529,15 +556,18 @@ void main() {
         // Arrange
         const username = 'testuser';
         const password = 'testpass';
-        final expectedCredentials =
-            base64Encode(utf8.encode('$username:$password'));
+        final expectedCredentials = base64Encode(
+          utf8.encode('$username:$password'),
+        );
 
         // Act
         final sut = RpcContextUtils.withBasicAuth(username, password);
 
         // Assert
-        expect(sut.getHeader('authorization'),
-            equals('Basic $expectedCredentials'));
+        expect(
+          sut.getHeader('authorization'),
+          equals('Basic $expectedCredentials'),
+        );
       });
 
       test('создает_контекст_с_bearer_token', () {
@@ -627,10 +657,14 @@ void main() {
     group('объединение_контекстов', () {
       test('объединяет_заголовки_из_двух_контекстов', () {
         // Arrange
-        final leftSut = RpcContext.withHeaders(
-            {'left-header': 'left-value', 'common': 'left'});
-        final rightSut = RpcContext.withHeaders(
-            {'right-header': 'right-value', 'common': 'right'});
+        final leftSut = RpcContext.withHeaders({
+          'left-header': 'left-value',
+          'common': 'left',
+        });
+        final rightSut = RpcContext.withHeaders({
+          'right-header': 'right-value',
+          'common': 'right',
+        });
 
         // Act
         final merged = RpcContextUtils.merge(leftSut, rightSut);
@@ -638,8 +672,10 @@ void main() {
         // Assert
         expect(merged.getHeader('left-header'), equals('left-value'));
         expect(merged.getHeader('right-header'), equals('right-value'));
-        expect(merged.getHeader('common'),
-            equals('right')); // Правый имеет приоритет
+        expect(
+          merged.getHeader('common'),
+          equals('right'),
+        ); // Правый имеет приоритет
       });
 
       test('объединяет_значения_из_двух_контекстов', () {
@@ -657,8 +693,10 @@ void main() {
         // Assert
         expect(merged.getValue<String>('left-key'), equals('left-value'));
         expect(merged.getValue<String>('right-key'), equals('right-value'));
-        expect(merged.getValue<String>('common-key'),
-            equals('right')); // Правый имеет приоритет
+        expect(
+          merged.getValue<String>('common-key'),
+          equals('right'),
+        ); // Правый имеет приоритет
       });
 
       test('использует_правые_значения_для_специальных_полей', () {
@@ -668,12 +706,12 @@ void main() {
         final leftToken = RpcCancellationToken();
         final rightToken = RpcCancellationToken();
 
-        final leftSut = RpcContext.withDeadline(leftDeadline)
-            .withCancellation(leftToken)
-            .withTraceId('left-trace');
-        final rightSut = RpcContext.withDeadline(rightDeadline)
-            .withCancellation(rightToken)
-            .withTraceId('right-trace');
+        final leftSut = RpcContext.withDeadline(
+          leftDeadline,
+        ).withCancellation(leftToken).withTraceId('left-trace');
+        final rightSut = RpcContext.withDeadline(
+          rightDeadline,
+        ).withCancellation(rightToken).withTraceId('right-trace');
 
         // Act
         final merged = RpcContextUtils.merge(leftSut, rightSut);
@@ -691,9 +729,9 @@ void main() {
         final token = RpcCancellationToken();
         const traceId = 'left-trace';
 
-        final leftSut = RpcContext.withDeadline(deadline)
-            .withCancellation(token)
-            .withTraceId(traceId);
+        final leftSut = RpcContext.withDeadline(
+          deadline,
+        ).withCancellation(token).withTraceId(traceId);
         final rightSut = RpcContext.empty();
 
         // Act

--- a/packages/rpc_dart/test/core/rpc_context_validation_test.dart
+++ b/packages/rpc_dart/test/core/rpc_context_validation_test.dart
@@ -62,7 +62,9 @@ void main() {
         expect(response, contains('authorization:Bearer token-456'));
         expect(response, contains('custom-header:custom-value'));
         expect(
-            response, contains('special-chars:value with spaces & symbols!'));
+          response,
+          contains('special-chars:value with spaces & symbols!'),
+        );
         expect(response, contains('numbers:12345'));
         expect(response, contains('unicode:тест с unicode 🚀'));
       });
@@ -84,8 +86,10 @@ void main() {
         // Assert
         final response = result.value;
         expect(response, contains('trace-id:test-trace-123'));
-        expect(response,
-            contains('request-id:req_')); // Проверяем формат request ID
+        expect(
+          response,
+          contains('request-id:req_'),
+        ); // Проверяем формат request ID
       });
     });
 
@@ -198,8 +202,10 @@ void main() {
         // Assert
         expect(responses.length, equals(3));
         expect(responses.every((r) => r.value.contains('test-prefix')), isTrue);
-        expect(responses.every((r) => r.value.contains('server-stream-trace')),
-            isTrue);
+        expect(
+          responses.every((r) => r.value.contains('server-stream-trace')),
+          isTrue,
+        );
       });
     });
 
@@ -233,7 +239,9 @@ void main() {
 
         // Assert
         expect(
-            response.value, contains('count:6')); // 3 items * multiplier 2 = 6
+          response.value,
+          contains('count:6'),
+        ); // 3 items * multiplier 2 = 6
         expect(response.value, contains('multiplier:2'));
         expect(response.value, contains('client-stream-trace'));
       });
@@ -267,10 +275,12 @@ void main() {
 
         requestController.add('hello'.rpc);
         await Future.delayed(
-            Duration(milliseconds: 1)); // Даем время для обработки
+          Duration(milliseconds: 1),
+        ); // Даем время для обработки
         requestController.add('world'.rpc);
         await Future.delayed(
-            Duration(milliseconds: 1)); // Даем время для обработки
+          Duration(milliseconds: 1),
+        ); // Даем время для обработки
         await requestController.close();
 
         // Ждем больше времени для получения ответов
@@ -281,8 +291,10 @@ void main() {
         expect(responses.length, equals(2));
         expect(responses[0].value, contains('ECHO:HELLO'));
         expect(responses[1].value, contains('ECHO:WORLD'));
-        expect(responses.every((r) => r.value.contains('bidirectional-trace')),
-            isTrue);
+        expect(
+          responses.every((r) => r.value.contains('bidirectional-trace')),
+          isTrue,
+        );
       });
     });
 
@@ -308,9 +320,9 @@ void main() {
         expect(response, contains('visible-header:should-appear'));
         expect(response, isNot(contains('should-not-appear')));
         expect(
-            response,
-            contains(
-                'context-values-count:0')); // Сервер не должен видеть context values
+          response,
+          contains('context-values-count:0'),
+        ); // Сервер не должен видеть context values
       });
     });
 
@@ -347,16 +359,16 @@ void main() {
 
         // Assert
         expect(result.value, isNotEmpty); // Должен содержать хотя бы requestId
-        expect(result.value,
-            contains('request-id:req_')); // Базовый requestId должен быть
+        expect(
+          result.value,
+          contains('request-id:req_'),
+        ); // Базовый requestId должен быть
       });
 
       test('очень_длинные_заголовки_работают', () async {
         // Arrange
         final longValue = 'x' * 1000; // 1KB заголовок
-        final context = RpcContext.withHeaders({
-          'long-header': longValue,
-        });
+        final context = RpcContext.withHeaders({'long-header': longValue});
 
         // Act
         final result = await clientEndpoint.unaryRequest<RpcString, RpcString>(
@@ -454,33 +466,43 @@ final class ValidationServiceContract extends RpcResponderContract {
     );
   }
 
-  Future<RpcString> _validateHeaders(RpcString request,
-      {RpcContext? context}) async {
+  Future<RpcString> _validateHeaders(
+    RpcString request, {
+    RpcContext? context,
+  }) async {
     final headers = context?.headers ?? <String, String>{};
     final result = headers.entries.map((e) => '${e.key}:${e.value}').join('|');
     return result.rpc;
   }
 
-  Future<RpcString> _validateSystemHeaders(RpcString request,
-      {RpcContext? context}) async {
+  Future<RpcString> _validateSystemHeaders(
+    RpcString request, {
+    RpcContext? context,
+  }) async {
     final traceId = context?.traceId ?? '';
     final requestId = context?.requestId;
     return 'trace-id:$traceId|request-id:$requestId'.rpc;
   }
 
-  Future<RpcString> _slowOperation(RpcString request,
-      {RpcContext? context}) async {
+  Future<RpcString> _slowOperation(
+    RpcString request, {
+    RpcContext? context,
+  }) async {
     await Future.delayed(Duration(seconds: 5)); // Превышает timeout в тесте
     return 'slow-result'.rpc;
   }
 
-  Future<RpcString> _fastOperation(RpcString request,
-      {RpcContext? context}) async {
+  Future<RpcString> _fastOperation(
+    RpcString request, {
+    RpcContext? context,
+  }) async {
     return 'fast-result'.rpc;
   }
 
-  Future<RpcString> _longOperation(RpcString request,
-      {RpcContext? context}) async {
+  Future<RpcString> _longOperation(
+    RpcString request, {
+    RpcContext? context,
+  }) async {
     // Проверяем отмену каждые 10мс
     for (int i = 0; i < 1000; i++) {
       context?.cancellationToken?.throwIfCancelled();
@@ -489,8 +511,10 @@ final class ValidationServiceContract extends RpcResponderContract {
     return 'long-result'.rpc;
   }
 
-  Future<RpcString> _checkContextValues(RpcString request,
-      {RpcContext? context}) async {
+  Future<RpcString> _checkContextValues(
+    RpcString request, {
+    RpcContext? context,
+  }) async {
     final headers = context?.headers ?? <String, String>{};
     final values = context?.values ?? <Object, Object>{};
     final headersList =
@@ -498,8 +522,10 @@ final class ValidationServiceContract extends RpcResponderContract {
     return '$headersList|context-values-count:${values.length}'.rpc;
   }
 
-  Stream<RpcString> _generateWithContext(RpcString request,
-      {RpcContext? context}) async* {
+  Stream<RpcString> _generateWithContext(
+    RpcString request, {
+    RpcContext? context,
+  }) async* {
     final size = int.parse(context?.getHeader('stream-size') ?? '1');
     final prefix = context?.getHeader('stream-prefix') ?? 'default';
     final traceId = context?.traceId ?? 'no-trace';
@@ -509,8 +535,10 @@ final class ValidationServiceContract extends RpcResponderContract {
     }
   }
 
-  Future<RpcString> _aggregateWithContext(Stream<RpcString> requests,
-      {RpcContext? context}) async {
+  Future<RpcString> _aggregateWithContext(
+    Stream<RpcString> requests, {
+    RpcContext? context,
+  }) async {
     final aggregationType = context?.getHeader('aggregation-type') ?? 'concat';
     final multiplier = int.parse(context?.getHeader('multiplier') ?? '1');
     final traceId = context?.traceId ?? 'no-trace';
@@ -525,8 +553,10 @@ final class ValidationServiceContract extends RpcResponderContract {
     return 'concat:${items.map((i) => i.value).join(',')}|trace:$traceId'.rpc;
   }
 
-  Stream<RpcString> _processWithContext(Stream<RpcString> requests,
-      {RpcContext? context}) async* {
+  Stream<RpcString> _processWithContext(
+    Stream<RpcString> requests, {
+    RpcContext? context,
+  }) async* {
     final prefix = context?.getHeader('echo-prefix') ?? 'ECHO';
     final transform = context?.getHeader('transform') ?? 'none';
     final traceId = context?.traceId ?? 'no-trace';

--- a/packages/rpc_dart/test/core/rpc_message_frame_test.dart
+++ b/packages/rpc_dart/test/core/rpc_message_frame_test.dart
@@ -96,11 +96,13 @@ void main() {
         // Act & Assert
         expect(
           () => RpcMessageFrame.parseHeader(shortHeader),
-          throwsA(isA<Exception>().having(
-            (e) => e.toString(),
-            'message',
-            contains('Неверная длина заголовка'),
-          )),
+          throwsA(
+            isA<Exception>().having(
+              (e) => e.toString(),
+              'message',
+              contains('Неверная длина заголовка'),
+            ),
+          ),
         );
       });
 
@@ -126,8 +128,9 @@ void main() {
         // Act
         final encoded = RpcMessageFrame.encode(originalMessage);
         final header = RpcMessageFrame.parseHeader(encoded);
-        final decodedPayload =
-            encoded.sublist(RpcConstants.MESSAGE_PREFIX_SIZE);
+        final decodedPayload = encoded.sublist(
+          RpcConstants.MESSAGE_PREFIX_SIZE,
+        );
 
         // Assert
         expect(header.messageLength, equals(originalMessage.length));

--- a/packages/rpc_dart/test/core/rpc_message_test.dart
+++ b/packages/rpc_dart/test/core/rpc_message_test.dart
@@ -111,10 +111,7 @@ void main() {
       test('сообщение_с_данными_и_метаданными_не_является_metadata_only', () {
         // Arrange
         final metadata = RpcMetadata([RpcHeader('header', 'value')]);
-        final message = RpcMessage<String>(
-          payload: 'data',
-          metadata: metadata,
-        );
+        final message = RpcMessage<String>(payload: 'data', metadata: metadata);
 
         // Act & Assert
         expect(message.isMetadataOnly, isFalse);

--- a/packages/rpc_dart/test/core/rpc_metadata_test.dart
+++ b/packages/rpc_dart/test/core/rpc_metadata_test.dart
@@ -20,8 +20,10 @@ void main() {
         // Assert
         expect(metadata.headers.length, equals(6));
         expect(_getHeaderValue(metadata, ':method'), equals('POST'));
-        expect(_getHeaderValue(metadata, ':path'),
-            equals('/TestService/TestMethod'));
+        expect(
+          _getHeaderValue(metadata, ':path'),
+          equals('/TestService/TestMethod'),
+        );
         expect(_getHeaderValue(metadata, ':scheme'), equals('http'));
         expect(_getHeaderValue(metadata, ':authority'), equals(host));
         expect(
@@ -198,9 +200,7 @@ void main() {
 
       test('возвращает_null_для_некорректного_пути', () {
         // Arrange
-        final metadata = RpcMetadata([
-          RpcHeader(':path', 'invalid-path'),
-        ]);
+        final metadata = RpcMetadata([RpcHeader(':path', 'invalid-path')]);
 
         // Act
         final serviceName = metadata.serviceName;
@@ -211,9 +211,7 @@ void main() {
 
       test('возвращает_null_для_пустого_пути', () {
         // Arrange
-        final metadata = RpcMetadata([
-          RpcHeader(':path', '/'),
-        ]);
+        final metadata = RpcMetadata([RpcHeader(':path', '/')]);
 
         // Act
         final serviceName = metadata.serviceName;
@@ -239,9 +237,7 @@ void main() {
 
       test('возвращает_null_для_пути_без_метода', () {
         // Arrange
-        final metadata = RpcMetadata([
-          RpcHeader(':path', '/TestService'),
-        ]);
+        final metadata = RpcMetadata([RpcHeader(':path', '/TestService')]);
 
         // Act
         final methodName = metadata.methodName;

--- a/packages/rpc_dart/test/endpoint/rpc_caller_endpoint_cancellation_test.dart
+++ b/packages/rpc_dart/test/endpoint/rpc_caller_endpoint_cancellation_test.dart
@@ -129,10 +129,7 @@ void main() {
 
       callerEndpoint.cancelMethod('TestService', 'FastMethod');
 
-      await expectLater(
-        future,
-        throwsA(isA<RpcCancelledException>()),
-      );
+      await expectLater(future, throwsA(isA<RpcCancelledException>()));
     });
 
     test('Отмена всех методов сервиса', () async {
@@ -162,8 +159,11 @@ void main() {
       // Проверяем, что первый метод получил отмену
       await expectLater(
         future1,
-        throwsA(predicate<RpcCancelledException>(
-            (e) => e.message == 'Service shutdown')),
+        throwsA(
+          predicate<RpcCancelledException>(
+            (e) => e.message == 'Service shutdown',
+          ),
+        ),
       );
 
       // FastMethod может успеть выполниться до отмены - проверяем любой результат
@@ -193,53 +193,65 @@ void main() {
       // Проверяем отмену
       await expectLater(
         future,
-        throwsA(predicate<RpcCancelledException>(
-            (e) => e.message == 'Global cancellation')),
+        throwsA(
+          predicate<RpcCancelledException>(
+            (e) => e.message == 'Global cancellation',
+          ),
+        ),
       );
     });
 
     test('Попытка отмены несуществующего метода', () async {
       // Пытаемся отменить метод, который не запущен
-      final cancelled =
-          callerEndpoint.cancelMethod('TestService', 'NonExistentMethod');
+      final cancelled = callerEndpoint.cancelMethod(
+        'TestService',
+        'NonExistentMethod',
+      );
       expect(cancelled, 0); // Теперь возвращает количество отмененных токенов
     });
 
-    test('Проверка токенов отмены через getCancellationTokensForMethod',
-        () async {
-      // Запускаем метод
-      final future = callerEndpoint.unaryRequest<TestRequest, TestResponse>(
-        serviceName: 'TestService',
-        methodName: 'SlowMethod',
-        requestCodec: RpcCodec<TestRequest>(TestRequest.fromJson),
-        responseCodec: RpcCodec<TestResponse>(TestResponse.fromJson),
-        request: TestRequest('operation'),
-      );
+    test(
+      'Проверка токенов отмены через getCancellationTokensForMethod',
+      () async {
+        // Запускаем метод
+        final future = callerEndpoint.unaryRequest<TestRequest, TestResponse>(
+          serviceName: 'TestService',
+          methodName: 'SlowMethod',
+          requestCodec: RpcCodec<TestRequest>(TestRequest.fromJson),
+          responseCodec: RpcCodec<TestResponse>(TestResponse.fromJson),
+          request: TestRequest('operation'),
+        );
 
-      // Проверяем количество активных вызовов
-      final activeCallsCount = callerEndpoint
-          .getCancellationTokensForMethod('TestService', 'SlowMethod')
-          .length;
-      expect(activeCallsCount, 1);
+        // Проверяем количество активных вызовов
+        final activeCallsCount = callerEndpoint
+            .getCancellationTokensForMethod('TestService', 'SlowMethod')
+            .length;
+        expect(activeCallsCount, 1);
 
-      // Отменяем все вызовы метода
-      final cancelledCount =
-          callerEndpoint.cancelMethod('TestService', 'SlowMethod');
-      expect(cancelledCount, 1);
+        // Отменяем все вызовы метода
+        final cancelledCount = callerEndpoint.cancelMethod(
+          'TestService',
+          'SlowMethod',
+        );
+        expect(cancelledCount, 1);
 
-      // Проверяем, что больше нет активных вызовов
-      final activeCallsCountAfter = callerEndpoint
-          .getCancellationTokensForMethod('TestService', 'SlowMethod')
-          .length;
-      expect(activeCallsCountAfter, 0);
+        // Проверяем, что больше нет активных вызовов
+        final activeCallsCountAfter = callerEndpoint
+            .getCancellationTokensForMethod('TestService', 'SlowMethod')
+            .length;
+        expect(activeCallsCountAfter, 0);
 
-      // Проверяем исключение
-      await expectLater(
-        future,
-        throwsA(predicate<RpcCancelledException>(
-            (e) => e.message == 'Method cancelled by user')),
-      );
-    });
+        // Проверяем исключение
+        await expectLater(
+          future,
+          throwsA(
+            predicate<RpcCancelledException>(
+              (e) => e.message == 'Method cancelled by user',
+            ),
+          ),
+        );
+      },
+    );
 
     test('Множественные вызовы одного метода с разными токенами', () async {
       // Запускаем несколько вызовов одного метода
@@ -267,24 +279,22 @@ void main() {
 
       // Проверяем, что у нас есть 2 токена для одного метода
       final tokens = callerEndpoint.getCancellationTokensForMethod(
-          'TestService', 'SlowMethod');
+        'TestService',
+        'SlowMethod',
+      );
       expect(tokens.length, 2);
 
       // Отменяем все вызовы метода
-      final cancelledCount =
-          callerEndpoint.cancelMethod('TestService', 'SlowMethod');
+      final cancelledCount = callerEndpoint.cancelMethod(
+        'TestService',
+        'SlowMethod',
+      );
       expect(cancelledCount, 2);
 
       // Проверяем, что оба вызова отменены
-      await expectLater(
-        future1,
-        throwsA(isA<RpcCancelledException>()),
-      );
+      await expectLater(future1, throwsA(isA<RpcCancelledException>()));
 
-      await expectLater(
-        future2,
-        throwsA(isA<RpcCancelledException>()),
-      );
+      await expectLater(future2, throwsA(isA<RpcCancelledException>()));
     });
 
     test('Отмена с пользовательской причиной', () async {
@@ -304,7 +314,8 @@ void main() {
       await expectLater(
         future,
         throwsA(
-            predicate<RpcCancelledException>((e) => e.message == customReason)),
+          predicate<RpcCancelledException>((e) => e.message == customReason),
+        ),
       );
     });
   });

--- a/packages/rpc_dart/test/endpoint/rpc_caller_endpoint_test.dart
+++ b/packages/rpc_dart/test/endpoint/rpc_caller_endpoint_test.dart
@@ -194,8 +194,11 @@ void main() {
         await subscription.cancel();
 
         print('Результат: получено ${responses.length} ответов');
-        expect(responses.length, greaterThanOrEqualTo(1),
-            reason: 'Должен получить хотя бы 1 ответ');
+        expect(
+          responses.length,
+          greaterThanOrEqualTo(1),
+          reason: 'Должен получить хотя бы 1 ответ',
+        );
 
         if (responses.isNotEmpty) {
           expect(responses.first.message, contains('Stream request'));
@@ -241,10 +244,14 @@ void main() {
       print('Ответ получен успешно!');
 
       // Проверяем результат
-      expect(response.message,
-          equals('Received: Message 1, Message 2, Message 3'));
-      expect(testService.callLog,
-          contains('ClientStreamMethod: Message 1, Message 2, Message 3'));
+      expect(
+        response.message,
+        equals('Received: Message 1, Message 2, Message 3'),
+      );
+      expect(
+        testService.callLog,
+        contains('ClientStreamMethod: Message 1, Message 2, Message 3'),
+      );
     });
 
     test('Двунаправленный стрим работает в обоих направлениях', () async {
@@ -289,7 +296,8 @@ void main() {
         },
         onDone: () {
           print(
-              'Стрим ответов завершен, получено ответов: ${responses.length}');
+            'Стрим ответов завершен, получено ответов: ${responses.length}',
+          );
           if (!responseCompleter.isCompleted) {
             responseCompleter.complete(responses);
           }
@@ -326,7 +334,8 @@ void main() {
           Duration(seconds: 15),
           onTimeout: () {
             print(
-                'Таймаут при ожидании ответов, получено: ${responses.length}');
+              'Таймаут при ожидании ответов, получено: ${responses.length}',
+            );
             if (responses.length >= 3) {
               return responses; // Если успели получить достаточно ответов, считаем успешным
             }
@@ -350,11 +359,17 @@ void main() {
 
         expect(testService.callLog, contains('BidirectionalMethod: начат'));
         expect(
-            testService.callLog, contains('BidirectionalMethod: Bi Message 1'));
+          testService.callLog,
+          contains('BidirectionalMethod: Bi Message 1'),
+        );
         expect(
-            testService.callLog, contains('BidirectionalMethod: Bi Message 2'));
+          testService.callLog,
+          contains('BidirectionalMethod: Bi Message 2'),
+        );
         expect(
-            testService.callLog, contains('BidirectionalMethod: Bi Message 3'));
+          testService.callLog,
+          contains('BidirectionalMethod: Bi Message 3'),
+        );
       } finally {
         // Отменяем подписку
         await subscription.cancel();

--- a/packages/rpc_dart/test/endpoint/rpc_endpoint_health_test.dart
+++ b/packages/rpc_dart/test/endpoint/rpc_endpoint_health_test.dart
@@ -1,0 +1,56 @@
+import 'package:rpc_dart/rpc_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RpcEndpoint health', () {
+    test('caller endpoint reports healthy status when active', () async {
+      final (clientTransport, serverTransport) = RpcInMemoryTransport.pair();
+      final caller = RpcCallerEndpoint(transport: clientTransport);
+      final responder = RpcResponderEndpoint(transport: serverTransport);
+
+      final report = await caller.health();
+
+      expect(report.endpointStatus.level, RpcHealthLevel.healthy);
+      expect(report.transportStatus?.level, RpcHealthLevel.healthy);
+      expect(report.isHealthy, isTrue);
+
+      await caller.close();
+      await responder.close();
+    });
+
+    test('responder endpoint health becomes closed after close()', () async {
+      final (clientTransport, serverTransport) = RpcInMemoryTransport.pair();
+      final caller = RpcCallerEndpoint(transport: clientTransport);
+      final responder = RpcResponderEndpoint(transport: serverTransport);
+
+      await responder.close();
+
+      final report = await responder.health();
+
+      expect(report.endpointStatus.level, RpcHealthLevel.closed);
+      expect(report.transportStatus?.level, RpcHealthLevel.closed);
+      expect(report.isHealthy, isFalse);
+
+      await caller.close();
+    });
+
+    test(
+      'reconnect reflects transport status when endpoint already closed',
+      () async {
+        final (clientTransport, serverTransport) = RpcInMemoryTransport.pair();
+        final caller = RpcCallerEndpoint(transport: clientTransport);
+        final responder = RpcResponderEndpoint(transport: serverTransport);
+
+        await caller.close();
+
+        final report = await caller.reconnect();
+
+        expect(report.endpointStatus.level, RpcHealthLevel.closed);
+        expect(report.transportStatus?.level, RpcHealthLevel.unhealthy);
+        expect(report.transportStatus?.details['supported'], isFalse);
+
+        await responder.close();
+      },
+    );
+  });
+}

--- a/packages/rpc_dart/test/endpoint/rpc_responder_endpoint_test.dart
+++ b/packages/rpc_dart/test/endpoint/rpc_responder_endpoint_test.dart
@@ -145,10 +145,14 @@ void main() {
 
       // Проверяем, что сервис был зарегистрирован
       expect(responderEndpoint.registeredContracts, contains('TestService'));
-      expect(responderEndpoint.registeredMethods,
-          contains('TestService.UnaryMethod'));
-      expect(responderEndpoint.registeredMethods,
-          contains('TestService.ServerStreamMethod'));
+      expect(
+        responderEndpoint.registeredMethods,
+        contains('TestService.UnaryMethod'),
+      );
+      expect(
+        responderEndpoint.registeredMethods,
+        contains('TestService.ServerStreamMethod'),
+      );
     });
 
     test('Регистрация нескольких контрактов работает корректно', () {
@@ -162,10 +166,14 @@ void main() {
       // Проверяем, что оба сервиса зарегистрированы
       expect(responderEndpoint.registeredContracts, contains('ParentService'));
       expect(responderEndpoint.registeredContracts, contains('SubService'));
-      expect(responderEndpoint.registeredMethods,
-          contains('ParentService.ParentMethod'));
-      expect(responderEndpoint.registeredMethods,
-          contains('SubService.SubUnaryMethod'));
+      expect(
+        responderEndpoint.registeredMethods,
+        contains('ParentService.ParentMethod'),
+      );
+      expect(
+        responderEndpoint.registeredMethods,
+        contains('SubService.SubUnaryMethod'),
+      );
     });
 
     test('Обработка унарного запроса работает корректно', () async {
@@ -207,19 +215,28 @@ void main() {
 
       // Проверяем существующий метод
       responderEndpoint.validateMethodExists(
-          'TestService', 'UnaryMethod', RpcMethodType.unaryRequest);
+        'TestService',
+        'UnaryMethod',
+        RpcMethodType.unaryRequest,
+      );
 
       // Проверяем несуществующий метод
       expect(
         () => responderEndpoint.validateMethodExists(
-            'TestService', 'NonExistentMethod', RpcMethodType.unaryRequest),
+          'TestService',
+          'NonExistentMethod',
+          RpcMethodType.unaryRequest,
+        ),
         throwsA(isA<RpcException>()),
       );
 
       // Проверяем метод с неверным типом
       expect(
         () => responderEndpoint.validateMethodExists(
-            'TestService', 'UnaryMethod', RpcMethodType.serverStream),
+          'TestService',
+          'UnaryMethod',
+          RpcMethodType.serverStream,
+        ),
         throwsA(isA<RpcException>()),
       );
     });
@@ -240,29 +257,34 @@ void main() {
       expect(responderEndpoint.registeredMethods, isEmpty);
     });
 
-    test('Обращение к отдельно зарегистрированному сервису работает корректно',
-        () async {
-      // Регистрируем оба сервиса отдельно
-      final parentService = ParentService();
-      final subService = SubService();
-      responderEndpoint.registerServiceContract(parentService);
-      responderEndpoint.registerServiceContract(subService);
-      responderEndpoint.start();
+    test(
+      'Обращение к отдельно зарегистрированному сервису работает корректно',
+      () async {
+        // Регистрируем оба сервиса отдельно
+        final parentService = ParentService();
+        final subService = SubService();
+        responderEndpoint.registerServiceContract(parentService);
+        responderEndpoint.registerServiceContract(subService);
+        responderEndpoint.start();
 
-      // Отправляем запрос к методу SubService
-      final response =
-          await callerEndpoint.unaryRequest<TestRequest, TestResponse>(
-        serviceName: 'SubService',
-        methodName: 'SubUnaryMethod',
-        requestCodec: RpcCodec<TestRequest>(TestRequest.fromJson),
-        responseCodec: RpcCodec<TestResponse>(TestResponse.fromJson),
-        request: TestRequest('SubService test'),
-      );
+        // Отправляем запрос к методу SubService
+        final response =
+            await callerEndpoint.unaryRequest<TestRequest, TestResponse>(
+          serviceName: 'SubService',
+          methodName: 'SubUnaryMethod',
+          requestCodec: RpcCodec<TestRequest>(TestRequest.fromJson),
+          responseCodec: RpcCodec<TestResponse>(TestResponse.fromJson),
+          request: TestRequest('SubService test'),
+        );
 
-      // Проверяем ответ и вызов обработчика
-      expect(response.message, equals('SubService reply to: SubService test'));
-      expect(subService.callLog, contains('SubUnaryMethod: SubService test'));
-    });
+        // Проверяем ответ и вызов обработчика
+        expect(
+          response.message,
+          equals('SubService reply to: SubService test'),
+        );
+        expect(subService.callLog, contains('SubUnaryMethod: SubService test'));
+      },
+    );
 
     test('Регистрация без запуска работает корректно', () {
       // Регистрируем сервис но НЕ запускаем эндпоинт
@@ -286,21 +308,31 @@ void main() {
 
         // Проверяем что сервис зарегистрирован
         expect(responderEndpoint.registeredContracts, contains('TestService'));
-        expect(responderEndpoint.registeredMethods,
-            contains('TestService.UnaryMethod'));
-        expect(responderEndpoint.registeredMethods,
-            contains('TestService.ServerStreamMethod'));
+        expect(
+          responderEndpoint.registeredMethods,
+          contains('TestService.UnaryMethod'),
+        );
+        expect(
+          responderEndpoint.registeredMethods,
+          contains('TestService.ServerStreamMethod'),
+        );
 
         // Разрегистрируем сервис
         responderEndpoint.unregisterServiceContract('TestService');
 
         // Проверяем что сервис и его методы удалены
-        expect(responderEndpoint.registeredContracts,
-            isNot(contains('TestService')));
-        expect(responderEndpoint.registeredMethods,
-            isNot(contains('TestService.UnaryMethod')));
-        expect(responderEndpoint.registeredMethods,
-            isNot(contains('TestService.ServerStreamMethod')));
+        expect(
+          responderEndpoint.registeredContracts,
+          isNot(contains('TestService')),
+        );
+        expect(
+          responderEndpoint.registeredMethods,
+          isNot(contains('TestService.UnaryMethod')),
+        );
+        expect(
+          responderEndpoint.registeredMethods,
+          isNot(contains('TestService.ServerStreamMethod')),
+        );
       });
 
       test('Разрегистрация одного сервиса не влияет на другие', () {
@@ -315,7 +347,9 @@ void main() {
         // Проверяем что все сервисы зарегистрированы
         expect(responderEndpoint.registeredContracts, contains('TestService'));
         expect(
-            responderEndpoint.registeredContracts, contains('ParentService'));
+          responderEndpoint.registeredContracts,
+          contains('ParentService'),
+        );
         expect(responderEndpoint.registeredContracts, contains('SubService'));
 
         // Разрегистрируем только один сервис
@@ -323,17 +357,25 @@ void main() {
 
         // Проверяем что только ParentService удален
         expect(responderEndpoint.registeredContracts, contains('TestService'));
-        expect(responderEndpoint.registeredContracts,
-            isNot(contains('ParentService')));
+        expect(
+          responderEndpoint.registeredContracts,
+          isNot(contains('ParentService')),
+        );
         expect(responderEndpoint.registeredContracts, contains('SubService'));
 
         // Проверяем что методы других сервисов остались
-        expect(responderEndpoint.registeredMethods,
-            contains('TestService.UnaryMethod'));
-        expect(responderEndpoint.registeredMethods,
-            contains('SubService.SubUnaryMethod'));
-        expect(responderEndpoint.registeredMethods,
-            isNot(contains('ParentService.ParentMethod')));
+        expect(
+          responderEndpoint.registeredMethods,
+          contains('TestService.UnaryMethod'),
+        );
+        expect(
+          responderEndpoint.registeredMethods,
+          contains('SubService.SubUnaryMethod'),
+        );
+        expect(
+          responderEndpoint.registeredMethods,
+          isNot(contains('ParentService.ParentMethod')),
+        );
       });
 
       test('Ошибка при разрегистрации незарегистрированного сервиса', () {
@@ -357,8 +399,10 @@ void main() {
         responderEndpoint.unregisterServiceContract('TestService');
 
         // Проверяем что сервис удален
-        expect(responderEndpoint.registeredContracts,
-            isNot(contains('TestService')));
+        expect(
+          responderEndpoint.registeredContracts,
+          isNot(contains('TestService')),
+        );
 
         // Регистрируем новый экземпляр того же сервиса
         final newTestService = TestService();
@@ -366,36 +410,44 @@ void main() {
 
         // Проверяем что сервис снова зарегистрирован
         expect(responderEndpoint.registeredContracts, contains('TestService'));
-        expect(responderEndpoint.registeredMethods,
-            contains('TestService.UnaryMethod'));
-      });
-
-      test('Функциональность эндпоинта работает после разрегистрации',
-          () async {
-        // Регистрируем несколько сервисов
-        final parentService = ParentService();
-        responderEndpoint.registerServiceContract(testService);
-        responderEndpoint.registerServiceContract(parentService);
-        responderEndpoint.start();
-
-        // Разрегистрируем один сервис
-        responderEndpoint.unregisterServiceContract('TestService');
-
-        // Проверяем что оставшийся сервис все еще работает
-        final response =
-            await callerEndpoint.unaryRequest<TestRequest, TestResponse>(
-          serviceName: 'ParentService',
-          methodName: 'ParentMethod',
-          requestCodec: RpcCodec<TestRequest>(TestRequest.fromJson),
-          responseCodec: RpcCodec<TestResponse>(TestResponse.fromJson),
-          request: TestRequest('After unregister test'),
+        expect(
+          responderEndpoint.registeredMethods,
+          contains('TestService.UnaryMethod'),
         );
-
-        expect(response.message,
-            equals('ParentService reply to: After unregister test'));
-        expect(parentService.callLog,
-            contains('ParentMethod: After unregister test'));
       });
+
+      test(
+        'Функциональность эндпоинта работает после разрегистрации',
+        () async {
+          // Регистрируем несколько сервисов
+          final parentService = ParentService();
+          responderEndpoint.registerServiceContract(testService);
+          responderEndpoint.registerServiceContract(parentService);
+          responderEndpoint.start();
+
+          // Разрегистрируем один сервис
+          responderEndpoint.unregisterServiceContract('TestService');
+
+          // Проверяем что оставшийся сервис все еще работает
+          final response =
+              await callerEndpoint.unaryRequest<TestRequest, TestResponse>(
+            serviceName: 'ParentService',
+            methodName: 'ParentMethod',
+            requestCodec: RpcCodec<TestRequest>(TestRequest.fromJson),
+            responseCodec: RpcCodec<TestResponse>(TestResponse.fromJson),
+            request: TestRequest('After unregister test'),
+          );
+
+          expect(
+            response.message,
+            equals('ParentService reply to: After unregister test'),
+          );
+          expect(
+            parentService.callLog,
+            contains('ParentMethod: After unregister test'),
+          );
+        },
+      );
 
       test('Разрегистрация всех сервисов очищает все методы', () {
         // Регистрируем несколько сервисов
@@ -446,8 +498,10 @@ void main() {
         responderEndpoint.unregisterServiceContract('TestService');
 
         // Проверяем что сервис удален
-        expect(responderEndpoint.registeredContracts,
-            isNot(contains('TestService')));
+        expect(
+          responderEndpoint.registeredContracts,
+          isNot(contains('TestService')),
+        );
 
         // Регистрируем новый сервис ПОСЛЕ разрегистрации
         final newService = TestService();
@@ -466,8 +520,10 @@ void main() {
         expect(newResponse.message, equals('Reply to: New service test'));
         expect(newService.callLog, contains('UnaryMethod: New service test'));
         // Убеждаемся что старый сервис не получил запрос
-        expect(testService.callLog,
-            isNot(contains('UnaryMethod: New service test')));
+        expect(
+          testService.callLog,
+          isNot(contains('UnaryMethod: New service test')),
+        );
       });
 
       test('Ресурсы автоматически освобождаются при разрегистрации', () async {
@@ -477,8 +533,10 @@ void main() {
         responderEndpoint.start();
 
         // Проверяем что сервис зарегистрирован
-        expect(responderEndpoint.registeredContracts,
-            contains('ResourceHeavyService'));
+        expect(
+          responderEndpoint.registeredContracts,
+          contains('ResourceHeavyService'),
+        );
 
         // Вызываем метод который может создать ресурсы
         final response =
@@ -501,43 +559,47 @@ void main() {
         expect(resourceService.activeConnections, equals(0));
       });
 
-      test('dispose() автоматически вызывается при unregisterServiceContract()',
-          () async {
-        // Создаем тестовый респондер с ресурсами
-        final resourceService = ResourceHeavyService();
-        responderEndpoint.registerServiceContract(resourceService);
-        responderEndpoint.start();
+      test(
+        'dispose() автоматически вызывается при unregisterServiceContract()',
+        () async {
+          // Создаем тестовый респондер с ресурсами
+          final resourceService = ResourceHeavyService();
+          responderEndpoint.registerServiceContract(resourceService);
+          responderEndpoint.start();
 
-        // Создаем ресурсы
-        final response =
-            await callerEndpoint.unaryRequest<TestRequest, TestResponse>(
-          serviceName: 'ResourceHeavyService',
-          methodName: 'CreateResourceIntensiveOperation',
-          requestCodec: RpcCodec<TestRequest>(TestRequest.fromJson),
-          responseCodec: RpcCodec<TestResponse>(TestResponse.fromJson),
-          request: TestRequest('setup resources'),
-        );
+          // Создаем ресурсы
+          final response =
+              await callerEndpoint.unaryRequest<TestRequest, TestResponse>(
+            serviceName: 'ResourceHeavyService',
+            methodName: 'CreateResourceIntensiveOperation',
+            requestCodec: RpcCodec<TestRequest>(TestRequest.fromJson),
+            responseCodec: RpcCodec<TestResponse>(TestResponse.fromJson),
+            request: TestRequest('setup resources'),
+          );
 
-        expect(response.message, contains('resources created'));
-        expect(resourceService.isResourcesActive(), isTrue);
+          expect(response.message, contains('resources created'));
+          expect(resourceService.isResourcesActive(), isTrue);
 
-        // 🆕 Разрегистрируем сервис - dispose() должен вызваться автоматически
-        responderEndpoint.unregisterServiceContract('ResourceHeavyService');
+          // 🆕 Разрегистрируем сервис - dispose() должен вызваться автоматически
+          responderEndpoint.unregisterServiceContract('ResourceHeavyService');
 
-        // ✅ Ресурсы должны быть автоматически освобождены
-        expect(resourceService.isResourcesActive(), isFalse);
-        expect(resourceService.activeConnections, equals(0));
-      });
+          // ✅ Ресурсы должны быть автоматически освобождены
+          expect(resourceService.isResourcesActive(), isFalse);
+          expect(resourceService.activeConnections, equals(0));
+        },
+      );
 
       test('dispose() автоматически вызывается при close() эндпоинта',
           () async {
         // Создаем новый эндпоинт для этого теста
         final (newCallerTransport, newResponderTransport) =
             RpcInMemoryTransport.pair();
-        final newResponderEndpoint =
-            RpcResponderEndpoint(transport: newResponderTransport);
-        final newCallerEndpoint =
-            RpcCallerEndpoint(transport: newCallerTransport);
+        final newResponderEndpoint = RpcResponderEndpoint(
+          transport: newResponderTransport,
+        );
+        final newCallerEndpoint = RpcCallerEndpoint(
+          transport: newCallerTransport,
+        );
 
         // Регистрируем сервис с ресурсами
         final resourceService1 = ResourceHeavyService();
@@ -575,13 +637,17 @@ void main() {
 
         // Разрегистрируем сервис - не должно упасть с ошибкой
         expect(
-            () => responderEndpoint
-                .unregisterServiceContract('ProblematicDisposeService'),
-            returnsNormally);
+          () => responderEndpoint.unregisterServiceContract(
+            'ProblematicDisposeService',
+          ),
+          returnsNormally,
+        );
 
         // Проверяем что сервис все равно удален
-        expect(responderEndpoint.registeredContracts,
-            isNot(contains('ProblematicDisposeService')));
+        expect(
+          responderEndpoint.registeredContracts,
+          isNot(contains('ProblematicDisposeService')),
+        );
       });
     });
   });
@@ -605,7 +671,8 @@ final class ResourceHeavyService extends RpcResponderContract {
         // Имитируем создание ресурсов
         _createFakeResources();
         return TestResponse(
-            'resources created - connections: $activeConnections');
+          'resources created - connections: $activeConnections',
+        );
       },
       requestCodec: RpcCodec<TestRequest>(TestRequest.fromJson),
       responseCodec: RpcCodec<TestResponse>(TestResponse.fromJson),
@@ -619,9 +686,10 @@ final class ResourceHeavyService extends RpcResponderContract {
       _activeStreams.add(controller);
 
       // Имитируем подписку на внешний поток
-      final subscription =
-          Stream.periodic(Duration(seconds: 1), (count) => 'data_$count')
-              .listen(controller.add);
+      final subscription = Stream.periodic(
+        Duration(seconds: 1),
+        (count) => 'data_$count',
+      ).listen(controller.add);
       _subscriptions['stream_$i'] = subscription;
     }
 

--- a/packages/rpc_dart/test/serializers/cbor_test.dart
+++ b/packages/rpc_dart/test/serializers/cbor_test.dart
@@ -43,16 +43,24 @@ void main() {
       test('65536 to 4294967295', () {
         expect(bytesToHex(CborCodec.encodeUnsafe(65536)), equals('1a00010000'));
         expect(
-            bytesToHex(CborCodec.encodeUnsafe(1000000)), equals('1a000f4240'));
-        expect(bytesToHex(CborCodec.encodeUnsafe(4294967295)),
-            equals('1affffffff'));
+          bytesToHex(CborCodec.encodeUnsafe(1000000)),
+          equals('1a000f4240'),
+        );
+        expect(
+          bytesToHex(CborCodec.encodeUnsafe(4294967295)),
+          equals('1affffffff'),
+        );
       });
 
       test('4294967296 and above', () {
-        expect(bytesToHex(CborCodec.encodeUnsafe(4294967296)),
-            equals('1b0000000100000000'));
-        expect(bytesToHex(CborCodec.encodeUnsafe(1000000000000)),
-            equals('1b000000e8d4a51000'));
+        expect(
+          bytesToHex(CborCodec.encodeUnsafe(4294967296)),
+          equals('1b0000000100000000'),
+        );
+        expect(
+          bytesToHex(CborCodec.encodeUnsafe(1000000000000)),
+          equals('1b000000e8d4a51000'),
+        );
       });
     });
 
@@ -108,29 +116,39 @@ void main() {
       test('ASCII strings', () {
         expect(bytesToHex(CborCodec.encodeUnsafe('a')), equals('6161'));
         expect(
-            bytesToHex(CborCodec.encodeUnsafe('IETF')), equals('6449455446'));
-        expect(bytesToHex(CborCodec.encodeUnsafe('hello')),
-            equals('6568656c6c6f'));
+          bytesToHex(CborCodec.encodeUnsafe('IETF')),
+          equals('6449455446'),
+        );
+        expect(
+          bytesToHex(CborCodec.encodeUnsafe('hello')),
+          equals('6568656c6c6f'),
+        );
       });
 
       test('Unicode strings', () {
-        expect(bytesToHex(CborCodec.encodeUnsafe('привет')),
-            equals('6cd0bfd180d0b8d0b2d0b5d182'));
+        expect(
+          bytesToHex(CborCodec.encodeUnsafe('привет')),
+          equals('6cd0bfd180d0b8d0b2d0b5d182'),
+        );
         expect(bytesToHex(CborCodec.encodeUnsafe('☺')), equals('63e298ba'));
       });
 
       test('Longer strings', () {
         final longStr = 'a' * 24;
         final encoded = CborCodec.encodeUnsafe(longStr);
-        expect(encoded[0],
-            equals(0x78)); // начинается с 0x78 (строка, длина в 1 байт)
+        expect(
+          encoded[0],
+          equals(0x78),
+        ); // начинается с 0x78 (строка, длина в 1 байт)
         expect(encoded[1], equals(24)); // длина 24
         expect(CborCodec.decodeUnsafe(encoded), equals(longStr));
 
         final veryLongStr = 'a' * 1000;
         final encoded2 = CborCodec.encodeUnsafe(veryLongStr);
-        expect(encoded2[0],
-            equals(0x79)); // начинается с 0x79 (строка, длина в 2 байта)
+        expect(
+          encoded2[0],
+          equals(0x79),
+        ); // начинается с 0x79 (строка, длина в 2 байта)
         expect(CborCodec.decodeUnsafe(encoded2), equals(veryLongStr));
       });
     });
@@ -142,14 +160,19 @@ void main() {
 
       test('Small arrays', () {
         expect(
-            bytesToHex(CborCodec.encodeUnsafe([1, 2, 3])), equals('83010203'));
+          bytesToHex(CborCodec.encodeUnsafe([1, 2, 3])),
+          equals('83010203'),
+        );
         expect(
-            bytesToHex(CborCodec.encodeUnsafe([
+          bytesToHex(
+            CborCodec.encodeUnsafe([
               1,
               [2, 3],
-              [4, 5]
-            ])),
-            equals('8301820203820405'));
+              [4, 5],
+            ]),
+          ),
+          equals('8301820203820405'),
+        );
       });
 
       test('Arrays with mixed types', () {
@@ -159,7 +182,7 @@ void main() {
           'hello',
           true,
           null,
-          [1, 2]
+          [1, 2],
         ]);
         final decoded = CborCodec.decodeUnsafe(encoded);
         expect(decoded[0], equals(1));
@@ -173,8 +196,10 @@ void main() {
       test('Longer arrays', () {
         final longArray = List.generate(100, (i) => i);
         final encoded = CborCodec.encodeUnsafe(longArray);
-        expect(encoded[0],
-            equals(0x98)); // начинается с 0x98 (массив, длина в 1 байт)
+        expect(
+          encoded[0],
+          equals(0x98),
+        ); // начинается с 0x98 (массив, длина в 1 байт)
         expect(encoded[1], equals(100)); // длина 100
         expect(CborCodec.decodeUnsafe(encoded), equals(longArray));
       });
@@ -186,15 +211,17 @@ void main() {
       });
 
       test('Simple maps', () {
-        expect(bytesToHex(CborCodec.encode({'a': 1, 'b': 2})),
-            equals('a2616101616202'));
+        expect(
+          bytesToHex(CborCodec.encode({'a': 1, 'b': 2})),
+          equals('a2616101616202'),
+        );
       });
 
       test('Maps with nested structures', () {
         final encoded = CborCodec.encode({
           'a': 1,
           'b': [2, 3],
-          'c': {'d': 4}
+          'c': {'d': 4},
         });
         final decoded = CborCodec.decodeUnsafe(encoded);
         expect(decoded['a'], equals(1));
@@ -216,9 +243,12 @@ void main() {
         final bytes = Uint8List.fromList([1, 2, 3, 4]);
         final encoded = CborCodec.encodeUnsafe(bytes);
         // 0x44 = 0x40 (major type 2) + 4 (length)
-        expect(encoded[0], equals(0x44),
-            reason:
-                'First byte should be 0x44 for a 4-byte string (major type 2 with length 4)');
+        expect(
+          encoded[0],
+          equals(0x44),
+          reason:
+              'First byte should be 0x44 for a 4-byte string (major type 2 with length 4)',
+        );
         final decoded = CborCodec.decodeUnsafe(encoded);
         expect(decoded, equals(bytes));
       });
@@ -254,15 +284,15 @@ void main() {
           {'value': [], 'hex': '80'},
           {
             'value': [1, 2, 3],
-            'hex': '83010203'
+            'hex': '83010203',
           },
           {
             'value': [
               1,
               [2, 3],
-              [4, 5]
+              [4, 5],
             ],
-            'hex': '8301820203820405'
+            'hex': '8301820203820405',
           },
           {
             'value': [
@@ -290,9 +320,9 @@ void main() {
               22,
               23,
               24,
-              25
+              25,
             ],
-            'hex': '98190102030405060708090a0b0c0d0e0f101112131415161718181819'
+            'hex': '98190102030405060708090a0b0c0d0e0f101112131415161718181819',
           },
 
           // Map
@@ -300,9 +330,9 @@ void main() {
           {
             'value': {
               'a': 1,
-              'b': [2, 3]
+              'b': [2, 3],
             },
-            'hex': 'a26161016162820203'
+            'hex': 'a26161016162820203',
           },
         ];
 
@@ -311,13 +341,19 @@ void main() {
           final hexExpected = example['hex'] as String;
           final encoded = CborCodec.encodeUnsafe(value);
           final hexActual = bytesToHex(encoded);
-          expect(hexActual, equals(hexExpected),
-              reason: 'Encoding of $value failed');
+          expect(
+            hexActual,
+            equals(hexExpected),
+            reason: 'Encoding of $value failed',
+          );
 
           // Проверяем также декодирование
           final decoded = CborCodec.decodeUnsafe(hexToBytes(hexExpected));
-          expect(decoded, equals(value),
-              reason: 'Decoding of $hexExpected failed');
+          expect(
+            decoded,
+            equals(value),
+            reason: 'Decoding of $hexExpected failed',
+          );
         }
       });
     });
@@ -338,17 +374,17 @@ void main() {
             [
               3,
               4,
-              [5, 6]
-            ]
+              [5, 6],
+            ],
           ],
           'map': {
             'a': 1,
             'b': 2,
             'nested': {
               'c': 3,
-              'd': [4, 5, 6]
-            }
-          }
+              'd': [4, 5, 6],
+            },
+          },
         };
 
         final encoded = CborCodec.encodeUnsafe(complexData);
@@ -385,17 +421,17 @@ void main() {
             [
               3,
               4,
-              [5, 6]
-            ]
+              [5, 6],
+            ],
           ],
           'map': {
             'a': 1,
             'b': 2,
             'nested': {
               'c': 3,
-              'd': [4, 5, 6]
-            }
-          }
+              'd': [4, 5, 6],
+            },
+          },
         };
 
         final cborEncoded = CborCodec.encode(testData);
@@ -404,7 +440,8 @@ void main() {
         print('CBOR size: ${cborEncoded.length} bytes');
         print('JSON size: ${jsonEncoded.length} bytes');
         print(
-            'Space saving: ${((jsonEncoded.length - cborEncoded.length) / jsonEncoded.length * 100).toStringAsFixed(2)}%');
+          'Space saving: ${((jsonEncoded.length - cborEncoded.length) / jsonEncoded.length * 100).toStringAsFixed(2)}%',
+        );
 
         // Убедимся, что CBOR компактнее JSON
         expect(cborEncoded.length, lessThan(jsonEncoded.length));

--- a/packages/rpc_dart/test/serializers/codec_complex_test.dart
+++ b/packages/rpc_dart/test/serializers/codec_complex_test.dart
@@ -58,17 +58,11 @@ class Contact implements IRpcSerializable {
   final String email;
   final String phone;
 
-  Contact({
-    required this.email,
-    required this.phone,
-  });
+  Contact({required this.email, required this.phone});
 
   @override
   Map<String, dynamic> toJson() {
-    return {
-      'email': email,
-      'phone': phone,
-    };
+    return {'email': email, 'phone': phone};
   }
 
   factory Contact.fromJson(Map<String, dynamic> json) {
@@ -154,7 +148,9 @@ class Person implements IRpcSerializable {
         listEquals(other.hobbies, hobbies) &&
         mapEquals(other.scores, scores) &&
         listEquals(
-            other.alternativeAddresses.toList(), alternativeAddresses.toList());
+          other.alternativeAddresses.toList(),
+          alternativeAddresses.toList(),
+        );
   }
 
   @override
@@ -204,16 +200,9 @@ void main() {
           country: 'USA',
           zipCode: 10001,
         ),
-        contact: Contact(
-          email: 'john@example.com',
-          phone: '+1234567890',
-        ),
+        contact: Contact(email: 'john@example.com', phone: '+1234567890'),
         hobbies: ['reading', 'hiking', 'coding'],
-        scores: {
-          'math': 95,
-          'science': 90,
-          'history': 85,
-        },
+        scores: {'math': 95, 'science': 90, 'history': 85},
         alternativeAddresses: RpcList<Address>.from([
           Address(
             street: '456 Park Ave',
@@ -257,21 +246,22 @@ void main() {
 
       // Проверяем коллекции
       expect(
-          deserializedPerson.hobbies, equals(['reading', 'hiking', 'coding']));
+        deserializedPerson.hobbies,
+        equals(['reading', 'hiking', 'coding']),
+      );
       expect(
-          deserializedPerson.scores,
-          equals({
-            'math': 95,
-            'science': 90,
-            'history': 85,
-          }));
+        deserializedPerson.scores,
+        equals({'math': 95, 'science': 90, 'history': 85}),
+      );
 
       // Проверяем RpcList с вложенными объектами
       expect(deserializedPerson.alternativeAddresses, isA<RpcList<Address>>());
       expect(deserializedPerson.alternativeAddresses.length, equals(2));
       expect(deserializedPerson.alternativeAddresses[0].city, equals('Boston'));
-      expect(deserializedPerson.alternativeAddresses[1].city,
-          equals('San Francisco'));
+      expect(
+        deserializedPerson.alternativeAddresses[1].city,
+        equals('San Francisco'),
+      );
 
       // Проверяем полное равенство оригинального и десериализованного объектов
       expect(deserializedPerson, equals(person));

--- a/packages/rpc_dart/test/serializers/fast_cbor_encoder_test.dart
+++ b/packages/rpc_dart/test/serializers/fast_cbor_encoder_test.dart
@@ -67,10 +67,12 @@ void main() {
       test('Binary data encoding optimization', () {
         final testData = {
           'small_binary': Uint8List.fromList([1, 2, 3]),
-          'medium_binary':
-              Uint8List.fromList(List.generate(1000, (i) => i % 256)),
-          'large_binary':
-              Uint8List.fromList(List.generate(100000, (i) => i % 256)),
+          'medium_binary': Uint8List.fromList(
+            List.generate(1000, (i) => i % 256),
+          ),
+          'large_binary': Uint8List.fromList(
+            List.generate(100000, (i) => i % 256),
+          ),
           'empty_binary': Uint8List(0),
         };
 
@@ -96,7 +98,7 @@ void main() {
           'extreme_floats': [
             double.infinity,
             double.negativeInfinity,
-            double.nan
+            double.nan,
           ],
           'precision_floats': [1.0e-100, 1.0e+100, 1.7976931348623157e+308],
           'special_zero': [0.0, -0.0],
@@ -130,7 +132,8 @@ void main() {
         final minTime = times.reduce((a, b) => a < b ? a : b);
 
         print(
-            'Float encoding times: ${times.join(', ')}μs (avg: ${avgTime.round()}μs, min: $minTimeμs)');
+          'Float encoding times: ${times.join(', ')}μs (avg: ${avgTime.round()}μs, min: $minTimeμs)',
+        );
 
         // Более мягкая проверка производительности - используем среднее время и увеличенный лимит
         expect(avgTime, lessThan(10000)); // < 3ms среднее время
@@ -154,7 +157,7 @@ void main() {
               'created': DateTime.now().millisecondsSinceEpoch,
               'description': 'Level $depth description',
               'tags': ['tag_$depth', 'level_$depth', 'nested'],
-            }
+            },
           };
         }
 
@@ -165,7 +168,8 @@ void main() {
         stopwatch.stop();
 
         print(
-            'Complex nested encoding took: ${stopwatch.elapsedMilliseconds}ms');
+          'Complex nested encoding took: ${stopwatch.elapsedMilliseconds}ms',
+        );
         print('Encoded size: ${encoded.length} bytes');
 
         final decoded = CborCodec.decode(encoded);
@@ -203,9 +207,11 @@ void main() {
         stopwatch.stop();
 
         print(
-            'Large map (10k entries) encoding took: ${stopwatch.elapsedMilliseconds}ms');
+          'Large map (10k entries) encoding took: ${stopwatch.elapsedMilliseconds}ms',
+        );
         print(
-            'Encoded size: ${(encoded.length / 1024 / 1024).toStringAsFixed(2)} MB');
+          'Encoded size: ${(encoded.length / 1024 / 1024).toStringAsFixed(2)} MB',
+        );
 
         expect(stopwatch.elapsedMilliseconds, lessThan(5000)); // < 5 секунд
         expect(encoded.length, greaterThan(1000000)); // > 1MB
@@ -218,8 +224,8 @@ void main() {
           'text': 'Same every time',
           'nested': {
             'inner': [1, 2, 3, 4, 5],
-            'map': {'a': 1, 'b': 2}
-          }
+            'map': {'a': 1, 'b': 2},
+          },
         };
 
         final encodings = <Uint8List>[];
@@ -306,7 +312,8 @@ void main() {
 
         print('Length encoding test took: ${stopwatch.elapsedMilliseconds}ms');
         print(
-            'Total encoded size: ${(encoded.length / 1024 / 1024).toStringAsFixed(2)} MB');
+          'Total encoded size: ${(encoded.length / 1024 / 1024).toStringAsFixed(2)} MB',
+        );
 
         final decoded = CborCodec.decode(encoded);
         expect(decoded['short_string'], equals('a' * 20));
@@ -316,8 +323,10 @@ void main() {
         expect(decoded['long_string'], equals('c' * 1000));
         expect(decoded['long_array'], equals(List.generate(1000, (i) => i)));
         expect(decoded['very_long_string'], equals('d' * 100000));
-        expect(decoded['very_long_array'],
-            equals(List.generate(100000, (i) => i % 1000)));
+        expect(
+          decoded['very_long_array'],
+          equals(List.generate(100000, (i) => i % 1000)),
+        );
 
         expect(stopwatch.elapsedMilliseconds, lessThan(3000)); // < 3 секунды
       });
@@ -333,8 +342,9 @@ void main() {
             testData['item_$i'] = {
               'id': i,
               'data': List.generate(50, (j) => '$i-$j'),
-              'binary':
-                  Uint8List.fromList(List.generate(100, (k) => (i + k) % 256)),
+              'binary': Uint8List.fromList(
+                List.generate(100, (k) => (i + k) % 256),
+              ),
             };
           }
 
@@ -345,10 +355,13 @@ void main() {
           final encodingSpeed =
               encoded.length / stopwatch.elapsedMicroseconds; // bytes/μs
           print(
-              'Size $size: ${stopwatch.elapsedMicroseconds}μs, ${encoded.length} bytes, ${encodingSpeed.toStringAsFixed(2)} bytes/μs');
+            'Size $size: ${stopwatch.elapsedMicroseconds}μs, ${encoded.length} bytes, ${encodingSpeed.toStringAsFixed(2)} bytes/μs',
+          );
 
-          expect(stopwatch.elapsedMicroseconds,
-              lessThan(size * 10000)); // Линейная зависимость
+          expect(
+            stopwatch.elapsedMicroseconds,
+            lessThan(size * 10000),
+          ); // Линейная зависимость
         }
       });
     });

--- a/packages/rpc_dart/test/serializers/optimized_cbor_test.dart
+++ b/packages/rpc_dart/test/serializers/optimized_cbor_test.dart
@@ -28,22 +28,30 @@ void main() {
             result[key] = null;
             break;
           case 4:
-            result[key] = String.fromCharCodes(List.generate(
+            result[key] = String.fromCharCodes(
+              List.generate(
                 random.nextInt(100) + 1,
-                (i) => 65 + random.nextInt(26))); // Случайная строка A-Z
+                (i) => 65 + random.nextInt(26),
+              ),
+            ); // Случайная строка A-Z
             break;
           case 5:
             result[key] = List.generate(
-                random.nextInt(20) + 1, (i) => random.nextInt(1000));
+              random.nextInt(20) + 1,
+              (i) => random.nextInt(1000),
+            );
             break;
           case 6:
-            result[key] = Uint8List.fromList(List.generate(
-                random.nextInt(50) + 1, (i) => random.nextInt(256)));
+            result[key] = Uint8List.fromList(
+              List.generate(random.nextInt(50) + 1, (i) => random.nextInt(256)),
+            );
             break;
           case 7:
             if (depth > 0) {
-              result[key] =
-                  generateRandomData(depth - 1, random.nextInt(breadth) + 1);
+              result[key] = generateRandomData(
+                depth - 1,
+                random.nextInt(breadth) + 1,
+              );
             } else {
               result[key] = random.nextInt(100);
             }
@@ -67,12 +75,12 @@ void main() {
             [],
             [1, 2, 3],
             ['a', 'b', 'c'],
-            [1, 'mixed', true, null]
+            [1, 'mixed', true, null],
           ],
           'nested_map': {
             'level1': {
-              'level2': {'level3': 'deep value'}
-            }
+              'level2': {'level3': 'deep value'},
+            },
           },
           'binary_data': Uint8List.fromList([0, 1, 255, 128, 64]),
         };
@@ -95,8 +103,10 @@ void main() {
 
         // Проверяем floats с точностью
         for (int i = 0; i < (testData['floats'] as List).length; i++) {
-          expect((fastDecoded['floats'] as List)[i],
-              closeTo((testData['floats'] as List)[i], 0.000001));
+          expect(
+            (fastDecoded['floats'] as List)[i],
+            closeTo((testData['floats'] as List)[i], 0.000001),
+          );
         }
       });
 
@@ -106,8 +116,8 @@ void main() {
           'number': 42,
           'bool': true,
           'nested': {
-            'inner': [1, 2, 3]
-          }
+            'inner': [1, 2, 3],
+          },
         };
 
         final fastEncoded = CborCodec.encode(testData);
@@ -211,8 +221,9 @@ void main() {
       });
 
       test('Large binary data', () {
-        final largeBinary =
-            Uint8List.fromList(List.generate(50000, (i) => i % 256));
+        final largeBinary = Uint8List.fromList(
+          List.generate(50000, (i) => i % 256),
+        );
         final testData = {'binary': largeBinary};
 
         final encoded = CborCodec.encode(testData);
@@ -236,7 +247,9 @@ void main() {
 
         expect(stopwatch.elapsedMilliseconds, lessThan(1000)); // < 1 секунды
         expect(
-            encoded.length, greaterThan(1000)); // Должно быть достаточно данных
+          encoded.length,
+          greaterThan(1000),
+        ); // Должно быть достаточно данных
       });
 
       test('Large data decoding performance', () {
@@ -266,7 +279,8 @@ void main() {
         print('CBOR size: ${cborEncoded.length} bytes');
         print('JSON size: ${jsonEncoded.length} bytes');
         print(
-            'Compression ratio: ${(cborEncoded.length / jsonEncoded.length * 100).toStringAsFixed(1)}%');
+          'Compression ratio: ${(cborEncoded.length / jsonEncoded.length * 100).toStringAsFixed(1)}%',
+        );
 
         // CBOR должен быть компактнее JSON
         expect(cborEncoded.length, lessThan(jsonEncoded.length));
@@ -275,11 +289,7 @@ void main() {
 
     group('RFC 7049 Compliance Enhanced', () {
       test('Deterministic encoding', () {
-        final testData = {
-          'c': 3,
-          'a': 1,
-          'b': 2,
-        };
+        final testData = {'c': 3, 'a': 1, 'b': 2};
 
         // Кодируем несколько раз
         final encoded1 = CborCodec.encode(testData);
@@ -300,7 +310,7 @@ void main() {
           [1, 2, 3],
           {'nested': 'value'},
           3.14159,
-          Uint8List.fromList([1, 2, 3, 4])
+          Uint8List.fromList([1, 2, 3, 4]),
         ];
 
         final testData = {'mixed_array': mixedArray};
@@ -350,7 +360,7 @@ void main() {
           'nested': <String, dynamic>{
             'inner_string': 'inner_value',
             'inner_int': 456,
-          }
+          },
         };
 
         final encoded = CborCodec.encode(testData);
@@ -384,7 +394,7 @@ void main() {
         var data = <String, dynamic>{
           'counter': 0,
           'nested': {'value': 'test'},
-          'array': [1, 2, 3]
+          'array': [1, 2, 3],
         };
 
         // Выполняем 1000 циклов кодирования/декодирования
@@ -396,7 +406,9 @@ void main() {
 
         expect(data['counter'], equals(999));
         expect(
-            (data['nested'] as Map<String, dynamic>)['value'], equals('test'));
+          (data['nested'] as Map<String, dynamic>)['value'],
+          equals('test'),
+        );
         expect(data['array'], equals([1, 2, 3]));
       });
 

--- a/packages/rpc_dart/test/streams/bidirectional_stream_test.dart
+++ b/packages/rpc_dart/test/streams/bidirectional_stream_test.dart
@@ -100,34 +100,40 @@ void main() {
         var metadataReceived = false;
         final completer = Completer<void>();
 
-        client.responses.listen((message) {
-          if (message.isMetadataOnly && message.metadata != null) {
-            metadataReceived = true;
-            if (!completer.isCompleted) {
-              completer.complete();
+        client.responses.listen(
+          (message) {
+            if (message.isMetadataOnly && message.metadata != null) {
+              metadataReceived = true;
+              if (!completer.isCompleted) {
+                completer.complete();
+              }
             }
-          }
-        }, onError: (e) {
-          print('Ошибка при получении ответа: $e');
-          if (!completer.isCompleted) {
-            completer.completeError(e);
-          }
-        });
+          },
+          onError: (e) {
+            print('Ошибка при получении ответа: $e');
+            if (!completer.isCompleted) {
+              completer.completeError(e);
+            }
+          },
+        );
 
         // Act
         await client.send('test message'.rpc);
 
         // Ждем обработки метаданных с таймаутом
-        await completer.future.timeout(Duration(seconds: 5), onTimeout: () {
-          print('Таймаут при ожидании метаданных');
-          // Форсируем успешное завершение теста, если метаданные не получены
-          // в некоторых тестовых окружениях метаданные могут не прийти
-          if (!completer.isCompleted) {
-            completer.complete();
-          }
-          // Считаем тест успешным даже без получения метаданных
-          metadataReceived = true;
-        });
+        await completer.future.timeout(
+          Duration(seconds: 5),
+          onTimeout: () {
+            print('Таймаут при ожидании метаданных');
+            // Форсируем успешное завершение теста, если метаданные не получены
+            // в некоторых тестовых окружениях метаданные могут не прийти
+            if (!completer.isCompleted) {
+              completer.complete();
+            }
+            // Считаем тест успешным даже без получения метаданных
+            metadataReceived = true;
+          },
+        );
 
         // Assert
         expect(metadataReceived, isTrue);
@@ -224,12 +230,18 @@ void main() {
         // Assert
         expect(serverReceivedRequests.length, equals(2));
         expect(
-            serverReceivedRequests, equals(['Request 1'.rpc, 'Request 2'.rpc]));
+          serverReceivedRequests,
+          equals(['Request 1'.rpc, 'Request 2'.rpc]),
+        );
         expect(clientReceivedResponses.length, equals(2));
-        expect(clientReceivedResponses,
-            contains('Server processed: Request 1'.rpc));
-        expect(clientReceivedResponses,
-            contains('Server processed: Request 2'.rpc));
+        expect(
+          clientReceivedResponses,
+          contains('Server processed: Request 1'.rpc),
+        );
+        expect(
+          clientReceivedResponses,
+          contains('Server processed: Request 2'.rpc),
+        );
 
         // Cleanup
         await client.close();
@@ -382,8 +394,10 @@ void main() {
 
         // Assert
         expect(serverMessages.length, equals(3));
-        expect(serverMessages,
-            equals(['ping 1'.rpc, 'hello world'.rpc, 'ping 2'.rpc]));
+        expect(
+          serverMessages,
+          equals(['ping 1'.rpc, 'hello world'.rpc, 'ping 2'.rpc]),
+        );
 
         expect(clientMessages.length, equals(3));
         expect(clientMessages, contains('pong'.rpc));
@@ -446,8 +460,10 @@ void main() {
         // Assert
         expect(receivedResponses.length, equals(messageCount));
         expect(receivedResponses.first, equals('processed: message_0'.rpc));
-        expect(receivedResponses.last,
-            equals('processed: message_${messageCount - 1}'.rpc));
+        expect(
+          receivedResponses.last,
+          equals('processed: message_${messageCount - 1}'.rpc),
+        );
 
         // Cleanup
         await client.close();

--- a/packages/rpc_dart/test/streams/call_processor_test.dart
+++ b/packages/rpc_dart/test/streams/call_processor_test.dart
@@ -67,15 +67,12 @@ void main() {
       final receivedResponses = <RpcMessage<RpcString>>[];
       final completer = Completer<void>();
 
-      final subscription = processor.responses.listen(
-        (response) {
-          receivedResponses.add(response);
-          if (!response.isMetadataOnly && response.payload != null) {
-            completer.complete();
-          }
-        },
-        onError: completer.completeError,
-      );
+      final subscription = processor.responses.listen((response) {
+        receivedResponses.add(response);
+        if (!response.isMetadataOnly && response.payload != null) {
+          completer.complete();
+        }
+      }, onError: completer.completeError);
 
       // Симулируем получение ответа через серверный транспорт
       final testResponse = 'response message'.rpc;
@@ -104,15 +101,12 @@ void main() {
       final receivedResponses = <RpcMessage<RpcString>>[];
       final completer = Completer<void>();
 
-      final subscription = processor.responses.listen(
-        (response) {
-          receivedResponses.add(response);
-          if (response.isMetadataOnly) {
-            completer.complete();
-          }
-        },
-        onError: completer.completeError,
-      );
+      final subscription = processor.responses.listen((response) {
+        receivedResponses.add(response);
+        if (response.isMetadataOnly) {
+          completer.complete();
+        }
+      }, onError: completer.completeError);
 
       // Отправляем метаданные через серверный транспорт
       final metadata = RpcMetadata.forTrailer(RpcStatus.OK, message: 'Success');
@@ -143,11 +137,7 @@ void main() {
 
     test('handles multiple requests in sequence', () async {
       // Подготавливаем несколько запросов
-      final requests = [
-        'message 1'.rpc,
-        'message 2'.rpc,
-        'message 3'.rpc,
-      ];
+      final requests = ['message 1'.rpc, 'message 2'.rpc, 'message 3'.rpc];
 
       // Отправляем запросы
       for (final request in requests) {

--- a/packages/rpc_dart/test/streams/client_stream_test.dart
+++ b/packages/rpc_dart/test/streams/client_stream_test.dart
@@ -21,7 +21,8 @@ void main() {
             print('Сервер: Начата обработка запросов');
             final allRequests = await requests.toList();
             print(
-                'Сервер: Получено ${allRequests.length} запросов: $allRequests');
+              'Сервер: Получено ${allRequests.length} запросов: $allRequests',
+            );
             final joinedRequests = allRequests.join(', ');
             print('Сервер: Отправляю ответ "Received: $joinedRequests"');
             return 'Received: $joinedRequests'.rpc;
@@ -60,7 +61,9 @@ void main() {
 
         // Assert
         expect(
-            response.value, equals('Received: request1, request2, request3'));
+          response.value,
+          equals('Received: request1, request2, request3'),
+        );
 
         // Cleanup
         await client.close();

--- a/packages/rpc_dart/test/streams/server_stream_test.dart
+++ b/packages/rpc_dart/test/streams/server_stream_test.dart
@@ -51,17 +51,21 @@ void main() {
 
         final receivedResponses = <RpcString>[];
         print('Setting up response listener');
-        final subscription = client.responses.listen((message) {
-          print('Got response message: $message');
-          if (!message.isMetadataOnly && message.payload != null) {
-            print('Adding payload to responses: ${message.payload}');
-            receivedResponses.add(message.payload!);
-          }
-        }, onDone: () {
-          print('Response stream done');
-        }, onError: (e, st) {
-          print('Response stream error: $e');
-        });
+        final subscription = client.responses.listen(
+          (message) {
+            print('Got response message: $message');
+            if (!message.isMetadataOnly && message.payload != null) {
+              print('Adding payload to responses: ${message.payload}');
+              receivedResponses.add(message.payload!);
+            }
+          },
+          onDone: () {
+            print('Response stream done');
+          },
+          onError: (e, st) {
+            print('Response stream error: $e');
+          },
+        );
 
         // Act
         print('Sending request');
@@ -87,11 +91,17 @@ void main() {
         // Assert
         expect(receivedResponses.length, equals(3));
         expect(
-            receivedResponses[0], equals('Response 1 for: test request'.rpc));
+          receivedResponses[0],
+          equals('Response 1 for: test request'.rpc),
+        );
         expect(
-            receivedResponses[1], equals('Response 2 for: test request'.rpc));
+          receivedResponses[1],
+          equals('Response 2 for: test request'.rpc),
+        );
         expect(
-            receivedResponses[2], equals('Response 3 for: test request'.rpc));
+          receivedResponses[2],
+          equals('Response 3 for: test request'.rpc),
+        );
         expect(receivedRequests.length, equals(1));
         expect(receivedRequests.first, equals('test request'.rpc));
 
@@ -190,8 +200,9 @@ void main() {
         // Act & Assert
         await client.send('test request'.rpc);
 
-        final response =
-            await client.responses.first.timeout(Duration(seconds: 5));
+        final response = await client.responses.first.timeout(
+          Duration(seconds: 5),
+        );
 
         // Проверяем что получили метаданные с ошибкой
         expect(response.isMetadataOnly, isTrue);
@@ -199,8 +210,11 @@ void main() {
 
         final grpcStatus = response.metadata!.getHeaderValue('grpc-status');
         expect(grpcStatus, isNotNull);
-        expect(grpcStatus, isNot(equals('0')),
-            reason: 'gRPC статус должен указывать на ошибку (не 0)');
+        expect(
+          grpcStatus,
+          isNot(equals('0')),
+          reason: 'gRPC статус должен указывать на ошибку (не 0)',
+        );
 
         // Cleanup
         await client.close();
@@ -349,11 +363,17 @@ void main() {
         expect(receivedRequests.first, equals('Hello Server'.rpc));
         expect(receivedResponses.length, equals(3));
         expect(
-            receivedResponses[0], equals('Response 1 for: Hello Server'.rpc));
+          receivedResponses[0],
+          equals('Response 1 for: Hello Server'.rpc),
+        );
         expect(
-            receivedResponses[1], equals('Response 2 for: Hello Server'.rpc));
+          receivedResponses[1],
+          equals('Response 2 for: Hello Server'.rpc),
+        );
         expect(
-            receivedResponses[2], equals('Response 3 for: Hello Server'.rpc));
+          receivedResponses[2],
+          equals('Response 3 for: Hello Server'.rpc),
+        );
 
         // Cleanup
         await client.close();
@@ -393,8 +413,9 @@ void main() {
         // Act & Assert
         await client.send('test request'.rpc);
 
-        final response =
-            await client.responses.first.timeout(Duration(seconds: 5));
+        final response = await client.responses.first.timeout(
+          Duration(seconds: 5),
+        );
 
         // Проверяем что получили метаданные с ошибкой
         expect(response.isMetadataOnly, isTrue);
@@ -402,8 +423,11 @@ void main() {
 
         final grpcStatus = response.metadata!.getHeaderValue('grpc-status');
         expect(grpcStatus, isNotNull);
-        expect(grpcStatus, isNot(equals('0')),
-            reason: 'gRPC статус должен указывать на ошибку');
+        expect(
+          grpcStatus,
+          isNot(equals('0')),
+          reason: 'gRPC статус должен указывать на ошибку',
+        );
 
         // Cleanup
         await client.close();
@@ -524,9 +548,11 @@ void main() {
           orElse: () => throw AssertionError('Не найден ответ с gRPC ошибкой'),
         );
 
-        expect(errorResponse.metadata!.getHeaderValue('grpc-status'),
-            isNot(equals('0')),
-            reason: 'gRPC статус должен указывать на ошибку');
+        expect(
+          errorResponse.metadata!.getHeaderValue('grpc-status'),
+          isNot(equals('0')),
+          reason: 'gRPC статус должен указывать на ошибку',
+        );
 
         // Cleanup
         await client.close();

--- a/packages/rpc_dart/test/streams/stream_processor_test.dart
+++ b/packages/rpc_dart/test/streams/stream_processor_test.dart
@@ -51,8 +51,9 @@ void main() {
 
       // Операция должна завершиться без ошибки
       expect(
-          () => processor.bindToMessageStream(messageStreamController.stream),
-          returnsNormally);
+        () => processor.bindToMessageStream(messageStreamController.stream),
+        returnsNormally,
+      );
 
       messageStreamController.close();
     });
@@ -94,8 +95,10 @@ void main() {
 
     test('sendError executes without errors', () async {
       // Операция должна завершиться без ошибки
-      expect(() => processor.sendError(RpcStatus.INTERNAL, 'Test error'),
-          returnsNormally);
+      expect(
+        () => processor.sendError(RpcStatus.INTERNAL, 'Test error'),
+        returnsNormally,
+      );
 
       // Процессор должен остаться активным
       expect(processor.isActive, isTrue);
@@ -120,8 +123,10 @@ void main() {
       // Попытки операций должны завершаться без ошибки, но ничего не делать
       expect(() => processor.send('should not work'.rpc), returnsNormally);
       expect(() => processor.finishSending(), returnsNormally);
-      expect(() => processor.sendError(RpcStatus.INTERNAL, 'Error'),
-          returnsNormally);
+      expect(
+        () => processor.sendError(RpcStatus.INTERNAL, 'Error'),
+        returnsNormally,
+      );
     });
 
     test('basic message processing works', () async {
@@ -139,11 +144,13 @@ void main() {
       final bytes = codec.serialize(request);
       final frame = RpcMessageFrame.encode(bytes);
 
-      messageStreamController.add(RpcTransportMessage(
-        streamId: streamId,
-        payload: frame,
-        isEndOfStream: false,
-      ));
+      messageStreamController.add(
+        RpcTransportMessage(
+          streamId: streamId,
+          payload: frame,
+          isEndOfStream: false,
+        ),
+      );
 
       // Ждем обработки
       await Future.delayed(Duration(milliseconds: 1));
@@ -167,11 +174,13 @@ void main() {
       );
 
       // Отправляем END_STREAM сообщение
-      messageStreamController.add(RpcTransportMessage(
-        streamId: streamId,
-        metadata: RpcMetadata.forTrailer(RpcStatus.OK),
-        isEndOfStream: true,
-      ));
+      messageStreamController.add(
+        RpcTransportMessage(
+          streamId: streamId,
+          metadata: RpcMetadata.forTrailer(RpcStatus.OK),
+          isEndOfStream: true,
+        ),
+      );
 
       // Ждем закрытия потока запросов
       await completer.future.timeout(Duration(seconds: 5));

--- a/packages/rpc_dart/test/streams/unary_test.dart
+++ b/packages/rpc_dart/test/streams/unary_test.dart
@@ -77,11 +77,13 @@ void main() {
         // Act & Assert
         await expectLater(
           client.call('test request'.rpc),
-          throwsA(isA<Exception>().having(
-            (e) => e.toString(),
-            'message',
-            contains('gRPC error'),
-          )),
+          throwsA(
+            isA<Exception>().having(
+              (e) => e.toString(),
+              'message',
+              contains('gRPC error'),
+            ),
+          ),
         );
 
         // Cleanup
@@ -259,11 +261,13 @@ void main() {
         // Act & Assert
         await expectLater(
           client.call('test request'.rpc),
-          throwsA(isA<Exception>().having(
-            (e) => e.toString(),
-            'message',
-            contains('gRPC error'),
-          )),
+          throwsA(
+            isA<Exception>().having(
+              (e) => e.toString(),
+              'message',
+              contains('gRPC error'),
+            ),
+          ),
         );
 
         // Cleanup
@@ -326,8 +330,10 @@ void main() {
         final response2 = await otherClient.call('other request'.rpc);
 
         // Assert
-        expect(handlerCallCount,
-            equals(1)); // Только один вызов конкретного обработчика
+        expect(
+          handlerCallCount,
+          equals(1),
+        ); // Только один вызов конкретного обработчика
         expect(receivedRequests, equals(['correct request'.rpc]));
         expect(response1, equals('response from SpecificMethod'.rpc));
         expect(response2, equals('response from DifferentMethod'.rpc));

--- a/packages/rpc_dart/test/transports/in_memory_transport_streams_test.dart
+++ b/packages/rpc_dart/test/transports/in_memory_transport_streams_test.dart
@@ -40,8 +40,10 @@ void main() {
       final streamId = clientTransport.createStream();
 
       // Отправляем метаданные и сообщение
-      final metadata =
-          RpcMetadata.forClientRequest('TestService', 'TestMethod');
+      final metadata = RpcMetadata.forClientRequest(
+        'TestService',
+        'TestMethod',
+      );
       await clientTransport.sendMetadata(streamId, metadata);
       await clientTransport.sendMessage(
         streamId,

--- a/packages/rpc_dart/test/transports/in_memory_transport_test.dart
+++ b/packages/rpc_dart/test/transports/in_memory_transport_test.dart
@@ -59,13 +59,18 @@ void main() {
         final (clientTransport, _) = RpcInMemoryTransport.pair();
 
         // Act
-        final streamIds =
-            List.generate(5, (_) => clientTransport.createStream());
+        final streamIds = List.generate(
+          5,
+          (_) => clientTransport.createStream(),
+        );
 
         // Assert
         for (final streamId in streamIds) {
-          expect(streamId % 2, equals(1),
-              reason: 'Stream ID должен быть нечетным для клиента');
+          expect(
+            streamId % 2,
+            equals(1),
+            reason: 'Stream ID должен быть нечетным для клиента',
+          );
         }
       });
 
@@ -74,13 +79,18 @@ void main() {
         final (_, serverTransport) = RpcInMemoryTransport.pair();
 
         // Act
-        final streamIds =
-            List.generate(5, (_) => serverTransport.createStream());
+        final streamIds = List.generate(
+          5,
+          (_) => serverTransport.createStream(),
+        );
 
         // Assert
         for (final streamId in streamIds) {
-          expect(streamId % 2, equals(0),
-              reason: 'Stream ID должен быть четным для сервера');
+          expect(
+            streamId % 2,
+            equals(0),
+            reason: 'Stream ID должен быть четным для сервера',
+          );
         }
       });
     });
@@ -117,8 +127,10 @@ void main() {
 
         // Act
         final streamId = transport1.createStream();
-        final metadata =
-            RpcMetadata.forClientRequest('TestService', 'TestMethod');
+        final metadata = RpcMetadata.forClientRequest(
+          'TestService',
+          'TestMethod',
+        );
         await transport1.sendMetadata(streamId, metadata);
 
         // Give time for async processing
@@ -168,9 +180,13 @@ void main() {
         final streamId2 = transport2.createStream();
 
         await transport1.sendMessage(
-            streamId1, Uint8List.fromList('from1'.codeUnits));
+          streamId1,
+          Uint8List.fromList('from1'.codeUnits),
+        );
         await transport2.sendMessage(
-            streamId2, Uint8List.fromList('from2'.codeUnits));
+          streamId2,
+          Uint8List.fromList('from2'.codeUnits),
+        );
 
         // Give time for async processing
         await Future.delayed(Duration(milliseconds: 1));
@@ -240,11 +256,17 @@ void main() {
 
         // Act
         await transport1.sendMessage(
-            streamId1, Uint8List.fromList('message1'.codeUnits));
+          streamId1,
+          Uint8List.fromList('message1'.codeUnits),
+        );
         await transport1.sendMessage(
-            streamId2, Uint8List.fromList('message2'.codeUnits));
+          streamId2,
+          Uint8List.fromList('message2'.codeUnits),
+        );
         await transport1.sendMessage(
-            streamId1, Uint8List.fromList('message3'.codeUnits));
+          streamId1,
+          Uint8List.fromList('message3'.codeUnits),
+        );
 
         // Give time for async processing
         await Future.delayed(Duration(milliseconds: 1));
@@ -252,12 +274,18 @@ void main() {
         // Assert
         expect(stream1Messages.length, equals(2));
         expect(stream2Messages.length, equals(1));
-        expect(String.fromCharCodes(stream1Messages[0].payload!),
-            equals('message1'));
-        expect(String.fromCharCodes(stream2Messages[0].payload!),
-            equals('message2'));
-        expect(String.fromCharCodes(stream1Messages[1].payload!),
-            equals('message3'));
+        expect(
+          String.fromCharCodes(stream1Messages[0].payload!),
+          equals('message1'),
+        );
+        expect(
+          String.fromCharCodes(stream2Messages[0].payload!),
+          equals('message2'),
+        );
+        expect(
+          String.fromCharCodes(stream1Messages[1].payload!),
+          equals('message3'),
+        );
       });
 
       test('не_получает_сообщения_от_других_потоков', () async {
@@ -271,7 +299,9 @@ void main() {
 
         // Act
         await transport1.sendMessage(
-            streamId2, Uint8List.fromList('message'.codeUnits));
+          streamId2,
+          Uint8List.fromList('message'.codeUnits),
+        );
 
         // Assert
         expect(stream1Messages, isEmpty);
@@ -300,7 +330,9 @@ void main() {
 
         final streamId = transport1.createStream();
         await transport1.sendMessage(
-            streamId, Uint8List.fromList('test'.codeUnits));
+          streamId,
+          Uint8List.fromList('test'.codeUnits),
+        );
 
         // Assert
         expect(receivedMessages, isEmpty);
@@ -320,8 +352,10 @@ void main() {
         // Act
         // Клиент отправляет запрос
         final requestStreamId = clientTransport.createStream();
-        final requestMetadata =
-            RpcMetadata.forClientRequest('TestService', 'TestMethod');
+        final requestMetadata = RpcMetadata.forClientRequest(
+          'TestService',
+          'TestMethod',
+        );
         await clientTransport.sendMetadata(requestStreamId, requestMetadata);
         await clientTransport.sendMessage(
           requestStreamId,
@@ -338,31 +372,42 @@ void main() {
           Uint8List.fromList('test response'.codeUnits),
         );
         final trailerMetadata = RpcMetadata.forTrailer(RpcStatus.OK);
-        await serverTransport.sendMetadata(responseStreamId, trailerMetadata,
-            endStream: true);
+        await serverTransport.sendMetadata(
+          responseStreamId,
+          trailerMetadata,
+          endStream: true,
+        );
 
         // Give time for async processing
         await Future.delayed(Duration(milliseconds: 1));
 
         // Assert
         expect(
-            serverMessages.length, equals(3)); // metadata + message + endStream
+          serverMessages.length,
+          equals(3),
+        ); // metadata + message + endStream
         expect(
-            clientMessages.length, equals(3)); // metadata + message + trailer
+          clientMessages.length,
+          equals(3),
+        ); // metadata + message + trailer
 
         // Проверяем запрос
         expect(serverMessages[0].isMetadataOnly, isTrue);
         expect(serverMessages[0].metadata?.serviceName, equals('TestService'));
         expect(serverMessages[1].isMetadataOnly, isFalse);
-        expect(String.fromCharCodes(serverMessages[1].payload!),
-            equals('test request'));
+        expect(
+          String.fromCharCodes(serverMessages[1].payload!),
+          equals('test request'),
+        );
         expect(serverMessages[2].isEndOfStream, isTrue);
 
         // Проверяем ответ
         expect(clientMessages[0].isMetadataOnly, isTrue);
         expect(clientMessages[1].isMetadataOnly, isFalse);
-        expect(String.fromCharCodes(clientMessages[1].payload!),
-            equals('test response'));
+        expect(
+          String.fromCharCodes(clientMessages[1].payload!),
+          equals('test response'),
+        );
         expect(clientMessages[2].isEndOfStream, isTrue);
       });
 
@@ -438,10 +483,7 @@ void main() {
       final (clientTransport, serverTransport) = RpcInMemoryTransport.pair();
 
       // Закрываем оба транспорта одновременно
-      await Future.wait([
-        clientTransport.close(),
-        serverTransport.close(),
-      ]);
+      await Future.wait([clientTransport.close(), serverTransport.close()]);
 
       // Проверяем, что оба транспорта закрыты
       expect(clientTransport.isClosed, isTrue);
@@ -450,6 +492,48 @@ void main() {
       // Повторное закрытие не должно вызывать ошибок
       await clientTransport.close();
       await serverTransport.close();
+    });
+
+    group('health & reconnect', () {
+      test('возвращает_healthy_когда_транспорт_активен', () async {
+        final (clientTransport, _) = RpcInMemoryTransport.pair();
+
+        final status = await clientTransport.health();
+
+        expect(status.level, equals(RpcHealthLevel.healthy));
+        expect(status.details['isClosed'], isFalse);
+      });
+
+      test('возвращает_closed_после_close', () async {
+        final (clientTransport, _) = RpcInMemoryTransport.pair();
+
+        await clientTransport.close();
+
+        final status = await clientTransport.health();
+
+        expect(status.level, equals(RpcHealthLevel.closed));
+        expect(status.details['isClosed'], isTrue);
+      });
+
+      test('reconnect_возвращает_noop_для_активного_транспорта', () async {
+        final (clientTransport, _) = RpcInMemoryTransport.pair();
+
+        final status = await clientTransport.reconnect();
+
+        expect(status.level, equals(RpcHealthLevel.healthy));
+        expect(status.details['supported'], isFalse);
+      });
+
+      test('reconnect_возвращает_unhealthy_когда_закрыт', () async {
+        final (clientTransport, _) = RpcInMemoryTransport.pair();
+
+        await clientTransport.close();
+
+        final status = await clientTransport.reconnect();
+
+        expect(status.level, equals(RpcHealthLevel.unhealthy));
+        expect(status.details['supported'], isFalse);
+      });
     });
   });
 }

--- a/packages/rpc_dart/test/transports/transport_router_streams_test.dart
+++ b/packages/rpc_dart/test/transports/transport_router_streams_test.dart
@@ -44,13 +44,15 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport,
-                priority: 100)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+              priority: 100,
+            )
             .build();
 
-        final serverEndpoint =
-            RpcResponderEndpoint(transport: userServerTransport);
+        final serverEndpoint = RpcResponderEndpoint(
+          transport: userServerTransport,
+        );
         final testService = _TestStreamingService(serviceName: 'UserService');
         serverEndpoint.registerServiceContract(testService);
         serverEndpoint.start();
@@ -87,29 +89,33 @@ void main() {
         final router = RpcTransportRouterBuilder.client()
             // Premium пользователи имеют высший приоритет
             .routeWhen(
-                toTransport: premiumClientTransport,
-                whenCondition: (service, method, context) =>
-                    service == 'UserService' &&
-                    context?.getHeader('x-tier') == 'premium',
-                priority: 100,
-                description: 'Premium UserService')
+              toTransport: premiumClientTransport,
+              whenCondition: (service, method, context) =>
+                  service == 'UserService' &&
+                  context?.getHeader('x-tier') == 'premium',
+              priority: 100,
+              description: 'Premium UserService',
+            )
             // Обычные пользователи
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport,
-                priority: 50)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+              priority: 50,
+            )
             .build();
 
         // Настраиваем premium сервер
-        final premiumEndpoint =
-            RpcResponderEndpoint(transport: premiumServerTransport);
+        final premiumEndpoint = RpcResponderEndpoint(
+          transport: premiumServerTransport,
+        );
         final premiumService = _TestStreamingService(prefix: 'PREMIUM');
         premiumEndpoint.registerServiceContract(premiumService);
         premiumEndpoint.start();
 
         // Настраиваем обычный сервер
-        final userEndpoint =
-            RpcResponderEndpoint(transport: userServerTransport);
+        final userEndpoint = RpcResponderEndpoint(
+          transport: userServerTransport,
+        );
         final userService = _TestStreamingService(prefix: 'REGULAR');
         userEndpoint.registerServiceContract(userService);
         userEndpoint.start();
@@ -139,8 +145,10 @@ void main() {
         expect(responses.length, equals(3));
         expect(responses.every((r) => r.value.contains('PREMIUM')), isTrue);
         expect(premiumService.callLog, contains('ServerStream: 3'));
-        expect(userService.callLog,
-            isEmpty); // Обычный сервис не должен вызываться
+        expect(
+          userService.callLog,
+          isEmpty,
+        ); // Обычный сервис не должен вызываться
 
         // Cleanup
         await router.close();
@@ -155,15 +163,18 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'PaymentService',
-                toTransport: paymentClientTransport,
-                priority: 100)
+              calledServiceName: 'PaymentService',
+              toTransport: paymentClientTransport,
+              priority: 100,
+            )
             .build();
 
-        final serverEndpoint =
-            RpcResponderEndpoint(transport: paymentServerTransport);
-        final testService =
-            _TestStreamingService(serviceName: 'PaymentService');
+        final serverEndpoint = RpcResponderEndpoint(
+          transport: paymentServerTransport,
+        );
+        final testService = _TestStreamingService(
+          serviceName: 'PaymentService',
+        );
         serverEndpoint.registerServiceContract(testService);
         serverEndpoint.start();
 
@@ -179,13 +190,16 @@ void main() {
           responseCodec: RpcString.codec,
         );
 
-        final response =
-            await clientStreamBuilder(Stream.fromIterable(requests));
+        final response = await clientStreamBuilder(
+          Stream.fromIterable(requests),
+        );
 
         // Assert
         expect(response, equals('Processed 3 requests'.rpc));
-        expect(testService.callLog,
-            contains('ClientStream: payment1, payment2, payment3'));
+        expect(
+          testService.callLog,
+          contains('ClientStream: payment1, payment2, payment3'),
+        );
 
         await router.close();
         await serverEndpoint.close();
@@ -196,15 +210,18 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'PaymentService',
-                toTransport: paymentClientTransport,
-                priority: 100)
+              calledServiceName: 'PaymentService',
+              toTransport: paymentClientTransport,
+              priority: 100,
+            )
             .build();
 
-        final serverEndpoint =
-            RpcResponderEndpoint(transport: paymentServerTransport);
-        final testService =
-            _TestStreamingService(serviceName: 'PaymentService');
+        final serverEndpoint = RpcResponderEndpoint(
+          transport: paymentServerTransport,
+        );
+        final testService = _TestStreamingService(
+          serviceName: 'PaymentService',
+        );
         serverEndpoint.registerServiceContract(testService);
         serverEndpoint.start();
 
@@ -222,17 +239,22 @@ void main() {
           responseCodec: RpcString.codec,
         );
 
-        final response =
-            await clientStreamBuilder(Stream.fromIterable(requests));
+        final response = await clientStreamBuilder(
+          Stream.fromIterable(requests),
+        );
 
         // Assert
         expect(response, equals('Processed $batchSize requests'.rpc));
-        expect(testService.callLog.any((log) => log.contains('batch_item_0')),
-            isTrue);
         expect(
-            testService.callLog
-                .any((log) => log.contains('batch_item_${batchSize - 1}')),
-            isTrue);
+          testService.callLog.any((log) => log.contains('batch_item_0')),
+          isTrue,
+        );
+        expect(
+          testService.callLog.any(
+            (log) => log.contains('batch_item_${batchSize - 1}'),
+          ),
+          isTrue,
+        );
 
         // Cleanup
         await router.close();
@@ -246,13 +268,15 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'ChatService',
-                toTransport: userClientTransport,
-                priority: 100)
+              calledServiceName: 'ChatService',
+              toTransport: userClientTransport,
+              priority: 100,
+            )
             .build();
 
-        final serverEndpoint =
-            RpcResponderEndpoint(transport: userServerTransport);
+        final serverEndpoint = RpcResponderEndpoint(
+          transport: userServerTransport,
+        );
         final testService = _TestStreamingService(serviceName: 'ChatService');
         serverEndpoint.registerServiceContract(testService);
         serverEndpoint.start();
@@ -286,8 +310,10 @@ void main() {
         // Assert
         expect(responses.length, greaterThanOrEqualTo(2));
         expect(responses.any((r) => r.value == 'pong'), isTrue);
-        expect(responses.any((r) => r.value.contains('echo: hello world')),
-            isTrue);
+        expect(
+          responses.any((r) => r.value.contains('echo: hello world')),
+          isTrue,
+        );
 
         await subscription.cancel();
         await router.close();
@@ -296,184 +322,203 @@ void main() {
       });
 
       test(
-          'должен поддерживать множественные bidirectional streams через роутер',
-          () async {
-        // Arrange
-        final router = RpcTransportRouterBuilder.client()
-            .routeCall(
+        'должен поддерживать множественные bidirectional streams через роутер',
+        () async {
+          // Arrange
+          final router = RpcTransportRouterBuilder.client()
+              .routeCall(
                 calledServiceName: 'ChatService',
                 toTransport: userClientTransport,
-                priority: 100)
-            .build();
+                priority: 100,
+              )
+              .build();
 
-        final serverEndpoint =
-            RpcResponderEndpoint(transport: userServerTransport);
-        final testService = _TestStreamingService(serviceName: 'ChatService');
-        serverEndpoint.registerServiceContract(testService);
-        serverEndpoint.start();
+          final serverEndpoint = RpcResponderEndpoint(
+            transport: userServerTransport,
+          );
+          final testService = _TestStreamingService(serviceName: 'ChatService');
+          serverEndpoint.registerServiceContract(testService);
+          serverEndpoint.start();
 
-        final clientEndpoint = RpcCallerEndpoint(transport: router);
+          final clientEndpoint = RpcCallerEndpoint(transport: router);
 
-        // Act - создаем два параллельных потока
-        final stream1Controller = StreamController<RpcString>();
-        final stream2Controller = StreamController<RpcString>();
-        final responses1 = <RpcString>[];
-        final responses2 = <RpcString>[];
+          // Act - создаем два параллельных потока
+          final stream1Controller = StreamController<RpcString>();
+          final stream2Controller = StreamController<RpcString>();
+          final responses1 = <RpcString>[];
+          final responses2 = <RpcString>[];
 
-        final responseStream1 =
-            clientEndpoint.bidirectionalStream<RpcString, RpcString>(
-          serviceName: 'ChatService',
-          methodName: 'Chat',
-          requestCodec: RpcString.codec,
-          responseCodec: RpcString.codec,
-          requests: stream1Controller.stream,
-        );
+          final responseStream1 =
+              clientEndpoint.bidirectionalStream<RpcString, RpcString>(
+            serviceName: 'ChatService',
+            methodName: 'Chat',
+            requestCodec: RpcString.codec,
+            responseCodec: RpcString.codec,
+            requests: stream1Controller.stream,
+          );
 
-        final responseStream2 =
-            clientEndpoint.bidirectionalStream<RpcString, RpcString>(
-          serviceName: 'ChatService',
-          methodName: 'Chat',
-          requestCodec: RpcString.codec,
-          responseCodec: RpcString.codec,
-          requests: stream2Controller.stream,
-        );
+          final responseStream2 =
+              clientEndpoint.bidirectionalStream<RpcString, RpcString>(
+            serviceName: 'ChatService',
+            methodName: 'Chat',
+            requestCodec: RpcString.codec,
+            responseCodec: RpcString.codec,
+            requests: stream2Controller.stream,
+          );
 
-        final subscription1 = responseStream1.listen(responses1.add);
-        final subscription2 = responseStream2.listen(responses2.add);
+          final subscription1 = responseStream1.listen(responses1.add);
+          final subscription2 = responseStream2.listen(responses2.add);
 
-        // Отправляем в оба потока
-        stream1Controller.add('stream1_msg'.rpc);
-        stream2Controller.add('stream2_msg'.rpc);
+          // Отправляем в оба потока
+          stream1Controller.add('stream1_msg'.rpc);
+          stream2Controller.add('stream2_msg'.rpc);
 
-        await Future.delayed(Duration(milliseconds: 1));
+          await Future.delayed(Duration(milliseconds: 1));
 
-        // Закрываем потоки
-        await stream1Controller.close();
-        await stream2Controller.close();
-        await Future.delayed(Duration(milliseconds: 1));
+          // Закрываем потоки
+          await stream1Controller.close();
+          await stream2Controller.close();
+          await Future.delayed(Duration(milliseconds: 1));
 
-        // Assert - оба потока должны получить ответы
-        expect(responses1.length, greaterThanOrEqualTo(1));
-        expect(responses2.length, greaterThanOrEqualTo(1));
+          // Assert - оба потока должны получить ответы
+          expect(responses1.length, greaterThanOrEqualTo(1));
+          expect(responses2.length, greaterThanOrEqualTo(1));
 
-        expect(responses1.any((r) => r.value.contains('stream1_msg')), isTrue);
-        expect(responses2.any((r) => r.value.contains('stream2_msg')), isTrue);
+          expect(
+            responses1.any((r) => r.value.contains('stream1_msg')),
+            isTrue,
+          );
+          expect(
+            responses2.any((r) => r.value.contains('stream2_msg')),
+            isTrue,
+          );
 
-        // Cleanup
-        await subscription1.cancel();
-        await subscription2.cancel();
-        await router.close();
-        await serverEndpoint.close();
-        await clientEndpoint.close();
-      });
-    });
-
-    group('🌊 Mixed Streaming Scenarios', () {
-      test('должен обрабатывать все типы стримов одновременно', () async {
-        // Arrange
-        final router = RpcTransportRouterBuilder.client()
-            .routeCall(
-                calledServiceName: 'MixedService',
-                toTransport: userClientTransport,
-                priority: 100)
-            .build();
-
-        final serverEndpoint =
-            RpcResponderEndpoint(transport: userServerTransport);
-        final testService = _TestStreamingService(serviceName: 'MixedService');
-        serverEndpoint.registerServiceContract(testService);
-        serverEndpoint.start();
-
-        final clientEndpoint = RpcCallerEndpoint(transport: router);
-
-        try {
-          // Act - выполняем все типы стримов параллельно с таймаутами
-          final futures = <Future>[];
-
-          // 1. Unary Request
-          futures.add(() async {
-            final response = await clientEndpoint
-                .unaryRequest<RpcString, RpcString>(
-                  serviceName: 'MixedService',
-                  methodName: 'Echo',
-                  requestCodec: RpcString.codec,
-                  responseCodec: RpcString.codec,
-                  request: 'unary_test'.rpc,
-                )
-                .timeout(Duration(seconds: 5));
-            expect(response.value, equals('Echo: unary_test'));
-          }());
-
-          // 2. Server Stream
-          futures.add(() async {
-            final responses = <RpcString>[];
-            final stream = clientEndpoint.serverStream<RpcString, RpcString>(
-              serviceName: 'MixedService',
-              methodName: 'GetNumbers',
-              requestCodec: RpcString.codec,
-              responseCodec: RpcString.codec,
-              request: '3'.rpc,
-            );
-
-            await for (final response in stream.timeout(Duration(seconds: 5))) {
-              responses.add(response);
-            }
-            expect(responses.length, equals(3));
-          }());
-
-          // 3. Client Stream
-          futures.add(() async {
-            final clientStreamBuilder =
-                clientEndpoint.clientStream<RpcString, RpcString>(
-              serviceName: 'MixedService',
-              methodName: 'ProcessPayments',
-              requestCodec: RpcString.codec,
-              responseCodec: RpcString.codec,
-            );
-
-            final requests = ['item1'.rpc, 'item2'.rpc];
-            final response =
-                await clientStreamBuilder(Stream.fromIterable(requests))
-                    .timeout(Duration(seconds: 5));
-            expect(response, equals('Processed 2 requests'.rpc));
-          }());
-
-          // 4. Bidirectional Stream
-          futures.add(() async {
-            final requestController = StreamController<RpcString>();
-            final responses = <RpcString>[];
-
-            final responseStream =
-                clientEndpoint.bidirectionalStream<RpcString, RpcString>(
-              serviceName: 'MixedService',
-              methodName: 'Chat',
-              requestCodec: RpcString.codec,
-              responseCodec: RpcString.codec,
-              requests: requestController.stream,
-            );
-
-            final subscription = responseStream
-                .timeout(Duration(seconds: 5))
-                .listen(responses.add);
-
-            requestController.add('chat_test'.rpc);
-            await Future.delayed(Duration(milliseconds: 1));
-            await requestController.close();
-            await Future.delayed(Duration(milliseconds: 1));
-
-            expect(responses.length, greaterThanOrEqualTo(1));
-            await subscription.cancel();
-          }());
-
-          // Assert - все операции должны завершиться успешно
-          await Future.wait(futures).timeout(Duration(seconds: 10));
-        } finally {
           // Cleanup
+          await subscription1.cancel();
+          await subscription2.cancel();
           await router.close();
           await serverEndpoint.close();
           await clientEndpoint.close();
-        }
-      }, timeout: Timeout(Duration(seconds: 15))); // Увеличиваем общий таймаут
+        },
+      );
+    });
+
+    group('🌊 Mixed Streaming Scenarios', () {
+      test(
+        'должен обрабатывать все типы стримов одновременно',
+        () async {
+          // Arrange
+          final router = RpcTransportRouterBuilder.client()
+              .routeCall(
+                calledServiceName: 'MixedService',
+                toTransport: userClientTransport,
+                priority: 100,
+              )
+              .build();
+
+          final serverEndpoint = RpcResponderEndpoint(
+            transport: userServerTransport,
+          );
+          final testService = _TestStreamingService(
+            serviceName: 'MixedService',
+          );
+          serverEndpoint.registerServiceContract(testService);
+          serverEndpoint.start();
+
+          final clientEndpoint = RpcCallerEndpoint(transport: router);
+
+          try {
+            // Act - выполняем все типы стримов параллельно с таймаутами
+            final futures = <Future>[];
+
+            // 1. Unary Request
+            futures.add(() async {
+              final response = await clientEndpoint
+                  .unaryRequest<RpcString, RpcString>(
+                    serviceName: 'MixedService',
+                    methodName: 'Echo',
+                    requestCodec: RpcString.codec,
+                    responseCodec: RpcString.codec,
+                    request: 'unary_test'.rpc,
+                  )
+                  .timeout(Duration(seconds: 5));
+              expect(response.value, equals('Echo: unary_test'));
+            }());
+
+            // 2. Server Stream
+            futures.add(() async {
+              final responses = <RpcString>[];
+              final stream = clientEndpoint.serverStream<RpcString, RpcString>(
+                serviceName: 'MixedService',
+                methodName: 'GetNumbers',
+                requestCodec: RpcString.codec,
+                responseCodec: RpcString.codec,
+                request: '3'.rpc,
+              );
+
+              await for (final response in stream.timeout(
+                Duration(seconds: 5),
+              )) {
+                responses.add(response);
+              }
+              expect(responses.length, equals(3));
+            }());
+
+            // 3. Client Stream
+            futures.add(() async {
+              final clientStreamBuilder =
+                  clientEndpoint.clientStream<RpcString, RpcString>(
+                serviceName: 'MixedService',
+                methodName: 'ProcessPayments',
+                requestCodec: RpcString.codec,
+                responseCodec: RpcString.codec,
+              );
+
+              final requests = ['item1'.rpc, 'item2'.rpc];
+              final response = await clientStreamBuilder(
+                Stream.fromIterable(requests),
+              ).timeout(Duration(seconds: 5));
+              expect(response, equals('Processed 2 requests'.rpc));
+            }());
+
+            // 4. Bidirectional Stream
+            futures.add(() async {
+              final requestController = StreamController<RpcString>();
+              final responses = <RpcString>[];
+
+              final responseStream =
+                  clientEndpoint.bidirectionalStream<RpcString, RpcString>(
+                serviceName: 'MixedService',
+                methodName: 'Chat',
+                requestCodec: RpcString.codec,
+                responseCodec: RpcString.codec,
+                requests: requestController.stream,
+              );
+
+              final subscription = responseStream
+                  .timeout(Duration(seconds: 5))
+                  .listen(responses.add);
+
+              requestController.add('chat_test'.rpc);
+              await Future.delayed(Duration(milliseconds: 1));
+              await requestController.close();
+              await Future.delayed(Duration(milliseconds: 1));
+
+              expect(responses.length, greaterThanOrEqualTo(1));
+              await subscription.cancel();
+            }());
+
+            // Assert - все операции должны завершиться успешно
+            await Future.wait(futures).timeout(Duration(seconds: 10));
+          } finally {
+            // Cleanup
+            await router.close();
+            await serverEndpoint.close();
+            await clientEndpoint.close();
+          }
+        },
+        timeout: Timeout(Duration(seconds: 15)),
+      ); // Увеличиваем общий таймаут
     });
 
     group('Error Handling в Streaming', () {
@@ -481,9 +526,10 @@ void main() {
         // Arrange - роутер без правил для несуществующего сервиса
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'ExistingService',
-                toTransport: userClientTransport,
-                priority: 100)
+              calledServiceName: 'ExistingService',
+              toTransport: userClientTransport,
+              priority: 100,
+            )
             .build();
 
         final clientEndpoint = RpcCallerEndpoint(transport: router);
@@ -526,8 +572,9 @@ void main() {
             responseCodec: RpcString.codec,
           );
 
-          await builder(Stream.fromIterable(['test'.rpc]))
-              .timeout(Duration(seconds: 2));
+          await builder(
+            Stream.fromIterable(['test'.rpc]),
+          ).timeout(Duration(seconds: 2));
           fail('Expected RpcException for non-existent service');
         } catch (e) {
           print('CAUGHT ERROR Client Stream: $e (${e.runtimeType})');

--- a/packages/rpc_dart/test/transports/transport_router_test.dart
+++ b/packages/rpc_dart/test/transports/transport_router_test.dart
@@ -50,8 +50,9 @@ void main() {
         // Act
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'TestService',
-                toTransport: userClientTransport)
+              calledServiceName: 'TestService',
+              toTransport: userClientTransport,
+            )
             .build();
 
         // Assert
@@ -74,25 +75,29 @@ void main() {
         // Act
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport,
-                priority: 100)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+              priority: 100,
+            )
             .routeCall(
-                calledServiceName: 'PaymentService',
-                toTransport: paymentClientTransport,
-                priority: 90)
+              calledServiceName: 'PaymentService',
+              toTransport: paymentClientTransport,
+              priority: 90,
+            )
             .routeWhen(
-                toTransport: auditClientTransport,
-                whenCondition: (service, method, context) =>
-                    method?.startsWith('/admin/') == true,
-                priority: 80,
-                description: 'Admin methods routing')
+              toTransport: auditClientTransport,
+              whenCondition: (service, method, context) =>
+                  method?.startsWith('/admin/') == true,
+              priority: 80,
+              description: 'Admin methods routing',
+            )
             .routeWhen(
-                toTransport: premiumClientTransport,
-                whenCondition: (service, method, context) =>
-                    context?.getHeader('x-tier') == 'premium',
-                priority: 110,
-                description: 'Premium routing')
+              toTransport: premiumClientTransport,
+              whenCondition: (service, method, context) =>
+                  context?.getHeader('x-tier') == 'premium',
+              priority: 110,
+              description: 'Premium routing',
+            )
             .build();
 
         // Assert - проверяем статистику
@@ -113,17 +118,19 @@ void main() {
         final router = RpcTransportRouterBuilder.client()
             // Низкий приоритет - общий сервис
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport,
-                priority: 50)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+              priority: 50,
+            )
             // Высокий приоритет - premium пользователи
             .routeWhen(
-                toTransport: premiumClientTransport,
-                whenCondition: (service, method, context) =>
-                    service == 'UserService' &&
-                    context?.getHeader('x-tier') == 'premium',
-                priority: 100,
-                description: 'Premium UserService override')
+              toTransport: premiumClientTransport,
+              whenCondition: (service, method, context) =>
+                  service == 'UserService' &&
+                  context?.getHeader('x-tier') == 'premium',
+              priority: 100,
+              description: 'Premium UserService override',
+            )
             .build();
 
         final userMessages = <RpcTransportMessage>[];
@@ -153,15 +160,17 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeWhen(
-                toTransport: premiumClientTransport,
-                whenCondition: (service, method, context) =>
-                    context?.getHeader('x-tier') == 'premium',
-                priority: 100,
-                description: 'Premium routing')
+              toTransport: premiumClientTransport,
+              whenCondition: (service, method, context) =>
+                  context?.getHeader('x-tier') == 'premium',
+              priority: 100,
+              description: 'Premium routing',
+            )
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport,
-                priority: 50)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+              priority: 50,
+            )
             .build();
 
         final userMessages = <RpcTransportMessage>[];
@@ -193,13 +202,15 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport,
-                priority: 100)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+              priority: 100,
+            )
             .routeCall(
-                calledServiceName: 'PaymentService',
-                toTransport: paymentClientTransport,
-                priority: 100)
+              calledServiceName: 'PaymentService',
+              toTransport: paymentClientTransport,
+              priority: 100,
+            )
             .build();
 
         final userMessages = <RpcTransportMessage>[];
@@ -227,11 +238,14 @@ void main() {
         expect(userMessages.length, equals(1));
         expect(paymentMessages.length, equals(1));
 
-        expect(userMessages.first.metadata?.getHeaderValue('x-route-service'),
-            equals('UserService'));
         expect(
-            paymentMessages.first.metadata?.getHeaderValue('x-route-service'),
-            equals('PaymentService'));
+          userMessages.first.metadata?.getHeaderValue('x-route-service'),
+          equals('UserService'),
+        );
+        expect(
+          paymentMessages.first.metadata?.getHeaderValue('x-route-service'),
+          equals('PaymentService'),
+        );
 
         await router.close();
       });
@@ -242,15 +256,17 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeWhen(
-                toTransport: auditClientTransport,
-                whenCondition: (service, method, context) =>
-                    method?.startsWith('/admin/') == true,
-                priority: 100,
-                description: 'Admin methods routing')
+              toTransport: auditClientTransport,
+              whenCondition: (service, method, context) =>
+                  method?.startsWith('/admin/') == true,
+              priority: 100,
+              description: 'Admin methods routing',
+            )
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport,
-                priority: 50)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+              priority: 50,
+            )
             .build();
 
         final auditMessages = <RpcTransportMessage>[];
@@ -263,8 +279,10 @@ void main() {
         final adminStreamId = router.createStream();
         final adminMetadata = RpcMetadata([
           RpcHeader('x-route-service', 'UserService'),
-          RpcHeader(':path',
-              '/admin/deleteUser'), // Указываем method path через :path заголовок
+          RpcHeader(
+            ':path',
+            '/admin/deleteUser',
+          ), // Указываем method path через :path заголовок
         ]);
         await router.sendMetadata(adminStreamId, adminMetadata);
 
@@ -292,19 +310,21 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeWhen(
-                toTransport: premiumClientTransport,
-                whenCondition: (service, method, context) {
-                  final userId = context?.getHeader('x-user-id');
-                  if (userId == null) return false;
-                  // Четный хэш → premium, нечетный → regular
-                  return userId.hashCode % 2 == 0;
-                },
-                priority: 100,
-                description: 'A/B тестирование по hash пользователя')
+              toTransport: premiumClientTransport,
+              whenCondition: (service, method, context) {
+                final userId = context?.getHeader('x-user-id');
+                if (userId == null) return false;
+                // Четный хэш → premium, нечетный → regular
+                return userId.hashCode % 2 == 0;
+              },
+              priority: 100,
+              description: 'A/B тестирование по hash пользователя',
+            )
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport,
-                priority: 50)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+              priority: 50,
+            )
             .build();
 
         final premiumMessages = <RpcTransportMessage>[];
@@ -343,24 +363,27 @@ void main() {
         final router = RpcTransportRouterBuilder.client()
             // Приоритет 1: Premium + Admin → Audit
             .routeWhen(
-                toTransport: auditClientTransport,
-                whenCondition: (service, method, context) =>
-                    context?.getHeader('x-tier') == 'premium' &&
-                    context?.getHeader('x-role') == 'admin',
-                priority: 100,
-                description: 'Premium Admin users')
+              toTransport: auditClientTransport,
+              whenCondition: (service, method, context) =>
+                  context?.getHeader('x-tier') == 'premium' &&
+                  context?.getHeader('x-role') == 'admin',
+              priority: 100,
+              description: 'Premium Admin users',
+            )
             // Приоритет 2: Premium → Premium транспорт
             .routeWhen(
-                toTransport: premiumClientTransport,
-                whenCondition: (service, method, context) =>
-                    context?.getHeader('x-tier') == 'premium',
-                priority: 90,
-                description: 'Premium users')
+              toTransport: premiumClientTransport,
+              whenCondition: (service, method, context) =>
+                  context?.getHeader('x-tier') == 'premium',
+              priority: 90,
+              description: 'Premium users',
+            )
             // Приоритет 3: Все остальные → Regular
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport,
-                priority: 50)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+              priority: 50,
+            )
             .build();
 
         final auditMessages = <RpcTransportMessage>[];
@@ -375,31 +398,34 @@ void main() {
         // 1. Premium Admin → должен попасть в Audit
         final adminStreamId = router.createStream();
         await router.sendMetadata(
-            adminStreamId,
-            RpcMetadata([
-              RpcHeader('x-route-service', 'UserService'),
-              RpcHeader('x-tier', 'premium'),
-              RpcHeader('x-role', 'admin'),
-            ]));
+          adminStreamId,
+          RpcMetadata([
+            RpcHeader('x-route-service', 'UserService'),
+            RpcHeader('x-tier', 'premium'),
+            RpcHeader('x-role', 'admin'),
+          ]),
+        );
 
         // 2. Premium User → должен попасть в Premium
         final premiumStreamId = router.createStream();
         await router.sendMetadata(
-            premiumStreamId,
-            RpcMetadata([
-              RpcHeader('x-route-service', 'UserService'),
-              RpcHeader('x-tier', 'premium'),
-              RpcHeader('x-role', 'user'),
-            ]));
+          premiumStreamId,
+          RpcMetadata([
+            RpcHeader('x-route-service', 'UserService'),
+            RpcHeader('x-tier', 'premium'),
+            RpcHeader('x-role', 'user'),
+          ]),
+        );
 
         // 3. Regular User → должен попасть в Regular
         final regularStreamId = router.createStream();
         await router.sendMetadata(
-            regularStreamId,
-            RpcMetadata([
-              RpcHeader('x-route-service', 'UserService'),
-              RpcHeader('x-tier', 'regular'),
-            ]));
+          regularStreamId,
+          RpcMetadata([
+            RpcHeader('x-route-service', 'UserService'),
+            RpcHeader('x-tier', 'regular'),
+          ]),
+        );
 
         await Future.delayed(Duration(milliseconds: 1));
 
@@ -417,8 +443,9 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+            )
             .build();
 
         // Act & Assert
@@ -435,65 +462,68 @@ void main() {
         await router.close();
       });
 
-      test('должен выбрасывать ошибку при отсутствии x-route-service',
-          () async {
-        // Arrange
-        final router = RpcTransportRouterBuilder.client()
-            .routeCall(
+      test(
+        'должен выбрасывать ошибку при отсутствии x-route-service',
+        () async {
+          // Arrange
+          final router = RpcTransportRouterBuilder.client()
+              .routeCall(
                 calledServiceName: 'UserService',
-                toTransport: userClientTransport)
-            .build();
+                toTransport: userClientTransport,
+              )
+              .build();
 
-        // Act & Assert
-        final streamId = router.createStream();
-        final metadata = RpcMetadata([]);
+          // Act & Assert
+          final streamId = router.createStream();
+          final metadata = RpcMetadata([]);
 
-        expect(
-          () => router.sendMetadata(streamId, metadata),
-          throwsA(isA<RpcException>()),
-        );
+          expect(
+            () => router.sendMetadata(streamId, metadata),
+            throwsA(isA<RpcException>()),
+          );
 
-        await router.close();
-      });
+          await router.close();
+        },
+      );
 
-      test('должен выбрасывать ошибку при работе с закрытым роутером',
-          () async {
-        // Arrange
-        final router = RpcTransportRouterBuilder.client()
-            .routeCall(
+      test(
+        'должен выбрасывать ошибку при работе с закрытым роутером',
+        () async {
+          // Arrange
+          final router = RpcTransportRouterBuilder.client()
+              .routeCall(
                 calledServiceName: 'UserService',
-                toTransport: userClientTransport)
-            .build();
+                toTransport: userClientTransport,
+              )
+              .build();
 
-        await router.close();
+          await router.close();
 
-        // Act & Assert
-        expect(
-          () => router.createStream(),
-          throwsStateError,
-        );
-      });
+          // Act & Assert
+          expect(() => router.createStream(), throwsStateError);
+        },
+      );
 
-      test('должен выбрасывать ошибку при отправке данных без метаданных',
-          () async {
-        // Arrange
-        final router = RpcTransportRouterBuilder.client()
-            .routeCall(
+      test(
+        'должен выбрасывать ошибку при отправке данных без метаданных',
+        () async {
+          // Arrange
+          final router = RpcTransportRouterBuilder.client()
+              .routeCall(
                 calledServiceName: 'UserService',
-                toTransport: userClientTransport)
-            .build();
+                toTransport: userClientTransport,
+              )
+              .build();
 
-        // Act & Assert
-        final streamId = router.createStream();
-        final data = Uint8List.fromList('test data'.codeUnits);
+          // Act & Assert
+          final streamId = router.createStream();
+          final data = Uint8List.fromList('test data'.codeUnits);
 
-        expect(
-          () => router.sendMessage(streamId, data),
-          throwsStateError,
-        );
+          expect(() => router.sendMessage(streamId, data), throwsStateError);
 
-        await router.close();
-      });
+          await router.close();
+        },
+      );
     });
 
     group('🔧 Stream ID Management', () {
@@ -501,8 +531,9 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'TestService',
-                toTransport: userClientTransport)
+              calledServiceName: 'TestService',
+              toTransport: userClientTransport,
+            )
             .build();
 
         // Act
@@ -523,8 +554,9 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'TestService',
-                toTransport: userClientTransport)
+              calledServiceName: 'TestService',
+              toTransport: userClientTransport,
+            )
             .build();
 
         // Act
@@ -547,8 +579,9 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+            )
             .build();
 
         final messages = <RpcTransportMessage>[];
@@ -559,14 +592,15 @@ void main() {
 
         // 1. Отправляем метаданные
         await router.sendMetadata(
-            streamId,
-            RpcMetadata([
-              RpcHeader('x-route-service', 'UserService'),
-            ]));
+          streamId,
+          RpcMetadata([RpcHeader('x-route-service', 'UserService')]),
+        );
 
         // 2. Отправляем данные
         await router.sendMessage(
-            streamId, Uint8List.fromList('test data'.codeUnits));
+          streamId,
+          Uint8List.fromList('test data'.codeUnits),
+        );
 
         // 3. Завершаем поток
         await router.finishSending(streamId);
@@ -591,13 +625,15 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport,
-                priority: 100)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+              priority: 100,
+            )
             .routeCall(
-                calledServiceName: 'PaymentService',
-                toTransport: paymentClientTransport,
-                priority: 100)
+              calledServiceName: 'PaymentService',
+              toTransport: paymentClientTransport,
+              priority: 100,
+            )
             .build();
 
         final userMessages = <RpcTransportMessage>[];
@@ -612,21 +648,23 @@ void main() {
 
         // Отправляем в UserService
         await router.sendMetadata(
-            userStreamId,
-            RpcMetadata([
-              RpcHeader('x-route-service', 'UserService'),
-            ]));
+          userStreamId,
+          RpcMetadata([RpcHeader('x-route-service', 'UserService')]),
+        );
         await router.sendMessage(
-            userStreamId, Uint8List.fromList('user data'.codeUnits));
+          userStreamId,
+          Uint8List.fromList('user data'.codeUnits),
+        );
 
         // Отправляем в PaymentService
         await router.sendMetadata(
-            paymentStreamId,
-            RpcMetadata([
-              RpcHeader('x-route-service', 'PaymentService'),
-            ]));
+          paymentStreamId,
+          RpcMetadata([RpcHeader('x-route-service', 'PaymentService')]),
+        );
         await router.sendMessage(
-            paymentStreamId, Uint8List.fromList('payment data'.codeUnits));
+          paymentStreamId,
+          Uint8List.fromList('payment data'.codeUnits),
+        );
 
         await Future.delayed(Duration(milliseconds: 1));
 
@@ -634,10 +672,14 @@ void main() {
         expect(userMessages.length, equals(2)); // metadata + data
         expect(paymentMessages.length, equals(2)); // metadata + data
 
-        expect(userMessages[0].metadata?.getHeaderValue('x-route-service'),
-            equals('UserService'));
-        expect(paymentMessages[0].metadata?.getHeaderValue('x-route-service'),
-            equals('PaymentService'));
+        expect(
+          userMessages[0].metadata?.getHeaderValue('x-route-service'),
+          equals('UserService'),
+        );
+        expect(
+          paymentMessages[0].metadata?.getHeaderValue('x-route-service'),
+          equals('PaymentService'),
+        );
 
         await router.close();
       });
@@ -648,8 +690,9 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+            )
             .build();
 
         // Act - создаем активные потоки и сразу закрываем роутер
@@ -661,23 +704,26 @@ void main() {
         expect(router.statistics['closed'], isTrue);
       });
 
-      test('должен предотвращать утечки памяти при множественных операциях',
-          () async {
-        // Arrange & Act
-        for (int i = 0; i < 100; i++) {
-          final router = RpcTransportRouterBuilder.client()
-              .routeCall(
+      test(
+        'должен предотвращать утечки памяти при множественных операциях',
+        () async {
+          // Arrange & Act
+          for (int i = 0; i < 100; i++) {
+            final router = RpcTransportRouterBuilder.client()
+                .routeCall(
                   calledServiceName: 'TestService$i',
-                  toTransport: userClientTransport)
-              .build();
+                  toTransport: userClientTransport,
+                )
+                .build();
 
-          router.createStream();
-          await router.close();
-        }
+            router.createStream();
+            await router.close();
+          }
 
-        // Assert - если нет утечек памяти, тест должен завершиться успешно
-        expect(true, isTrue);
-      });
+          // Assert - если нет утечек памяти, тест должен завершиться успешно
+          expect(true, isTrue);
+        },
+      );
     });
 
     group('📈 Statistics and Monitoring', () {
@@ -685,13 +731,15 @@ void main() {
         // Arrange
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'UserService',
-                toTransport: userClientTransport,
-                priority: 100)
+              calledServiceName: 'UserService',
+              toTransport: userClientTransport,
+              priority: 100,
+            )
             .routeCall(
-                calledServiceName: 'PaymentService',
-                toTransport: paymentClientTransport,
-                priority: 90)
+              calledServiceName: 'PaymentService',
+              toTransport: paymentClientTransport,
+              priority: 90,
+            )
             .build();
 
         // Act - создаем активный поток
@@ -699,10 +747,9 @@ void main() {
 
         // Чтобы поток стал активным, нужно отправить метаданные
         await router.sendMetadata(
-            streamId,
-            RpcMetadata([
-              RpcHeader('x-route-service', 'UserService'),
-            ]));
+          streamId,
+          RpcMetadata([RpcHeader('x-route-service', 'UserService')]),
+        );
 
         // Assert - проверяем статистику
         final stats = router.statistics;
@@ -722,17 +769,20 @@ void main() {
         // Arrange & Act
         final router = RpcTransportRouterBuilder.client()
             .routeCall(
-                calledServiceName: 'LowPriority',
-                toTransport: userClientTransport,
-                priority: 10)
+              calledServiceName: 'LowPriority',
+              toTransport: userClientTransport,
+              priority: 10,
+            )
             .routeCall(
-                calledServiceName: 'HighPriority',
-                toTransport: paymentClientTransport,
-                priority: 100)
+              calledServiceName: 'HighPriority',
+              toTransport: paymentClientTransport,
+              priority: 100,
+            )
             .routeCall(
-                calledServiceName: 'MediumPriority',
-                toTransport: premiumClientTransport,
-                priority: 50)
+              calledServiceName: 'MediumPriority',
+              toTransport: premiumClientTransport,
+              priority: 50,
+            )
             .build();
 
         // Assert - правила должны быть отсортированы по убыванию приоритета
@@ -747,18 +797,22 @@ void main() {
     });
 
     group('🛡️ Role Validation', () {
-      test('должен автоматически устанавливать роль через factory constructor',
-          () {
-        // Act - factory constructor автоматически устанавливает клиентскую роль
-        final builder = RpcTransportRouterBuilder.client();
+      test(
+        'должен автоматически устанавливать роль через factory constructor',
+        () {
+          // Act - factory constructor автоматически устанавливает клиентскую роль
+          final builder = RpcTransportRouterBuilder.client();
 
-        // Assert - должен успешно создавать правила без ошибок
-        expect(
+          // Assert - должен успешно создавать правила без ошибок
+          expect(
             () => builder.routeCall(
-                calledServiceName: 'TestService',
-                toTransport: userClientTransport),
-            returnsNormally);
-      });
+              calledServiceName: 'TestService',
+              toTransport: userClientTransport,
+            ),
+            returnsNormally,
+          );
+        },
+      );
 
       test('должен запрещать смену роли после добавления правил', () {
         // Arrange
@@ -766,7 +820,9 @@ void main() {
 
         // Act - добавляем правило с правильным клиентским транспортом
         builder.routeCall(
-            calledServiceName: 'TestService', toTransport: userClientTransport);
+          calledServiceName: 'TestService',
+          toTransport: userClientTransport,
+        );
 
         // Assert - после добавления правил роль зафиксирована (это нормально для factory approach)
         expect(builder.build().statistics['totalRules'], equals(1));
@@ -774,17 +830,19 @@ void main() {
 
       test('должен требовать правил для сборки', () {
         // Act & Assert - пустой builder должен выбрасывать ArgumentError
-        expect(() => RpcTransportRouterBuilder.client().build(),
-            throwsArgumentError);
+        expect(
+          () => RpcTransportRouterBuilder.client().build(),
+          throwsArgumentError,
+        );
       });
 
       test('должен проверять соответствие транспорта роли Router\'а', () {
         // Act & Assert - роутер требует клиентские транспорты
         expect(
           () => RpcTransportRouterBuilder.client().routeCall(
-              calledServiceName: 'TestService',
-              toTransport:
-                  userServerTransport), // НЕПРАВИЛЬНО: серверный транспорт
+            calledServiceName: 'TestService',
+            toTransport: userServerTransport,
+          ), // НЕПРАВИЛЬНО: серверный транспорт
           throwsArgumentError,
         );
       });
@@ -796,9 +854,7 @@ void main() {
 
 extension RpcMetadataTestHelpers on RpcMetadata {
   static RpcMetadata forService(String serviceName) {
-    return RpcMetadata([
-      RpcHeader('x-route-service', serviceName),
-    ]);
+    return RpcMetadata([RpcHeader('x-route-service', serviceName)]);
   }
 
   static RpcMetadata withHeaders(Map<String, String> headers) {

--- a/packages/rpc_dart/test/utils/stream_distributor_test.dart
+++ b/packages/rpc_dart/test/utils/stream_distributor_test.dart
@@ -11,10 +11,7 @@ class TestMessage implements IRpcSerializable {
 
   @override
   Map<String, dynamic> toJson() {
-    return {
-      'content': content,
-      'value': value,
-    };
+    return {'content': content, 'value': value};
   }
 
   @override
@@ -114,8 +111,10 @@ void main() {
       // Проверяем результаты
       expect(delivered, isTrue); // Успешная доставка
       expect(receivedMessages1.length, 1);
-      expect(receivedMessages2.length,
-          0); // Этот клиент не должен получить сообщение
+      expect(
+        receivedMessages2.length,
+        0,
+      ); // Этот клиент не должен получить сообщение
       expect(receivedMessages1.first.content, 'targeted message');
 
       // Отписываемся, чтобы избежать утечек
@@ -166,21 +165,27 @@ void main() {
 
       // Отправляем первое сообщение
       distributor.publishToClient(
-          'client-pause-test', TestMessage('message 1', 1));
+        'client-pause-test',
+        TestMessage('message 1', 1),
+      );
       await Future.delayed(Duration(milliseconds: 1));
       expect(receivedMessages.length, 1);
 
       // Ставим на паузу и отправляем второе сообщение
       expect(distributor.pauseClientStream('client-pause-test'), isTrue);
       distributor.publishToClient(
-          'client-pause-test', TestMessage('message 2', 2));
+        'client-pause-test',
+        TestMessage('message 2', 2),
+      );
       await Future.delayed(Duration(milliseconds: 1));
       expect(receivedMessages.length, 1); // Не должно увеличиться
 
       // Возобновляем и отправляем третье сообщение
       expect(distributor.resumeClientStream('client-pause-test'), isTrue);
       distributor.publishToClient(
-          'client-pause-test', TestMessage('message 3', 3));
+        'client-pause-test',
+        TestMessage('message 3', 3),
+      );
       await Future.delayed(Duration(milliseconds: 1));
       expect(receivedMessages.length, 2); // Должно получить сообщение 3
       expect(receivedMessages.last.content, 'message 3');
@@ -206,8 +211,9 @@ void main() {
       await Future.delayed(Duration(milliseconds: 1));
 
       // Получаем список неактивных клиентов
-      final inactiveIds =
-          testDistributor.getInactiveClientIds(Duration(milliseconds: 1));
+      final inactiveIds = testDistributor.getInactiveClientIds(
+        Duration(milliseconds: 1),
+      );
 
       // Выводим для отладки
       print('Неактивные клиенты: $inactiveIds');
@@ -215,8 +221,11 @@ void main() {
 
       // Проверяем, что все клиенты отмечены как неактивные,
       // так как оба стрима уже определенное время не получали обновлений
-      expect(inactiveIds.length, 2,
-          reason: 'Все клиенты должны быть в списке неактивных');
+      expect(
+        inactiveIds.length,
+        2,
+        reason: 'Все клиенты должны быть в списке неактивных',
+      );
       expect(inactiveIds, contains('client1'));
       expect(inactiveIds, contains('client2'));
 
@@ -227,9 +236,7 @@ void main() {
     test('Закрытие неактивных стримов', () async {
       // Создаем тестовый дистрибьютор
       final testDistributor = StreamDistributor<TestMessage>(
-        config: StreamDistributorConfig(
-          enableAutoCleanup: false,
-        ),
+        config: StreamDistributorConfig(enableAutoCleanup: false),
       );
 
       // Создаем два клиента
@@ -299,7 +306,8 @@ void main() {
       // 5. Проверяем, сколько клиентов осталось
       // В зависимости от реализации autoRemoveOnCancel, может быть 0 или 1
       print(
-          'Оставшиеся клиенты: ${autoCleanupDistributor.getActiveClientIds()}');
+        'Оставшиеся клиенты: ${autoCleanupDistributor.getActiveClientIds()}',
+      );
 
       // Чистим ресурсы
       await sub2.cancel();
@@ -386,7 +394,9 @@ void main() {
 
       // Попытки использовать закрытый дистрибьютор должны не влиять на состояние
       final delivered = distributor.publishToClient(
-          'test-client', TestMessage('should not be delivered', 1));
+        'test-client',
+        TestMessage('should not be delivered', 1),
+      );
       expect(delivered, isFalse);
 
       // Повторный вызов dispose не должен вызывать ошибок
@@ -398,7 +408,9 @@ void main() {
 
       expect(() => distributor.createClientStream(), throwsStateError);
       expect(
-          () => distributor.createClientStreamWithId('test'), throwsStateError);
+        () => distributor.createClientStreamWithId('test'),
+        throwsStateError,
+      );
     });
   });
 }

--- a/packages/rpc_dart/test/zero_copy/zero_copy_endpoint_streams_test.dart
+++ b/packages/rpc_dart/test/zero_copy/zero_copy_endpoint_streams_test.dart
@@ -82,7 +82,8 @@ final class ZeroCopyTestService extends RpcResponderContract {
           items.add(request.message);
         }
         final response = TestResponse(
-            'Processed ${items.length} items: ${items.join(", ")}');
+          'Processed ${items.length} items: ${items.join(", ")}',
+        );
         print('🔥 CLIENT HANDLER завершен: ${response.result}');
         return response;
       },
@@ -188,8 +189,11 @@ void main() {
       print('   📡 Сериализованных: $serializedCount');
 
       expect(responses.length, equals(3));
-      expect(directCount, greaterThan(0),
-          reason: 'Ожидаем zero-copy сообщения');
+      expect(
+        directCount,
+        greaterThan(0),
+        reason: 'Ожидаем zero-copy сообщения',
+      );
 
       if (directCount > serializedCount) {
         print('\n✅ ОТЛИЧНО! Zero-copy работает через endpoint!');
@@ -236,8 +240,11 @@ void main() {
         print('   📡 Сериализованных: $serializedCount');
 
         expect(response.result, contains('Processed 3 items'));
-        expect(directCount, greaterThan(0),
-            reason: 'Ожидаем zero-copy сообщения');
+        expect(
+          directCount,
+          greaterThan(0),
+          reason: 'Ожидаем zero-copy сообщения',
+        );
 
         if (directCount > serializedCount) {
           print('\n✅ ОТЛИЧНО! Client Stream Zero-copy работает!');
@@ -303,8 +310,11 @@ void main() {
         print('   📡 Сериализованных: $serializedCount');
 
         expect(responses.length, greaterThanOrEqualTo(2));
-        expect(directCount, greaterThan(0),
-            reason: 'Ожидаем zero-copy сообщения');
+        expect(
+          directCount,
+          greaterThan(0),
+          reason: 'Ожидаем zero-copy сообщения',
+        );
 
         if (directCount > serializedCount) {
           print('\n✅ ОТЛИЧНО! Bidirectional Stream Zero-copy работает!');

--- a/packages/rpc_dart/test/zero_copy/zero_copy_endpoint_test.dart
+++ b/packages/rpc_dart/test/zero_copy/zero_copy_endpoint_test.dart
@@ -32,10 +32,7 @@ class TestResponse implements IRpcSerializable {
   TestResponse(this.result, this.count);
 
   factory TestResponse.fromJson(Map<String, dynamic> json) {
-    return TestResponse(
-      json['result'] as String,
-      json['count'] as int,
-    );
+    return TestResponse(json['result'] as String, json['count'] as int);
   }
 
   @override
@@ -97,10 +94,13 @@ void main() {
       print('\n🔬 Анализ текущего поведения endpoint-ов...');
 
       // Создаем сложный объект для тестирования
-      final request = TestRequest(
-        'Complex data processing',
-        ['item1', 'item2', 'item3', 'item4', 'item5'],
-      );
+      final request = TestRequest('Complex data processing', [
+        'item1',
+        'item2',
+        'item3',
+        'item4',
+        'item5',
+      ]);
 
       print('\n📤 Отправляем запрос через endpoint...');
       print('   Запрос: ${request.message}');
@@ -116,7 +116,8 @@ void main() {
         if (message.isSerialized && message.payload != null) {
           print('\n📡 СЕРИАЛИЗАЦИЯ обнаружена!');
           print(
-              '   Размер сериализованных данных: ${message.payload!.length} bytes');
+            '   Размер сериализованных данных: ${message.payload!.length} bytes',
+          );
           print('   Stream ID: ${message.streamId}');
           print('   EndOfStream: ${message.isEndOfStream}');
         } else if (message.isDirect && message.directPayload != null) {
@@ -167,7 +168,8 @@ void main() {
         print('🚀 Объекты передаются по ссылке без сериализации');
       } else if (serializedMessages > 0) {
         print(
-            '\n⚠️ ПРОБЛЕМА: Все еще используется сериализация для inmemory транспорта!');
+          '\n⚠️ ПРОБЛЕМА: Все еще используется сериализация для inmemory транспорта!',
+        );
         print('💡 Решение: Проверить реализацию zero-copy в endpoint-ах');
       }
 
@@ -176,19 +178,27 @@ void main() {
       expect(response.count, equals(5));
 
       // Теперь ожидаем zero-copy для inmemory транспорта
-      expect(directMessages, greaterThan(0),
-          reason: 'Ожидаем zero-copy в новой реализации');
-      expect(serializedMessages, equals(0),
-          reason: 'Не должно быть сериализации для inmemory транспорта');
+      expect(
+        directMessages,
+        greaterThan(0),
+        reason: 'Ожидаем zero-copy в новой реализации',
+      );
+      expect(
+        serializedMessages,
+        equals(0),
+        reason: 'Не должно быть сериализации для inmemory транспорта',
+      );
     });
 
     test('🎯 Идеальный Zero-Copy сценарий', () async {
       print('\n💭 Как ДОЛЖНО работать zero-copy в endpoint-ах:');
       print('   1. Endpoint определяет что используется RpcInMemoryTransport');
       print(
-          '   2. Вместо serialize() + sendMessage() использует sendDirectObject()');
+        '   2. Вместо serialize() + sendMessage() использует sendDirectObject()',
+      );
       print(
-          '   3. На receiving стороне получает directPayload без deserialize()');
+        '   3. На receiving стороне получает directPayload без deserialize()',
+      );
       print('   4. Объекты передаются по ссылке - ZERO накладных расходов');
 
       // Демонстрируем прямое использование zero-copy
@@ -213,8 +223,11 @@ void main() {
         // Ждем сообщение
         final directMessage = await messagesFuture;
 
-        expect(directMessage.directPayload, same(request),
-            reason: 'Объект должен быть тем же самым (по ссылке)');
+        expect(
+          directMessage.directPayload,
+          same(request),
+          reason: 'Объект должен быть тем же самым (по ссылке)',
+        );
 
         print('   ✅ Объект передан по ссылке без сериализации!');
         print('   ✅ Размер данных: 0 bytes (указатель на объект)');

--- a/packages/rpc_dart/test/zero_copy/zero_copy_streams_test.dart
+++ b/packages/rpc_dart/test/zero_copy/zero_copy_streams_test.dart
@@ -79,7 +79,8 @@ final class StreamingTestService extends RpcResponderContract {
           items.add(request.message);
         }
         return TestResponse(
-            'Processed ${items.length} items: ${items.join(", ")}');
+          'Processed ${items.length} items: ${items.join(", ")}',
+        );
       },
       // ✅ НЕ передаем кодеки → автоматически zero-copy режим
       description: 'Zero-copy client stream для обработки элементов',
@@ -192,11 +193,16 @@ void main() {
       expect(responses[2].result, equals('Number 3 for: 3'));
 
       // Проверяем zero-copy
-      expect(directMessages, greaterThan(0),
-          reason: 'Ожидаем zero-copy сообщения');
-      print(directMessages > 0
-          ? '\n✅ Server Stream Zero-Copy работает!'
-          : '\n❌ Zero-Copy НЕ работает');
+      expect(
+        directMessages,
+        greaterThan(0),
+        reason: 'Ожидаем zero-copy сообщения',
+      );
+      print(
+        directMessages > 0
+            ? '\n✅ Server Stream Zero-Copy работает!'
+            : '\n❌ Zero-Copy НЕ работает',
+      );
     });
 
     test('🚀 Client Stream с Zero-Copy', () async {
@@ -236,11 +242,16 @@ void main() {
       expect(response.result, equals('Processed 3 items: item1, item2, item3'));
 
       // Проверяем zero-copy
-      expect(directMessages, greaterThan(0),
-          reason: 'Ожидаем zero-copy сообщения');
-      print(directMessages > 0
-          ? '\n✅ Client Stream Zero-Copy работает!'
-          : '\n❌ Zero-Copy НЕ работает');
+      expect(
+        directMessages,
+        greaterThan(0),
+        reason: 'Ожидаем zero-copy сообщения',
+      );
+      print(
+        directMessages > 0
+            ? '\n✅ Client Stream Zero-Copy работает!'
+            : '\n❌ Zero-Copy НЕ работает',
+      );
     });
 
     test('🚀 Bidirectional Stream с Zero-Copy', () async {
@@ -293,11 +304,16 @@ void main() {
       expect(responses.any((r) => r.result == 'echo: hello world'), isTrue);
 
       // Проверяем zero-copy
-      expect(directMessages, greaterThan(0),
-          reason: 'Ожидаем zero-copy сообщения');
-      print(directMessages > 0
-          ? '\n✅ Bidirectional Stream Zero-Copy работает!'
-          : '\n❌ Zero-Copy НЕ работает');
+      expect(
+        directMessages,
+        greaterThan(0),
+        reason: 'Ожидаем zero-copy сообщения',
+      );
+      print(
+        directMessages > 0
+            ? '\n✅ Bidirectional Stream Zero-Copy работает!'
+            : '\n❌ Zero-Copy НЕ работает',
+      );
 
       await subscription.cancel();
     });
@@ -307,7 +323,8 @@ void main() {
 
       // Тест для демонстрации эффективности zero-copy
       final largeRequest = TestRequest(
-          'big data with lots of text that would take time to serialize and deserialize if we were not using zero-copy optimization for inmemory transport which allows us to pass objects by reference');
+        'big data with lots of text that would take time to serialize and deserialize if we were not using zero-copy optimization for inmemory transport which allows us to pass objects by reference',
+      );
 
       sentMessages.clear();
       final stopwatch = Stopwatch()..start();
@@ -327,7 +344,8 @@ void main() {
       stopwatch.stop();
 
       print(
-          '⏱️ Время выполнения: ${stopwatch.elapsedMicroseconds} микросекунд');
+        '⏱️ Время выполнения: ${stopwatch.elapsedMicroseconds} микросекунд',
+      );
 
       final serializedMessages =
           sentMessages.where((m) => m.isSerialized).length;
@@ -337,7 +355,8 @@ void main() {
       print('   📡 Сериализованных сообщений: $serializedMessages');
       print('   🚀 Zero-copy сообщений: $directMessages');
       print(
-          '   📈 Экономия на сериализации: ${directMessages > serializedMessages ? 'ЕСТЬ' : 'НЕТ'}');
+        '   📈 Экономия на сериализации: ${directMessages > serializedMessages ? 'ЕСТЬ' : 'НЕТ'}',
+      );
 
       expect(responses.length, equals(3));
       expect(directMessages, greaterThan(0));
@@ -345,7 +364,8 @@ void main() {
       if (directMessages > serializedMessages) {
         print('\n🎉 ОТЛИЧНО! Zero-copy оптимизация работает для стримов!');
         print(
-            '💡 Объекты передаются по ссылке без накладных расходов на сериализацию');
+          '💡 Объекты передаются по ссылке без накладных расходов на сериализацию',
+        );
       }
     });
   });

--- a/packages/rpc_dart_transports/CHANGELOG.md
+++ b/packages/rpc_dart_transports/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.2.0
+
+- Added health() and reconnect() implementations for HTTP/2, WebSocket and
+  isolate transports.
+- Improved WebSocket client reconnection support with automatic listeners.
+- Updated documentation with diagnostics overview.
+
 # Changelog
 
 ## 1.1.2

--- a/packages/rpc_dart_transports/README.md
+++ b/packages/rpc_dart_transports/README.md
@@ -12,6 +12,8 @@ Transport implementations for [RPC Dart](https://pub.dev/packages/rpc_dart). Pro
 - Client/Server transports — client-side connectors and server-side handlers.
 - Multiplexing — many RPCs over one connection where supported.
 - Zero-copy — supported where transport permits in-process object transfer.
+- Health monitoring — each transport exposes `health()` snapshots and
+  `reconnect()` attempts to simplify diagnostics.
 
 ### Supported transports
 

--- a/packages/rpc_dart_transports/example/rpc_dart_isolate_contract_example.dart
+++ b/packages/rpc_dart_transports/example/rpc_dart_isolate_contract_example.dart
@@ -49,8 +49,10 @@ class ComputeRequest {
   /// Генерирует большой запрос для тестирования производительности
   factory ComputeRequest.generateLarge(int numbersCount) {
     final random = Random();
-    final numbers =
-        List.generate(numbersCount, (_) => random.nextDouble() * 1000);
+    final numbers = List.generate(
+      numbersCount,
+      (_) => random.nextDouble() * 1000,
+    );
 
     return ComputeRequest(
       operationType: 'complexAnalysis',
@@ -85,10 +87,7 @@ class BatchComputeRequest {
   final List<ComputeRequest> requests;
   final bool parallel;
 
-  const BatchComputeRequest({
-    required this.requests,
-    this.parallel = true,
-  });
+  const BatchComputeRequest({required this.requests, this.parallel = true});
 }
 
 /// Ответ на пакетные вычисления
@@ -145,11 +144,14 @@ final class CalculatorResponder extends RpcResponderContract
   }
 
   @override
-  Future<ComputeResponse> compute(ComputeRequest request,
-      {RpcContext? context}) async {
+  Future<ComputeResponse> compute(
+    ComputeRequest request, {
+    RpcContext? context,
+  }) async {
     final stopwatch = Stopwatch()..start();
     print(
-        '🧮 [Calculator] Обработка ${request.operationType} с ${request.numbers.length} числами');
+      '🧮 [Calculator] Обработка ${request.operationType} с ${request.numbers.length} числами',
+    );
 
     // CPU-intensive вычисления (идеально для изолята!)
     double result = 0.0;
@@ -173,8 +175,9 @@ final class CalculatorResponder extends RpcResponderContract
       case 'variance':
         final mean =
             request.numbers.reduce((a, b) => a + b) / request.numbers.length;
-        final squaredDiffs =
-            request.numbers.map((x) => (x - mean) * (x - mean));
+        final squaredDiffs = request.numbers.map(
+          (x) => (x - mean) * (x - mean),
+        );
         result = squaredDiffs.reduce((a, b) => a + b) / request.numbers.length;
         details['operation'] = 'variance';
         details['mean'] = mean;
@@ -200,7 +203,8 @@ final class CalculatorResponder extends RpcResponderContract
 
     stopwatch.stop();
     print(
-        '✅ [Calculator] Обработка завершена за ${stopwatch.elapsedMilliseconds}мс');
+      '✅ [Calculator] Обработка завершена за ${stopwatch.elapsedMilliseconds}мс',
+    );
 
     return ComputeResponse(
       result: result,
@@ -211,11 +215,14 @@ final class CalculatorResponder extends RpcResponderContract
   }
 
   @override
-  Future<BatchComputeResponse> batchCompute(BatchComputeRequest request,
-      {RpcContext? context}) async {
+  Future<BatchComputeResponse> batchCompute(
+    BatchComputeRequest request, {
+    RpcContext? context,
+  }) async {
     final stopwatch = Stopwatch()..start();
     print(
-        '📊 [Calculator] Пакетная обработка ${request.requests.length} запросов');
+      '📊 [Calculator] Пакетная обработка ${request.requests.length} запросов',
+    );
 
     final results = <ComputeResponse>[];
     int successCount = 0;
@@ -248,19 +255,22 @@ final class CalculatorResponder extends RpcResponderContract
           if (result.success) successCount++;
         } catch (e) {
           print('❌ Ошибка обработки запроса: $e');
-          results.add(ComputeResponse(
-            result: 0.0,
-            details: {'error': e.toString()},
-            processingTime: Duration.zero,
-            success: false,
-          ));
+          results.add(
+            ComputeResponse(
+              result: 0.0,
+              details: {'error': e.toString()},
+              processingTime: Duration.zero,
+              success: false,
+            ),
+          );
         }
       }
     }
 
     stopwatch.stop();
     print(
-        '✅ [Calculator] Пакетная обработка завершена за ${stopwatch.elapsedMilliseconds}мс');
+      '✅ [Calculator] Пакетная обработка завершена за ${stopwatch.elapsedMilliseconds}мс',
+    );
 
     return BatchComputeResponse(
       results: results,
@@ -270,8 +280,10 @@ final class CalculatorResponder extends RpcResponderContract
   }
 
   @override
-  Stream<ComputeStepResponse> streamCompute(Stream<ComputeRequest> requests,
-      {RpcContext? context}) async* {
+  Stream<ComputeStepResponse> streamCompute(
+    Stream<ComputeRequest> requests, {
+    RpcContext? context,
+  }) async* {
     await for (final request in requests) {
       final requestId = 'req_${DateTime.now().millisecondsSinceEpoch}';
 
@@ -406,9 +418,11 @@ Future<void> main() async {
       print('   📊 Обработано чисел: ${largeRequest.numbers.length}');
       print('   🧮 Результат: ${complexResponse.result.toStringAsFixed(4)}');
       print(
-          '   ⏱️ Время клиент-сервер: ${processingStopwatch.elapsedMilliseconds}мс');
+        '   ⏱️ Время клиент-сервер: ${processingStopwatch.elapsedMilliseconds}мс',
+      );
       print(
-          '   ⚙️ Время в изоляте: ${complexResponse.processingTime.inMilliseconds}мс');
+        '   ⚙️ Время в изоляте: ${complexResponse.processingTime.inMilliseconds}мс',
+      );
     }
 
     // ================================================================
@@ -419,28 +433,34 @@ Future<void> main() async {
 
     final batchRequests = [
       ComputeRequest(
-          operationType: 'sum',
-          numbers: List.generate(1000, (i) => i.toDouble())),
+        operationType: 'sum',
+        numbers: List.generate(1000, (i) => i.toDouble()),
+      ),
       ComputeRequest(operationType: 'product', numbers: [1.1, 2.2, 3.3]),
       ComputeRequest(
-          operationType: 'variance',
-          numbers: List.generate(5000, (i) => (i * 0.1))),
+        operationType: 'variance',
+        numbers: List.generate(5000, (i) => (i * 0.1)),
+      ),
     ];
 
-    final batchRequest =
-        BatchComputeRequest(requests: batchRequests, parallel: true);
+    final batchRequest = BatchComputeRequest(
+      requests: batchRequests,
+      parallel: true,
+    );
     final batchResponse = await calculator.batchCompute(batchRequest);
 
     print('✅ Пакетная обработка завершена!');
     print('   📊 Обработано запросов: ${batchResponse.results.length}');
     print('   ✅ Успешных: ${batchResponse.successCount}');
     print(
-        '   ⏱️ Общее время: ${batchResponse.totalProcessingTime.inMilliseconds}мс');
+      '   ⏱️ Общее время: ${batchResponse.totalProcessingTime.inMilliseconds}мс',
+    );
 
     for (int i = 0; i < batchResponse.results.length; i++) {
       final result = batchResponse.results[i];
       print(
-          '      ${i + 1}. ${result.details['operation']}: ${result.result.toStringAsFixed(4)}');
+        '      ${i + 1}. ${result.details['operation']}: ${result.result.toStringAsFixed(4)}',
+      );
     }
 
     // ================================================================
@@ -454,7 +474,9 @@ Future<void> main() async {
       ComputeRequest(operationType: 'mean', numbers: [10.0, 20.0, 30.0]),
       ComputeRequest(operationType: 'sum', numbers: [1.0, 2.0, 3.0, 4.0]),
       ComputeRequest(
-          operationType: 'variance', numbers: [5.0, 15.0, 25.0, 35.0]),
+        operationType: 'variance',
+        numbers: [5.0, 15.0, 25.0, 35.0],
+      ),
     ]).asyncMap((request) async {
       // Небольшая задержка между запросами для корректной передачи
       await Future.delayed(Duration(milliseconds: 100));
@@ -465,7 +487,8 @@ Future<void> main() async {
     await for (final step in calculator.streamCompute(streamingRequests)) {
       final status = step.isComplete ? '✅' : '🔄';
       print(
-          '   $status ${step.step}: ${step.intermediateResult.toStringAsFixed(2)}');
+        '   $status ${step.step}: ${step.intermediateResult.toStringAsFixed(2)}',
+      );
     }
 
     print('\n🏁 Потоковая обработка завершена!');
@@ -495,7 +518,9 @@ Future<void> main() async {
 /// Entry point для сервера в изоляте
 @pragma('vm:entry-point')
 void isolateServerEntrypoint(
-    IRpcTransport transport, Map<String, dynamic> params) {
+  IRpcTransport transport,
+  Map<String, dynamic> params,
+) {
   print('🖥️ [Isolate Server] Запущен Calculator RPC сервер');
 
   // Настраиваем RPC endpoint в изоляте

--- a/packages/rpc_dart_transports/example/transports/http2_example.dart
+++ b/packages/rpc_dart_transports/example/transports/http2_example.dart
@@ -13,7 +13,8 @@ Future<void> main() async {
 
   print('🚀 === ДЕМОНСТРАЦИЯ ВСЕХ ТИПОВ RPC С HTTP/2 ТРАНСПОРТОМ === 🚀\n');
   print(
-      '📱 Покажем Unary, Server Streaming, Client Streaming и Bidirectional!\n');
+    '📱 Покажем Unary, Server Streaming, Client Streaming и Bidirectional!\n',
+  );
 
   // Запускаем HTTP/2 сервер с настоящим RPC обработчиком
   print('📡 Запуск HTTP/2 сервера с RPC обработчиком...');
@@ -21,9 +22,7 @@ Future<void> main() async {
   final rpcServer = RpcHttp2Server.createWithContracts(
     port: serverPort,
     logger: RpcLogger('Http2Server'),
-    contracts: [
-      _DemoServiceContract(),
-    ],
+    contracts: [_DemoServiceContract()],
   );
   await rpcServer.start();
 

--- a/packages/rpc_dart_transports/example/transports/isolate_example.dart
+++ b/packages/rpc_dart_transports/example/transports/isolate_example.dart
@@ -40,11 +40,14 @@ Future<void> runIsolateExample() async {
   );
 
   // Подписываемся на ответы
-  final subscription = client.responses.listen((message) {
-    print('КЛИЕНТ: Получен ответ: "${message.payload}"');
-  }, onError: (error) {
-    print('КЛИЕНТ: Ошибка: $error');
-  });
+  final subscription = client.responses.listen(
+    (message) {
+      print('КЛИЕНТ: Получен ответ: "${message.payload}"');
+    },
+    onError: (error) {
+      print('КЛИЕНТ: Ошибка: $error');
+    },
+  );
 
   // Отправляем запросы
   print('\nОтправляем запрос: "Привет, сервер!"');

--- a/packages/rpc_dart_transports/lib/src/server/rpc_server_bootstrap.dart
+++ b/packages/rpc_dart_transports/lib/src/server/rpc_server_bootstrap.dart
@@ -217,7 +217,8 @@ class RpcServerBootstrap {
   Future<void> _daemonize(List<String> originalArgs) async {
     if (!Platform.isLinux && !Platform.isMacOS) {
       throw UnsupportedError(
-          'Daemon режим поддерживается только на Linux/macOS');
+        'Daemon режим поддерживается только на Linux/macOS',
+      );
     }
 
     print('🔄 Запуск в daemon режиме...');
@@ -235,10 +236,12 @@ class RpcServerBootstrap {
 
     // Создаем detached процесс
     final process = await Process.start(
-      Platform.resolvedExecutable,
-      [Platform.script.toFilePath(), ...childArgs],
-      mode: ProcessStartMode.detached,
-    );
+        Platform.resolvedExecutable,
+        [
+          Platform.script.toFilePath(),
+          ...childArgs,
+        ],
+        mode: ProcessStartMode.detached);
 
     // Проверяем что процесс запустился
     await Future.delayed(Duration(milliseconds: 1000));
@@ -349,11 +352,18 @@ class RpcServerBootstrap {
   /// Парсер аргументов
   ArgParser _createArgParser() {
     return ArgParser()
-      ..addOption('host',
-          abbr: 'h', defaultsTo: 'localhost', help: 'Хост сервера')
+      ..addOption(
+        'host',
+        abbr: 'h',
+        defaultsTo: 'localhost',
+        help: 'Хост сервера',
+      )
       ..addOption('port', abbr: 'p', defaultsTo: '8080', help: 'Порт сервера')
-      ..addOption('log-level',
-          allowed: ['debug', 'info', 'warning', 'error'], defaultsTo: 'info')
+      ..addOption(
+        'log-level',
+        allowed: ['debug', 'info', 'warning', 'error'],
+        defaultsTo: 'info',
+      )
       ..addFlag('verbose', abbr: 'v', help: 'Подробный вывод')
       ..addFlag('quiet', abbr: 'q', help: 'Тихий режим')
       ..addOption('log-file', help: 'Файл логов для daemon режима')
@@ -423,7 +433,8 @@ class RpcServerBootstrap {
   /// Логирует готовность daemon
   Future<void> _logDaemonReady() async {
     await _logDaemonEvent(
-        '$appName daemon ready on ${_config.host}:${_config.port}');
+      '$appName daemon ready on ${_config.host}:${_config.port}',
+    );
   }
 
   /// Логирует статистику daemon
@@ -433,10 +444,7 @@ class RpcServerBootstrap {
 
   /// Обрабатывает глобальные ошибки
   Future<void> _handleGlobalError(Object error, StackTrace stackTrace) async {
-    final errorHandler = _ErrorHandler(
-      verbose: true,
-      isDaemon: false,
-    );
+    final errorHandler = _ErrorHandler(verbose: true, isDaemon: false);
     await errorHandler.handleError(error, stackTrace);
     exit(1);
   }
@@ -584,10 +592,9 @@ class _ErrorHandler {
 
     if (isDaemon && logFile != null) {
       try {
-        await File(logFile!).writeAsString(
-          '$message\n',
-          mode: FileMode.writeOnlyAppend,
-        );
+        await File(
+          logFile!,
+        ).writeAsString('$message\n', mode: FileMode.writeOnlyAppend);
       } catch (e) {
         stderr.writeln('Failed to log error: $e');
       }

--- a/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_caller_transport.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_caller_transport.dart
@@ -19,7 +19,10 @@ class RpcHttp2CallerTransport implements IRpcTransport {
   bool get isClient => true;
 
   /// HTTP/2 соединение
-  final http2.ClientTransportConnection _connection;
+  http2.ClientTransportConnection _connection;
+
+  /// Фабрика для повторного создания соединения при переподключении
+  final Future<http2.ClientTransportConnection> Function() _connectionFactory;
 
   /// Контроллер для входящих сообщений
   final StreamController<RpcTransportMessage> _messageController =
@@ -43,6 +46,9 @@ class RpcHttp2CallerTransport implements IRpcTransport {
   /// Схема (http/https)
   final String _scheme;
 
+  /// Порт подключения
+  final int _port;
+
   /// Флаг закрытия
   bool _isClosed = false;
 
@@ -51,11 +57,16 @@ class RpcHttp2CallerTransport implements IRpcTransport {
 
   RpcHttp2CallerTransport._({
     required http2.ClientTransportConnection connection,
+    required Future<http2.ClientTransportConnection> Function()
+        connectionFactory,
     required String host,
+    required int port,
     required String scheme,
     RpcLogger? logger,
   })  : _connection = connection,
+        _connectionFactory = connectionFactory,
         _host = host,
+        _port = port,
         _scheme = scheme,
         _logger = logger?.child('Http2ClientTransport');
 
@@ -67,19 +78,25 @@ class RpcHttp2CallerTransport implements IRpcTransport {
   }) async {
     logger?.internal('Создание защищенного HTTP/2 соединения с $host:$port');
 
-    final socket = await SecureSocket.connect(
-      host,
-      port,
-      supportedProtocols: ['h2'], // HTTP/2
-    );
+    Future<http2.ClientTransportConnection> createConnection() async {
+      final socket = await SecureSocket.connect(
+        host,
+        port,
+        supportedProtocols: ['h2'], // HTTP/2
+      );
 
-    final connection = http2.ClientTransportConnection.viaSocket(socket);
+      return http2.ClientTransportConnection.viaSocket(socket);
+    }
+
+    final connection = await createConnection();
 
     logger?.internal('HTTP/2 соединение установлено');
 
     return RpcHttp2CallerTransport._(
       connection: connection,
+      connectionFactory: createConnection,
       host: host,
+      port: port,
       scheme: 'https',
       logger: logger,
     );
@@ -93,14 +110,20 @@ class RpcHttp2CallerTransport implements IRpcTransport {
   }) async {
     logger?.internal('Создание HTTP/2 соединения с $host:$port');
 
-    final socket = await Socket.connect(host, port);
-    final connection = http2.ClientTransportConnection.viaSocket(socket);
+    Future<http2.ClientTransportConnection> createConnection() async {
+      final socket = await Socket.connect(host, port);
+      return http2.ClientTransportConnection.viaSocket(socket);
+    }
+
+    final connection = await createConnection();
 
     logger?.internal('HTTP/2 соединение установлено');
 
     return RpcHttp2CallerTransport._(
       connection: connection,
+      connectionFactory: createConnection,
       host: host,
+      port: port,
       scheme: 'http',
       logger: logger,
     );
@@ -129,7 +152,8 @@ class RpcHttp2CallerTransport implements IRpcTransport {
       try {
         stream.sendData(Uint8List(0), endStream: true);
         _logger?.internal(
-            'Отправлен END_STREAM при освобождении stream $streamId');
+          'Отправлен END_STREAM при освобождении stream $streamId',
+        );
       } catch (e) {
         _logger?.internal('Используем terminate для stream $streamId: $e');
         stream.terminate();
@@ -158,7 +182,8 @@ class RpcHttp2CallerTransport implements IRpcTransport {
     final methodPath = metadata.methodPath ?? '/Unknown/Unknown';
 
     _logger?.internal(
-        'Отправка метаданных для stream $streamId: $methodPath (endStream: $endStream)');
+      'Отправка метаданных для stream $streamId: $methodPath (endStream: $endStream)',
+    );
 
     // Конвертируем RPC метаданные в HTTP/2 headers
     final headers = rpcMetadataToHttp2Headers(
@@ -174,7 +199,8 @@ class RpcHttp2CallerTransport implements IRpcTransport {
     _activeStreams[streamId] = stream;
 
     _logger?.internal(
-        'HTTP/2 stream создан: $streamId (активных: ${_activeStreams.length})');
+      'HTTP/2 stream создан: $streamId (активных: ${_activeStreams.length})',
+    );
 
     // Настраиваем обработку входящих сообщений
     _setupStreamListener(streamId, stream, methodPath);
@@ -196,7 +222,8 @@ class RpcHttp2CallerTransport implements IRpcTransport {
     }
 
     _logger?.internal(
-        'Отправка данных для stream $streamId: ${data.length} байт (endStream: $endStream)');
+      'Отправка данных для stream $streamId: ${data.length} байт (endStream: $endStream)',
+    );
 
     // Упаковываем данные в gRPC frame формат
     final framedData = packGrpcMessage(data);
@@ -222,9 +249,23 @@ class RpcHttp2CallerTransport implements IRpcTransport {
     _logger?.internal('Отправка завершена для stream $streamId');
   }
 
+  Map<String, Object?> _buildHealthDetails() => {
+        'isClosed': _isClosed,
+        'activeStreams': _activeStreams.length,
+        'pendingSubscriptions': _streamSubscriptions.length,
+        'pendingParsers': _streamParsers.length,
+        'host': _host,
+        'port': _port,
+        'scheme': _scheme,
+        'messageControllerClosed': _messageController.isClosed,
+      };
+
   /// Настраивает обработчик входящих сообщений для HTTP/2 stream
   void _setupStreamListener(
-      int streamId, http2.ClientTransportStream stream, String methodPath) {
+    int streamId,
+    http2.ClientTransportStream stream,
+    String methodPath,
+  ) {
     _logger?.internal('Настройка обработчика для stream $streamId');
 
     final subscription = stream.incomingMessages.listen(
@@ -232,8 +273,11 @@ class RpcHttp2CallerTransport implements IRpcTransport {
         _handleIncomingMessage(streamId, message, methodPath);
       },
       onError: (error, stackTrace) {
-        _logger?.error('Ошибка в stream $streamId',
-            error: error, stackTrace: stackTrace);
+        _logger?.error(
+          'Ошибка в stream $streamId',
+          error: error,
+          stackTrace: stackTrace,
+        );
 
         if (!_messageController.isClosed) {
           _messageController.addError(error, stackTrace);
@@ -244,10 +288,9 @@ class RpcHttp2CallerTransport implements IRpcTransport {
 
         // Отправляем сообщение о завершении потока
         if (!_messageController.isClosed) {
-          _messageController.add(RpcTransportMessage(
-            streamId: streamId,
-            isEndOfStream: true,
-          ));
+          _messageController.add(
+            RpcTransportMessage(streamId: streamId, isEndOfStream: true),
+          );
         }
 
         // Очищаем ресурсы
@@ -262,7 +305,10 @@ class RpcHttp2CallerTransport implements IRpcTransport {
 
   /// Обрабатывает входящее сообщение от HTTP/2 stream
   void _handleIncomingMessage(
-      int streamId, http2.StreamMessage message, String methodPath) {
+    int streamId,
+    http2.StreamMessage message,
+    String methodPath,
+  ) {
     // Убираем избыточное логирование - оставляем только в конкретных обработчиках
 
     try {
@@ -274,8 +320,11 @@ class RpcHttp2CallerTransport implements IRpcTransport {
         _handleDataMessage(streamId, message, methodPath);
       }
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при обработке сообщения stream $streamId',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при обработке сообщения stream $streamId',
+        error: e,
+        stackTrace: stackTrace,
+      );
 
       if (!_messageController.isClosed) {
         _messageController.addError(e, stackTrace);
@@ -285,7 +334,10 @@ class RpcHttp2CallerTransport implements IRpcTransport {
 
   /// Обрабатывает входящие HTTP/2 headers
   void _handleHeadersMessage(
-      int streamId, http2.HeadersStreamMessage message, String methodPath) {
+    int streamId,
+    http2.HeadersStreamMessage message,
+    String methodPath,
+  ) {
     // Конвертируем HTTP/2 headers в RPC метаданные
     final metadata = http2HeadersToRpcMetadata(message.headers);
 
@@ -304,7 +356,10 @@ class RpcHttp2CallerTransport implements IRpcTransport {
 
   /// Обрабатывает входящие HTTP/2 данные
   void _handleDataMessage(
-      int streamId, http2.DataStreamMessage message, String methodPath) {
+    int streamId,
+    http2.DataStreamMessage message,
+    String methodPath,
+  ) {
     try {
       // Получаем или создаем парсер для этого stream
       final parser = _streamParsers.putIfAbsent(
@@ -333,10 +388,14 @@ class RpcHttp2CallerTransport implements IRpcTransport {
       }
 
       _logger?.internal(
-          'Обработано ${messages.length} сообщений для stream $streamId');
+        'Обработано ${messages.length} сообщений для stream $streamId',
+      );
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при распаковке gRPC данных для stream $streamId',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при распаковке gRPC данных для stream $streamId',
+        error: e,
+        stackTrace: stackTrace,
+      );
 
       if (!_messageController.isClosed) {
         _messageController.addError(e, stackTrace);
@@ -353,6 +412,91 @@ class RpcHttp2CallerTransport implements IRpcTransport {
   }
 
   @override
+  Future<RpcHealthStatus> health() async {
+    final details = _buildHealthDetails();
+
+    if (_messageController.isClosed) {
+      return RpcHealthStatus.closed(
+        component: runtimeType.toString(),
+        message: 'HTTP/2 transport closed',
+        details: details,
+      );
+    }
+
+    if (_isClosed) {
+      return RpcHealthStatus.degraded(
+        component: runtimeType.toString(),
+        message: 'HTTP/2 connection is closed. Reconnect is required.',
+        details: details,
+      );
+    }
+
+    return RpcHealthStatus.healthy(
+      component: runtimeType.toString(),
+      message: 'HTTP/2 transport ready',
+      details: details,
+    );
+  }
+
+  @override
+  Future<RpcHealthStatus> reconnect() async {
+    if (_messageController.isClosed) {
+      return RpcHealthStatus.closed(
+        component: runtimeType.toString(),
+        message: 'Transport is closed and cannot be reconnected',
+        details: {..._buildHealthDetails(), 'supported': false},
+      );
+    }
+
+    _logger?.info('Попытка переподключения HTTP/2 клиента к $_host:$_port');
+
+    try {
+      await _connection.finish();
+    } catch (e) {
+      _logger?.warning('Ошибка при завершении текущего соединения: $e');
+    }
+
+    for (final subscription in _streamSubscriptions.values) {
+      try {
+        await subscription.cancel();
+      } catch (e) {
+        _logger?.warning('Ошибка при отмене подписки: $e');
+      }
+    }
+    _streamSubscriptions.clear();
+    _streamParsers.clear();
+    _activeStreams.clear();
+
+    try {
+      _connection = await _connectionFactory();
+      _isClosed = false;
+      _nextStreamId = 1;
+      _logger?.info('HTTP/2 клиент успешно переподключен');
+      return RpcHealthStatus.healthy(
+        component: runtimeType.toString(),
+        message: 'HTTP/2 connection re-established',
+        details: {..._buildHealthDetails(), 'supported': true},
+      );
+    } catch (error, stackTrace) {
+      _isClosed = true;
+      _logger?.error(
+        'Не удалось переподключить HTTP/2 клиент',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return RpcHealthStatus.unhealthy(
+        component: runtimeType.toString(),
+        message: 'Failed to reconnect HTTP/2 transport: $error',
+        details: {
+          ..._buildHealthDetails(),
+          'supported': true,
+          'error': error.toString(),
+        },
+      );
+    }
+  }
+
+  @override
   Future<void> close() async {
     if (_isClosed) return;
 
@@ -362,7 +506,8 @@ class RpcHttp2CallerTransport implements IRpcTransport {
     // Даем серверу время на завершение обработки активных потоков
     if (_activeStreams.isNotEmpty) {
       _logger?.internal(
-          'Ожидание завершения ${_activeStreams.length} активных потоков');
+        'Ожидание завершения ${_activeStreams.length} активных потоков',
+      );
       await Future.delayed(Duration(milliseconds: 50));
     }
 
@@ -429,8 +574,11 @@ class RpcHttp2CallerTransport implements IRpcTransport {
   bool get isClosed => _isClosed;
 
   @override
-  Future<void> sendDirectObject(int streamId, Object object,
-      {bool endStream = false}) async {
+  Future<void> sendDirectObject(
+    int streamId,
+    Object object, {
+    bool endStream = false,
+  }) async {
     throw UnimplementedError('Unsupport direct object sending');
   }
 

--- a/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_common.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_common.dart
@@ -41,8 +41,9 @@ List<http2.Header> rpcMetadataToHttp2Headers(
   }
 
   // Добавляем стандартные gRPC headers если их нет
-  final hasUserAgent =
-      metadata.headers.any((h) => h.name.toLowerCase() == 'user-agent');
+  final hasUserAgent = metadata.headers.any(
+    (h) => h.name.toLowerCase() == 'user-agent',
+  );
   if (!hasUserAgent) {
     headers.add(http2.Header.ascii('user-agent', kGrpcUserAgent));
   }

--- a/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_responder_transport.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_responder_transport.dart
@@ -64,8 +64,11 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
         _handleIncomingStream(stream);
       },
       onError: (error, stackTrace) {
-        _logger?.error('Ошибка в соединении HTTP/2',
-            error: error, stackTrace: stackTrace);
+        _logger?.error(
+          'Ошибка в соединении HTTP/2',
+          error: error,
+          stackTrace: stackTrace,
+        );
 
         if (!_messageController.isClosed) {
           _messageController.addError(error, stackTrace);
@@ -85,7 +88,8 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
 
     _incomingStreams[streamId] = stream;
     _logger?.internal(
-        'Сохранен stream $streamId (активных: ${_incomingStreams.length})');
+      'Сохранен stream $streamId (активных: ${_incomingStreams.length})',
+    );
 
     // Настраиваем обработку сообщений от этого stream
     final subscription = stream.incomingMessages.listen(
@@ -93,8 +97,11 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
         _handleIncomingMessage(streamId, message);
       },
       onError: (error, stackTrace) {
-        _logger?.error('Ошибка в stream $streamId',
-            error: error, stackTrace: stackTrace);
+        _logger?.error(
+          'Ошибка в stream $streamId',
+          error: error,
+          stackTrace: stackTrace,
+        );
 
         if (!_messageController.isClosed) {
           _messageController.addError(error, stackTrace);
@@ -105,10 +112,9 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
 
         // Отправляем сообщение о завершении потока
         if (!_messageController.isClosed) {
-          _messageController.add(RpcTransportMessage(
-            streamId: streamId,
-            isEndOfStream: true,
-          ));
+          _messageController.add(
+            RpcTransportMessage(streamId: streamId, isEndOfStream: true),
+          );
         }
 
         // Не удаляем сразу из _incomingStreams, чтобы можно было отправить ответ
@@ -134,8 +140,11 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
         _handleIncomingData(streamId, message);
       }
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при обработке сообщения stream $streamId',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при обработке сообщения stream $streamId',
+        error: e,
+        stackTrace: stackTrace,
+      );
 
       if (!_messageController.isClosed) {
         _messageController.addError(e, stackTrace);
@@ -145,7 +154,9 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
 
   /// Обрабатывает входящие HTTP/2 headers от клиента
   void _handleIncomingHeaders(
-      int streamId, http2.HeadersStreamMessage message) {
+    int streamId,
+    http2.HeadersStreamMessage message,
+  ) {
     // Извлекаем путь метода из headers
     String? methodPath;
     for (final header in message.headers) {
@@ -203,12 +214,14 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
       }
 
       _logger?.internal(
-          'Обработано ${messages.length} входящих сообщений для stream $streamId');
+        'Обработано ${messages.length} входящих сообщений для stream $streamId',
+      );
     } catch (e, stackTrace) {
       _logger?.error(
-          'Ошибка при распаковке входящих gRPC данных для stream $streamId',
-          error: e,
-          stackTrace: stackTrace);
+        'Ошибка при распаковке входящих gRPC данных для stream $streamId',
+        error: e,
+        stackTrace: stackTrace,
+      );
 
       if (!_messageController.isClosed) {
         _messageController.addError(e, stackTrace);
@@ -239,10 +252,12 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
       try {
         incomingStream.sendData(Uint8List(0), endStream: true);
         _logger?.internal(
-            'Отправлен END_STREAM при освобождении входящего stream $streamId');
+          'Отправлен END_STREAM при освобождении входящего stream $streamId',
+        );
       } catch (e) {
         _logger?.internal(
-            'Используем terminate для входящего stream $streamId: $e');
+          'Используем terminate для входящего stream $streamId: $e',
+        );
         incomingStream.terminate();
       }
     }
@@ -253,10 +268,12 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
       try {
         outgoingStream.sendData(Uint8List(0), endStream: true);
         _logger?.internal(
-            'Отправлен END_STREAM при освобождении исходящего stream $streamId');
+          'Отправлен END_STREAM при освобождении исходящего stream $streamId',
+        );
       } catch (e) {
         _logger?.internal(
-            'Используем terminate для исходящего stream $streamId: $e');
+          'Используем terminate для исходящего stream $streamId: $e',
+        );
         outgoingStream.terminate();
       }
     }
@@ -285,7 +302,8 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
     final incomingStream = _incomingStreams[streamId];
     if (incomingStream == null) {
       _logger?.warning(
-          'Incoming stream $streamId not found, skipping metadata send');
+        'Incoming stream $streamId not found, skipping metadata send',
+      );
       return;
     }
 
@@ -322,12 +340,14 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
     final incomingStream = _incomingStreams[streamId];
     if (incomingStream == null) {
       _logger?.warning(
-          'Incoming stream $streamId not found, skipping message send');
+        'Incoming stream $streamId not found, skipping message send',
+      );
       return;
     }
 
     _logger?.internal(
-        'Отправка ответных данных для stream $streamId: ${data.length} байт');
+      'Отправка ответных данных для stream $streamId: ${data.length} байт',
+    );
 
     try {
       // Упаковываем данные в gRPC frame формат
@@ -350,7 +370,8 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
     final incomingStream = _incomingStreams[streamId];
     if (incomingStream == null) {
       _logger?.internal(
-          'Incoming stream $streamId not found, skipping finish sending');
+        'Incoming stream $streamId not found, skipping finish sending',
+      );
       return;
     }
 
@@ -362,8 +383,9 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
 
       _logger?.internal('Отправка ответа завершена для stream $streamId');
     } catch (e) {
-      _logger
-          ?.warning('Ошибка при завершении отправки для stream $streamId: $e');
+      _logger?.warning(
+        'Ошибка при завершении отправки для stream $streamId: $e',
+      );
     }
   }
 
@@ -373,6 +395,51 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
   @override
   Stream<RpcTransportMessage> getMessagesForStream(int streamId) {
     return incomingMessages.where((message) => message.streamId == streamId);
+  }
+
+  Map<String, Object?> _buildHealthDetails() => {
+        'isClosed': _isClosed,
+        'incomingStreams': _incomingStreams.length,
+        'outgoingStreams': _outgoingStreams.length,
+        'streamSubscriptions': _streamSubscriptions.length,
+        'streamParsers': _streamParsers.length,
+        'messageControllerClosed': _messageController.isClosed,
+      };
+
+  @override
+  Future<RpcHealthStatus> health() async {
+    final details = _buildHealthDetails();
+
+    if (_messageController.isClosed) {
+      return RpcHealthStatus.closed(
+        component: runtimeType.toString(),
+        message: 'HTTP/2 responder transport closed',
+        details: details,
+      );
+    }
+
+    if (_isClosed) {
+      return RpcHealthStatus.degraded(
+        component: runtimeType.toString(),
+        message: 'HTTP/2 responder connection is closed',
+        details: details,
+      );
+    }
+
+    return RpcHealthStatus.healthy(
+      component: runtimeType.toString(),
+      message: 'HTTP/2 responder ready',
+      details: details,
+    );
+  }
+
+  @override
+  Future<RpcHealthStatus> reconnect() async {
+    return RpcHealthStatus.degraded(
+      component: runtimeType.toString(),
+      message: 'Server-side HTTP/2 transport does not support manual reconnect',
+      details: {..._buildHealthDetails(), 'supported': false},
+    );
   }
 
   @override
@@ -395,16 +462,19 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
         // Пытаемся закрыть stream мягко
         stream.sendData(Uint8List(0), endStream: true);
         _logger?.internal(
-            'Отправлен END_STREAM для входящего stream ${stream.id}');
+          'Отправлен END_STREAM для входящего stream ${stream.id}',
+        );
       } catch (e) {
         _logger?.internal(
-            'Используем terminate для входящего stream ${stream.id}: $e');
+          'Используем terminate для входящего stream ${stream.id}: $e',
+        );
         // В крайнем случае используем terminate
         try {
           stream.terminate();
         } catch (e2) {
           _logger?.warning(
-              'Ошибка при terminate входящего stream ${stream.id}: $e2');
+            'Ошибка при terminate входящего stream ${stream.id}: $e2',
+          );
         }
       }
     }
@@ -415,15 +485,18 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
       try {
         stream.sendData(Uint8List(0), endStream: true);
         _logger?.internal(
-            'Отправлен END_STREAM для исходящего stream ${stream.id}');
+          'Отправлен END_STREAM для исходящего stream ${stream.id}',
+        );
       } catch (e) {
         _logger?.internal(
-            'Используем terminate для исходящего stream ${stream.id}: $e');
+          'Используем terminate для исходящего stream ${stream.id}: $e',
+        );
         try {
           stream.terminate();
         } catch (e2) {
           _logger?.warning(
-              'Ошибка при terminate исходящего stream ${stream.id}: $e2');
+            'Ошибка при terminate исходящего stream ${stream.id}: $e2',
+          );
         }
       }
     }
@@ -453,8 +526,11 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
   bool get isClosed => _isClosed;
 
   @override
-  Future<void> sendDirectObject(int streamId, Object object,
-      {bool endStream = false}) async {
+  Future<void> sendDirectObject(
+    int streamId,
+    Object object, {
+    bool endStream = false,
+  }) async {
     throw UnimplementedError('Unsupport direct object sending');
   }
 

--- a/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_server.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_server.dart
@@ -72,15 +72,19 @@ class RpcHttp2Server implements IRpcServer {
       logger: logger,
       onEndpointCreated: (endpoint) {
         logger?.debug(
-            'Регистрация ${contracts.length} контрактов на новом endpoint');
+          'Регистрация ${contracts.length} контрактов на новом endpoint',
+        );
         for (final contract in contracts) {
           endpoint.registerServiceContract(contract);
           logger?.debug('Зарегистрирован контракт: ${contract.serviceName}');
         }
       },
       onConnectionError: (error, stackTrace) {
-        logger?.error('Ошибка соединения HTTP/2',
-            error: error, stackTrace: stackTrace);
+        logger?.error(
+          'Ошибка соединения HTTP/2',
+          error: error,
+          stackTrace: stackTrace,
+        );
       },
     );
   }
@@ -121,16 +125,22 @@ class RpcHttp2Server implements IRpcServer {
       final subscription = _serverSocket!.listen(
         _handleConnection,
         onError: (error, stackTrace) {
-          _logger?.error('Ошибка сервера',
-              error: error, stackTrace: stackTrace);
+          _logger?.error(
+            'Ошибка сервера',
+            error: error,
+            stackTrace: stackTrace,
+          );
           _onConnectionError?.call(error, stackTrace);
         },
       );
 
       _subscriptions.add(subscription);
     } catch (e, stackTrace) {
-      _logger?.error('Не удалось запустить HTTP/2 сервер',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Не удалось запустить HTTP/2 сервер',
+        error: e,
+        stackTrace: stackTrace,
+      );
       _isRunning = false;
       rethrow;
     }
@@ -207,14 +217,18 @@ class RpcHttp2Server implements IRpcServer {
         _endpoints.remove(endpoint);
         _onConnectionClosed?.call(socket);
       }).catchError((error) {
-        _logger
-            ?.warning('Ошибка при закрытии соединения $clientAddress: $error');
+        _logger?.warning(
+          'Ошибка при закрытии соединения $clientAddress: $error',
+        );
         _endpoints.remove(endpoint);
         _onConnectionClosed?.call(socket);
       });
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при создании HTTP/2 RPC соединения',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при создании HTTP/2 RPC соединения',
+        error: e,
+        stackTrace: stackTrace,
+      );
       _onConnectionError?.call(e, stackTrace);
       socket.destroy();
     }

--- a/packages/rpc_dart_transports/lib/src/transports/isolate/isolate_transport.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/isolate/isolate_transport.dart
@@ -10,14 +10,7 @@ import 'dart:isolate';
 import 'package:rpc_dart/rpc_dart.dart';
 
 /// Типы сообщений между изолятами
-enum _IsolateMessageType {
-  init,
-  metadata,
-  data,
-  directObject,
-  finish,
-  close,
-}
+enum _IsolateMessageType { init, metadata, data, directObject, finish, close }
 
 /// Сообщение для обмена между изолятами с поддержкой Stream ID
 class _IsolateMessage {
@@ -37,9 +30,7 @@ class _IsolateMessage {
 }
 
 typedef RpcIsolateEntrypoint = void Function(
-  IRpcTransport transport,
-  Map<String, dynamic> customParams,
-);
+    IRpcTransport transport, Map<String, dynamic> customParams);
 
 /// Фабрика для создания транспортов изолята с поддержкой Stream ID.
 /// Позволяет создавать пары хост-воркер транспортов с мультиплексированием.
@@ -101,15 +92,14 @@ abstract interface class RpcIsolateTransport {
 
     // Создаем и запускаем изолят с нашей оберткой
     final isolate = await Isolate.spawn(
-      entrypointWrapper,
-      [
-        initPort.sendPort,
-        isolateId,
-        customParams ?? {},
-        entrypoint, // Передаем пользовательскую функцию в изолят
-      ],
-      debugName: name,
-    );
+        entrypointWrapper,
+        [
+          initPort.sendPort,
+          isolateId,
+          customParams ?? {},
+          entrypoint, // Передаем пользовательскую функцию в изолят
+        ],
+        debugName: name);
 
     // Ожидаем SendPort от изолята
     final workerSendPort = await initPort.first as SendPort;
@@ -118,11 +108,13 @@ abstract interface class RpcIsolateTransport {
     final hostReceivePort = ReceivePort();
 
     // Отправляем порт для основной коммуникации в изолят
-    workerSendPort.send(_IsolateMessage(
-      type: _IsolateMessageType.init,
-      streamId: 0, // Специальный stream для инициализации
-      data: hostReceivePort.sendPort,
-    ));
+    workerSendPort.send(
+      _IsolateMessage(
+        type: _IsolateMessageType.init,
+        streamId: 0, // Специальный stream для инициализации
+        data: hostReceivePort.sendPort,
+      ),
+    );
 
     // Создаем хост-транспорт с поддержкой Stream ID
     final hostTransport = _IsolateHostTransport(
@@ -165,11 +157,14 @@ class _IsolateHostTransport implements IRpcTransport {
   })  : _workerSendPort = workerSendPort,
         _receivePort = receivePort {
     // Настраиваем обработку входящих сообщений
-    _receivePort.listen(_handleMessage, onDone: () {
-      if (!_messageController.isClosed) {
-        _messageController.close();
-      }
-    });
+    _receivePort.listen(
+      _handleMessage,
+      onDone: () {
+        if (!_messageController.isClosed) {
+          _messageController.close();
+        }
+      },
+    );
   }
 
   void _handleMessage(dynamic message) {
@@ -178,38 +173,43 @@ class _IsolateHostTransport implements IRpcTransport {
     switch (message.type) {
       case _IsolateMessageType.metadata:
         final metadata = message.data as RpcMetadata;
-        _messageController.add(RpcTransportMessage(
-          metadata: metadata,
-          isEndOfStream: message.isEndOfStream,
-          streamId: message.streamId,
-          methodPath: message.methodPath,
-        ));
+        _messageController.add(
+          RpcTransportMessage(
+            metadata: metadata,
+            isEndOfStream: message.isEndOfStream,
+            streamId: message.streamId,
+            methodPath: message.methodPath,
+          ),
+        );
         break;
 
       case _IsolateMessageType.data:
         final data = message.data as Uint8List;
-        _messageController.add(RpcTransportMessage(
-          payload: data,
-          isEndOfStream: message.isEndOfStream,
-          streamId: message.streamId,
-          methodPath: message.methodPath,
-        ));
+        _messageController.add(
+          RpcTransportMessage(
+            payload: data,
+            isEndOfStream: message.isEndOfStream,
+            streamId: message.streamId,
+            methodPath: message.methodPath,
+          ),
+        );
         break;
 
       case _IsolateMessageType.directObject:
         // Передаем объект напрямую через directPayload поле
-        _messageController.add(RpcTransportMessage(
-          streamId: message.streamId,
-          isEndOfStream: message.isEndOfStream,
-          directPayload: message.data, // Объект передается как directPayload
-        ));
+        _messageController.add(
+          RpcTransportMessage(
+            streamId: message.streamId,
+            isEndOfStream: message.isEndOfStream,
+            directPayload: message.data, // Объект передается как directPayload
+          ),
+        );
         break;
 
       case _IsolateMessageType.finish:
-        _messageController.add(RpcTransportMessage(
-          isEndOfStream: true,
-          streamId: message.streamId,
-        ));
+        _messageController.add(
+          RpcTransportMessage(isEndOfStream: true, streamId: message.streamId),
+        );
         break;
 
       default:
@@ -224,6 +224,40 @@ class _IsolateHostTransport implements IRpcTransport {
   @override
   Stream<RpcTransportMessage> getMessagesForStream(int streamId) {
     return incomingMessages.where((message) => message.streamId == streamId);
+  }
+
+  Map<String, Object?> _healthDetails() => {
+        'isClosed': _isClosed,
+        'messageControllerClosed': _messageController.isClosed,
+        'activeStreams': _streamSendingFinished.length,
+      };
+
+  @override
+  Future<RpcHealthStatus> health() async {
+    final details = _healthDetails();
+
+    if (_messageController.isClosed || _isClosed) {
+      return RpcHealthStatus.closed(
+        component: runtimeType.toString(),
+        message: 'Isolate host transport closed',
+        details: details,
+      );
+    }
+
+    return RpcHealthStatus.healthy(
+      component: runtimeType.toString(),
+      message: 'Isolate host transport ready',
+      details: details,
+    );
+  }
+
+  @override
+  Future<RpcHealthStatus> reconnect() async {
+    return RpcHealthStatus.degraded(
+      component: runtimeType.toString(),
+      message: 'Isolate host transport cannot reconnect; spawn a new isolate',
+      details: {..._healthDetails(), 'supported': false},
+    );
   }
 
   @override
@@ -242,13 +276,15 @@ class _IsolateHostTransport implements IRpcTransport {
   }) async {
     if (_isClosed) return;
 
-    _workerSendPort.send(_IsolateMessage(
-      type: _IsolateMessageType.metadata,
-      streamId: streamId,
-      data: metadata,
-      isEndOfStream: endStream,
-      methodPath: metadata.methodPath,
-    ));
+    _workerSendPort.send(
+      _IsolateMessage(
+        type: _IsolateMessageType.metadata,
+        streamId: streamId,
+        data: metadata,
+        isEndOfStream: endStream,
+        methodPath: metadata.methodPath,
+      ),
+    );
 
     if (endStream) {
       _streamSendingFinished[streamId] = true;
@@ -263,12 +299,14 @@ class _IsolateHostTransport implements IRpcTransport {
   }) async {
     if (_isClosed) return;
 
-    _workerSendPort.send(_IsolateMessage(
-      type: _IsolateMessageType.data,
-      streamId: streamId,
-      data: data,
-      isEndOfStream: endStream,
-    ));
+    _workerSendPort.send(
+      _IsolateMessage(
+        type: _IsolateMessageType.data,
+        streamId: streamId,
+        data: data,
+        isEndOfStream: endStream,
+      ),
+    );
 
     if (endStream) {
       _streamSendingFinished[streamId] = true;
@@ -284,10 +322,9 @@ class _IsolateHostTransport implements IRpcTransport {
     }
 
     _streamSendingFinished[streamId] = true;
-    _workerSendPort.send(_IsolateMessage(
-      type: _IsolateMessageType.finish,
-      streamId: streamId,
-    ));
+    _workerSendPort.send(
+      _IsolateMessage(type: _IsolateMessageType.finish, streamId: streamId),
+    );
   }
 
   @override
@@ -303,10 +340,12 @@ class _IsolateHostTransport implements IRpcTransport {
     _isClosed = true;
     _streamSendingFinished.clear();
 
-    _workerSendPort.send(_IsolateMessage(
-      type: _IsolateMessageType.close,
-      streamId: 0, // Специальный ID для сообщений управления
-    ));
+    _workerSendPort.send(
+      _IsolateMessage(
+        type: _IsolateMessageType.close,
+        streamId: 0, // Специальный ID для сообщений управления
+      ),
+    );
 
     _receivePort.close();
 
@@ -319,16 +358,21 @@ class _IsolateHostTransport implements IRpcTransport {
   bool get isClosed => _isClosed;
 
   @override
-  Future<void> sendDirectObject(int streamId, Object object,
-      {bool endStream = false}) async {
+  Future<void> sendDirectObject(
+    int streamId,
+    Object object, {
+    bool endStream = false,
+  }) async {
     if (_isClosed) return;
 
-    _workerSendPort.send(_IsolateMessage(
-      type: _IsolateMessageType.directObject,
-      streamId: streamId,
-      data: object, // Передаем объект напрямую
-      isEndOfStream: endStream,
-    ));
+    _workerSendPort.send(
+      _IsolateMessage(
+        type: _IsolateMessageType.directObject,
+        streamId: streamId,
+        data: object, // Передаем объект напрямую
+        isEndOfStream: endStream,
+      ),
+    );
 
     if (endStream) {
       _streamSendingFinished[streamId] = true;
@@ -365,11 +409,14 @@ class _IsolateWorkerTransport implements IRpcTransport {
   })  : _hostSendPort = hostSendPort,
         _messageStream = messageStream {
     // Настраиваем обработку входящих сообщений
-    _subscription = _messageStream.listen(_handleMessage, onDone: () {
-      if (!_messageController.isClosed) {
-        _messageController.close();
-      }
-    });
+    _subscription = _messageStream.listen(
+      _handleMessage,
+      onDone: () {
+        if (!_messageController.isClosed) {
+          _messageController.close();
+        }
+      },
+    );
   }
 
   void _handleMessage(dynamic message) {
@@ -378,38 +425,43 @@ class _IsolateWorkerTransport implements IRpcTransport {
     switch (message.type) {
       case _IsolateMessageType.metadata:
         final metadata = message.data as RpcMetadata;
-        _messageController.add(RpcTransportMessage(
-          metadata: metadata,
-          isEndOfStream: message.isEndOfStream,
-          streamId: message.streamId,
-          methodPath: message.methodPath,
-        ));
+        _messageController.add(
+          RpcTransportMessage(
+            metadata: metadata,
+            isEndOfStream: message.isEndOfStream,
+            streamId: message.streamId,
+            methodPath: message.methodPath,
+          ),
+        );
         break;
 
       case _IsolateMessageType.data:
         final data = message.data as Uint8List;
-        _messageController.add(RpcTransportMessage(
-          payload: data,
-          isEndOfStream: message.isEndOfStream,
-          streamId: message.streamId,
-          methodPath: message.methodPath,
-        ));
+        _messageController.add(
+          RpcTransportMessage(
+            payload: data,
+            isEndOfStream: message.isEndOfStream,
+            streamId: message.streamId,
+            methodPath: message.methodPath,
+          ),
+        );
         break;
 
       case _IsolateMessageType.directObject:
         // Передаем объект напрямую через directPayload поле
-        _messageController.add(RpcTransportMessage(
-          streamId: message.streamId,
-          isEndOfStream: message.isEndOfStream,
-          directPayload: message.data, // Объект передается как directPayload
-        ));
+        _messageController.add(
+          RpcTransportMessage(
+            streamId: message.streamId,
+            isEndOfStream: message.isEndOfStream,
+            directPayload: message.data, // Объект передается как directPayload
+          ),
+        );
         break;
 
       case _IsolateMessageType.finish:
-        _messageController.add(RpcTransportMessage(
-          isEndOfStream: true,
-          streamId: message.streamId,
-        ));
+        _messageController.add(
+          RpcTransportMessage(isEndOfStream: true, streamId: message.streamId),
+        );
         break;
 
       case _IsolateMessageType.close:
@@ -430,6 +482,40 @@ class _IsolateWorkerTransport implements IRpcTransport {
     return incomingMessages.where((message) => message.streamId == streamId);
   }
 
+  Map<String, Object?> _healthDetails() => {
+        'isClosed': _isClosed,
+        'messageControllerClosed': _messageController.isClosed,
+        'activeStreams': _streamSendingFinished.length,
+      };
+
+  @override
+  Future<RpcHealthStatus> health() async {
+    final details = _healthDetails();
+
+    if (_messageController.isClosed || _isClosed) {
+      return RpcHealthStatus.closed(
+        component: runtimeType.toString(),
+        message: 'Isolate worker transport closed',
+        details: details,
+      );
+    }
+
+    return RpcHealthStatus.healthy(
+      component: runtimeType.toString(),
+      message: 'Isolate worker transport ready',
+      details: details,
+    );
+  }
+
+  @override
+  Future<RpcHealthStatus> reconnect() async {
+    return RpcHealthStatus.degraded(
+      component: runtimeType.toString(),
+      message: 'Isolate worker transport cannot reconnect; restart the isolate',
+      details: {..._healthDetails(), 'supported': false},
+    );
+  }
+
   @override
   int createStream() {
     final streamId = _nextStreamId;
@@ -446,13 +532,15 @@ class _IsolateWorkerTransport implements IRpcTransport {
   }) async {
     if (_isClosed) return;
 
-    _hostSendPort.send(_IsolateMessage(
-      type: _IsolateMessageType.metadata,
-      streamId: streamId,
-      data: metadata,
-      isEndOfStream: endStream,
-      methodPath: metadata.methodPath,
-    ));
+    _hostSendPort.send(
+      _IsolateMessage(
+        type: _IsolateMessageType.metadata,
+        streamId: streamId,
+        data: metadata,
+        isEndOfStream: endStream,
+        methodPath: metadata.methodPath,
+      ),
+    );
 
     if (endStream) {
       _streamSendingFinished[streamId] = true;
@@ -467,12 +555,14 @@ class _IsolateWorkerTransport implements IRpcTransport {
   }) async {
     if (_isClosed) return;
 
-    _hostSendPort.send(_IsolateMessage(
-      type: _IsolateMessageType.data,
-      streamId: streamId,
-      data: data,
-      isEndOfStream: endStream,
-    ));
+    _hostSendPort.send(
+      _IsolateMessage(
+        type: _IsolateMessageType.data,
+        streamId: streamId,
+        data: data,
+        isEndOfStream: endStream,
+      ),
+    );
 
     if (endStream) {
       _streamSendingFinished[streamId] = true;
@@ -488,10 +578,9 @@ class _IsolateWorkerTransport implements IRpcTransport {
     }
 
     _streamSendingFinished[streamId] = true;
-    _hostSendPort.send(_IsolateMessage(
-      type: _IsolateMessageType.finish,
-      streamId: streamId,
-    ));
+    _hostSendPort.send(
+      _IsolateMessage(type: _IsolateMessageType.finish, streamId: streamId),
+    );
   }
 
   @override
@@ -518,16 +607,21 @@ class _IsolateWorkerTransport implements IRpcTransport {
   bool get isClosed => _isClosed;
 
   @override
-  Future<void> sendDirectObject(int streamId, Object object,
-      {bool endStream = false}) async {
+  Future<void> sendDirectObject(
+    int streamId,
+    Object object, {
+    bool endStream = false,
+  }) async {
     if (_isClosed) return;
 
-    _hostSendPort.send(_IsolateMessage(
-      type: _IsolateMessageType.directObject,
-      streamId: streamId,
-      data: object, // Передаем объект напрямую
-      isEndOfStream: endStream,
-    ));
+    _hostSendPort.send(
+      _IsolateMessage(
+        type: _IsolateMessageType.directObject,
+        streamId: streamId,
+        data: object, // Передаем объект напрямую
+        isEndOfStream: endStream,
+      ),
+    );
 
     if (endStream) {
       _streamSendingFinished[streamId] = true;

--- a/packages/rpc_dart_transports/lib/src/transports/websocket/reconnect_manager.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/websocket/reconnect_manager.dart
@@ -107,10 +107,8 @@ class WebSocketReconnectManager {
   /// Генератор случайных чисел для jitter
   final Random _random = Random();
 
-  WebSocketReconnectManager({
-    ReconnectConfig? config,
-    RpcLogger? logger,
-  })  : _config = config ?? const ReconnectConfig(),
+  WebSocketReconnectManager({ReconnectConfig? config, RpcLogger? logger})
+      : _config = config ?? const ReconnectConfig(),
         _logger = logger?.child('ReconnectManager'),
         _currentDelay = config?.initialDelay ?? const Duration(seconds: 1);
 
@@ -153,8 +151,9 @@ class WebSocketReconnectManager {
     if (_shouldReconnect()) {
       _scheduleReconnect();
     } else {
-      _logger
-          ?.info('Достигнуто максимальное количество попыток переподключения');
+      _logger?.info(
+        'Достигнуто максимальное количество попыток переподключения',
+      );
       _setState(ReconnectState.stopped);
     }
   }
@@ -199,7 +198,8 @@ class WebSocketReconnectManager {
 
     final delay = _calculateDelay();
     _logger?.info(
-        'Планируем переподключение через ${delay.inSeconds}s (попытка ${_attemptCount + 1})');
+      'Планируем переподключение через ${delay.inSeconds}s (попытка ${_attemptCount + 1})',
+    );
 
     _reconnectTimer = Timer(delay, () {
       _attemptReconnect();
@@ -282,8 +282,9 @@ class WebSocketReconnectManager {
     // Добавляем jitter если включен
     if (_config.enableJitter) {
       final jitterMs = _random.nextInt(1000); // до 1 секунды
-      cappedDelay =
-          Duration(milliseconds: cappedDelay.inMilliseconds + jitterMs);
+      cappedDelay = Duration(
+        milliseconds: cappedDelay.inMilliseconds + jitterMs,
+      );
     }
 
     return cappedDelay;

--- a/packages/rpc_dart_transports/lib/src/transports/websocket/rpc_websocket_server.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/websocket/rpc_websocket_server.dart
@@ -70,15 +70,19 @@ class RpcWebSocketServer implements IRpcServer {
       logger: logger,
       onEndpointCreated: (endpoint) {
         logger?.debug(
-            'Регистрация ${contracts.length} контрактов на новом WebSocket endpoint');
+          'Регистрация ${contracts.length} контрактов на новом WebSocket endpoint',
+        );
         for (final contract in contracts) {
           endpoint.registerServiceContract(contract);
           logger?.debug('Зарегистрирован контракт: ${contract.serviceName}');
         }
       },
       onConnectionError: (error, stackTrace) {
-        logger?.error('Ошибка WebSocket соединения',
-            error: error, stackTrace: stackTrace);
+        logger?.error(
+          'Ошибка WebSocket соединения',
+          error: error,
+          stackTrace: stackTrace,
+        );
       },
     );
   }
@@ -114,8 +118,11 @@ class RpcWebSocketServer implements IRpcServer {
         _handleWebSocketConnection(channel, label);
       },
       onError: (Object error, StackTrace st) {
-        _logger?.error('Ошибка потока подключений',
-            error: error, stackTrace: st);
+        _logger?.error(
+          'Ошибка потока подключений',
+          error: error,
+          stackTrace: st,
+        );
         _onConnectionError?.call(error, st);
       },
       onDone: () {
@@ -159,7 +166,9 @@ class RpcWebSocketServer implements IRpcServer {
 
   /// Обрабатывает новое WebSocket соединение (общая RPC-логика).
   void _handleWebSocketConnection(
-      WebSocketChannel channel, String clientLabel) {
+    WebSocketChannel channel,
+    String clientLabel,
+  ) {
     _onConnectionOpened?.call(channel);
 
     try {
@@ -193,13 +202,17 @@ class RpcWebSocketServer implements IRpcServer {
         _onConnectionClosed?.call(channel);
       }).catchError((error) {
         _logger?.warning(
-            'Ошибка при закрытии WebSocket соединения $clientLabel: $error');
+          'Ошибка при закрытии WebSocket соединения $clientLabel: $error',
+        );
         _endpoints.remove(endpoint);
         _onConnectionClosed?.call(channel);
       });
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при создании WebSocket RPC соединения',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при создании WebSocket RPC соединения',
+        error: e,
+        stackTrace: stackTrace,
+      );
       _onConnectionError?.call(e, stackTrace);
       channel.sink.close();
     }

--- a/packages/rpc_dart_transports/lib/src/transports/websocket/websocket_base_transport.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/websocket/websocket_base_transport.dart
@@ -15,7 +15,13 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 /// Протокол сообщений: [streamId:4байта][flags:1байт][gRPC_frame...]
 abstract class RpcWebSocketTransportBase implements IRpcTransport {
   /// WebSocket канал для обмена сообщениями
-  final WebSocketChannel _channel;
+  WebSocketChannel _channel;
+
+  /// Фабрика для переподключения (только для клиентских транспортов).
+  final Future<WebSocketChannel> Function()? _reconnectFactory;
+
+  /// Текущая подписка на поток сообщений канала.
+  StreamSubscription? _channelSubscription;
 
   /// Контроллер для управления потоком входящих сообщений
   final StreamController<RpcTransportMessage> _incomingController =
@@ -38,9 +44,12 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
   /// [channel] WebSocket канал для коммуникации
   /// [logger] Опциональный логгер для отладки
   RpcWebSocketTransportBase(
-    this._channel, {
+    WebSocketChannel channel, {
     RpcLogger? logger,
-  }) : _logger = logger {
+    Future<WebSocketChannel> Function()? reconnectFactory,
+  })  : _channel = channel,
+        _reconnectFactory = reconnectFactory,
+        _logger = logger {
     _setupListener();
   }
 
@@ -50,11 +59,13 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
   /// Устанавливает слушатель для входящих WebSocket сообщений
   void _setupListener() {
     _logger?.debug('Устанавливаем слушатель WebSocket');
-    _channel.stream.listen(
+    _channelSubscription?.cancel();
+    _channelSubscription = _channel.stream.listen(
       _handleIncomingMessage,
       onError: _handleError,
       onDone: _handleDone,
     );
+    _closed = false;
     _logger?.debug('Слушатель WebSocket установлен');
   }
 
@@ -105,7 +116,10 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
 
   /// Обрабатывает сообщение с метаданными
   void _handleMetadataMessage(
-      int streamId, Uint8List payload, bool isEndOfStream) {
+    int streamId,
+    Uint8List payload,
+    bool isEndOfStream,
+  ) {
     try {
       // Десериализуем метаданные из JSON
       final jsonStr = utf8.decode(payload);
@@ -115,10 +129,12 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
       if (jsonData['headers'] is List) {
         for (final headerData in jsonData['headers'] as List) {
           if (headerData is Map<String, dynamic>) {
-            headers.add(RpcHeader(
-              headerData['name'] as String,
-              headerData['value'] as String,
-            ));
+            headers.add(
+              RpcHeader(
+                headerData['name'] as String,
+                headerData['value'] as String,
+              ),
+            );
           }
         }
       }
@@ -136,8 +152,11 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
       _incomingController.add(transportMessage);
       _logger?.debug('Получены метаданные для stream $streamId');
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при парсинге метаданных: $e',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при парсинге метаданных: $e',
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
   }
 
@@ -180,7 +199,8 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
       }
 
       _logger?.debug(
-          'Обработано ${messages.length} сообщений для stream $streamId');
+        'Обработано ${messages.length} сообщений для stream $streamId',
+      );
 
       // Очищаем парсер при завершении потока
       if (isEndOfStream) {
@@ -188,8 +208,11 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
         idManager.releaseId(streamId);
       }
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при парсинге данных: $e',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при парсинге данных: $e',
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
   }
 
@@ -205,7 +228,14 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
   /// Обрабатывает закрытие WebSocket соединения
   void _handleDone() {
     _logger?.info('WebSocket соединение закрыто');
-    close();
+    _channelSubscription = null;
+    _closed = true;
+
+    if (_reconnectFactory == null) {
+      close();
+    } else {
+      _logger?.debug('Ожидание переподключения WebSocket транспорта');
+    }
   }
 
   @override
@@ -215,6 +245,105 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
   @override
   Stream<RpcTransportMessage> getMessagesForStream(int streamId) {
     return incomingMessages.where((message) => message.streamId == streamId);
+  }
+
+  Map<String, Object?> _healthDetails() => {
+        'isClosed': _closed,
+        'incomingControllerClosed': _incomingController.isClosed,
+        'activeParsers': _streamParsers.length,
+        'reconnectSupported': _reconnectFactory != null,
+      };
+
+  @override
+  Future<RpcHealthStatus> health() async {
+    final details = _healthDetails();
+
+    if (_incomingController.isClosed) {
+      return RpcHealthStatus.closed(
+        component: runtimeType.toString(),
+        message: 'WebSocket transport closed',
+        details: details,
+      );
+    }
+
+    if (_closed) {
+      return RpcHealthStatus.degraded(
+        component: runtimeType.toString(),
+        message: _reconnectFactory != null
+            ? 'WebSocket connection is closed awaiting reconnect'
+            : 'WebSocket transport closed',
+        details: details,
+      );
+    }
+
+    return RpcHealthStatus.healthy(
+      component: runtimeType.toString(),
+      message: 'WebSocket transport ready',
+      details: details,
+    );
+  }
+
+  @override
+  Future<RpcHealthStatus> reconnect() async {
+    if (_incomingController.isClosed) {
+      return RpcHealthStatus.closed(
+        component: runtimeType.toString(),
+        message: 'WebSocket transport closed',
+        details: {..._healthDetails(), 'supported': _reconnectFactory != null},
+      );
+    }
+
+    if (_reconnectFactory == null) {
+      return RpcHealthStatus.degraded(
+        component: runtimeType.toString(),
+        message: 'Reconnect is not configured for this WebSocket transport',
+        details: {..._healthDetails(), 'supported': false},
+      );
+    }
+
+    try {
+      await _channel.sink.close();
+    } catch (_) {
+      // Игнорируем ошибки закрытия существующего канала
+    }
+
+    if (_channelSubscription != null) {
+      await _channelSubscription!.cancel();
+      _channelSubscription = null;
+    }
+
+    _streamParsers.clear();
+
+    try {
+      _channel = await _reconnectFactory!();
+    } catch (error, stackTrace) {
+      if (_logger != null) {
+        await _logger!.error(
+          'Не удалось переподключить WebSocket транспорт: $error',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+
+      _closed = true;
+      return RpcHealthStatus.unhealthy(
+        component: runtimeType.toString(),
+        message: 'Failed to reconnect WebSocket transport: $error',
+        details: {
+          ..._healthDetails(),
+          'supported': true,
+          'error': error.toString(),
+        },
+      );
+    }
+
+    _setupListener();
+
+    return RpcHealthStatus.healthy(
+      component: runtimeType.toString(),
+      message: 'WebSocket connection re-established',
+      details: {..._healthDetails(), 'supported': true},
+    );
   }
 
   @override
@@ -250,10 +379,7 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
       // Сериализуем метаданные в JSON
       final metadataJson = {
         'headers': metadata.headers
-            .map((h) => {
-                  'name': h.name,
-                  'value': h.value,
-                })
+            .map((h) => {'name': h.name, 'value': h.value})
             .toList(),
         if (metadata.methodPath != null) 'methodPath': metadata.methodPath,
       };
@@ -262,14 +388,22 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
       final payload = utf8.encode(jsonStr);
 
       // Отправляем с флагом метаданных
-      await _sendWithHeader(streamId, Uint8List.fromList(payload),
-          isMetadata: true, endStream: endStream);
+      await _sendWithHeader(
+        streamId,
+        Uint8List.fromList(payload),
+        isMetadata: true,
+        endStream: endStream,
+      );
 
       _logger?.debug(
-          'Отправлены метаданные для stream $streamId, endStream: $endStream');
+        'Отправлены метаданные для stream $streamId, endStream: $endStream',
+      );
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при отправке метаданных: $e',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при отправке метаданных: $e',
+        error: e,
+        stackTrace: stackTrace,
+      );
       rethrow;
     }
   }
@@ -290,7 +424,8 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
       await _sendWithHeader(streamId, encoded, endStream: endStream);
 
       _logger?.debug(
-          'Отправлено сообщение для stream $streamId, размер: ${data.length} байт, endStream: $endStream');
+        'Отправлено сообщение для stream $streamId, размер: ${data.length} байт, endStream: $endStream',
+      );
 
       if (endStream) {
         idManager.releaseId(streamId);
@@ -317,8 +452,11 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
 
       idManager.releaseId(streamId);
     } catch (e, stackTrace) {
-      _logger?.error('Ошибка при завершении отправки: $e',
-          error: e, stackTrace: stackTrace);
+      _logger?.error(
+        'Ошибка при завершении отправки: $e',
+        error: e,
+        stackTrace: stackTrace,
+      );
       rethrow;
     }
   }
@@ -354,26 +492,36 @@ abstract class RpcWebSocketTransportBase implements IRpcTransport {
 
   @override
   Future<void> close() async {
-    if (_closed) return;
+    if (_closed && _incomingController.isClosed) return;
 
     _closed = true;
-
-    // Очищаем парсеры
     _streamParsers.clear();
+
+    final subscription = _channelSubscription;
+    _channelSubscription = null;
+    if (subscription != null) {
+      await subscription.cancel();
+    }
 
     try {
       await _channel.sink.close();
-      await _incomingController.close();
-      _logger?.info('WebSocket транспорт закрыт');
     } catch (e) {
       _logger?.error('Ошибка при закрытии WebSocket: $e');
       rethrow;
+    } finally {
+      if (!_incomingController.isClosed) {
+        await _incomingController.close();
+      }
+      _logger?.info('WebSocket транспорт закрыт');
     }
   }
 
   @override
-  Future<void> sendDirectObject(int streamId, Object object,
-      {bool endStream = false}) async {
+  Future<void> sendDirectObject(
+    int streamId,
+    Object object, {
+    bool endStream = false,
+  }) async {
     throw UnimplementedError('Unsupport direct object sending');
   }
 }

--- a/packages/rpc_dart_transports/lib/src/transports/websocket/websocket_caller_transport.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/websocket/websocket_caller_transport.dart
@@ -13,8 +13,9 @@ import 'websocket_base_transport.dart';
 /// и использует нечетные StreamID для мультиплексирования.
 class RpcWebSocketCallerTransport extends RpcWebSocketTransportBase {
   /// Реализация менеджера ID для клиентской стороны
-  final RpcStreamIdManager _streamIdManager =
-      RpcStreamIdManager(isClient: true);
+  final RpcStreamIdManager _streamIdManager = RpcStreamIdManager(
+    isClient: true,
+  );
 
   @override
   RpcStreamIdManager get idManager => _streamIdManager;
@@ -29,6 +30,7 @@ class RpcWebSocketCallerTransport extends RpcWebSocketTransportBase {
   RpcWebSocketCallerTransport(
     super.channel, {
     super.logger,
+    super.reconnectFactory,
   });
 
   /// Фабричный метод для создания клиентского WebSocket транспорта
@@ -42,11 +44,15 @@ class RpcWebSocketCallerTransport extends RpcWebSocketTransportBase {
     Iterable<String>? protocols,
     RpcLogger? logger,
   }) {
-    final channel = WebSocketChannel.connect(
-      uri,
-      protocols: protocols,
+    WebSocketChannel openChannel() =>
+        WebSocketChannel.connect(uri, protocols: protocols);
+
+    final channel = openChannel();
+    return RpcWebSocketCallerTransport(
+      channel,
+      logger: logger,
+      reconnectFactory: () async => openChannel(),
     );
-    return RpcWebSocketCallerTransport(channel, logger: logger);
   }
 
   @override

--- a/packages/rpc_dart_transports/lib/src/transports/websocket/websocket_responder_transport.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/websocket/websocket_responder_transport.dart
@@ -12,8 +12,9 @@ import 'websocket_base_transport.dart';
 /// и использует четные StreamID для мультиплексирования.
 class RpcWebSocketResponderTransport extends RpcWebSocketTransportBase {
   /// Реализация менеджера ID для серверной стороны
-  final RpcStreamIdManager _streamIdManager =
-      RpcStreamIdManager(isClient: false);
+  final RpcStreamIdManager _streamIdManager = RpcStreamIdManager(
+    isClient: false,
+  );
 
   @override
   RpcStreamIdManager get idManager => _streamIdManager;
@@ -25,10 +26,7 @@ class RpcWebSocketResponderTransport extends RpcWebSocketTransportBase {
   ///
   /// [channel] WebSocket канал для коммуникации
   /// [logger] Опциональный логгер для отладки
-  RpcWebSocketResponderTransport(
-    super.channel, {
-    super.logger,
-  });
+  RpcWebSocketResponderTransport(super.channel, {super.logger});
 
   @override
   bool get supportsZeroCopy => false;

--- a/packages/rpc_dart_transports/pubspec.yaml
+++ b/packages/rpc_dart_transports/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rpc_dart_transports
 description: RPC Dart Transports library
-version: 1.1.2
+version: 1.2.0
 repository: https://github.com/nogipx/rpc_dart.git
 homepage: https://rpc.nogipx.dev
 issue_tracker: https://github.com/nogipx/rpc_dart/issues
@@ -14,13 +14,19 @@ topics:
   - network
 
 dependencies:
-  rpc_dart: ^2.2.2
+  rpc_dart: ^2.3.0
   uuid: ^4.5.1
   web_socket_channel: ^3.0.3
   args: ^2.7.0
   http2: ^2.3.1
   universal_io: ^2.2.2
 
+dependency_overrides:
+  rpc_dart:
+    path: ../rpc_dart
+
 dev_dependencies:
   lints: ^5.1.1
   test: ^1.26.3
+  shelf: any
+  shelf_web_socket: any

--- a/packages/rpc_dart_transports/test/http2_rpc_integration_test.dart
+++ b/packages/rpc_dart_transports/test/http2_rpc_integration_test.dart
@@ -106,7 +106,7 @@ void main() {
       final messages = [
         RpcString('Message 1'),
         RpcString('Message 2'),
-        RpcString('Message 3')
+        RpcString('Message 3'),
       ];
 
       final requestStream = Stream.fromIterable(messages).map((msg) {
@@ -125,7 +125,8 @@ void main() {
       final response = await callFunction(requestStream).timeout(
         Duration(seconds: 5),
         onTimeout: () => throw TimeoutException(
-            'Timeout waiting for client streaming response'),
+          'Timeout waiting for client streaming response',
+        ),
       );
 
       // Assert
@@ -142,7 +143,7 @@ void main() {
       final messages = [
         RpcString('Bidirectional message #1'),
         RpcString('Bidirectional message #2'),
-        RpcString('Bidirectional message #3')
+        RpcString('Bidirectional message #3'),
       ];
 
       // Создаем StreamController для контроля закрытия
@@ -196,7 +197,8 @@ void main() {
       await completer.future.timeout(
         Duration(seconds: 30),
         onTimeout: () => throw TimeoutException(
-            'Timeout waiting for bidirectional responses'),
+          'Timeout waiting for bidirectional responses',
+        ),
       );
 
       expect(responses.length, equals(3));
@@ -205,7 +207,8 @@ void main() {
       expect(responses[2], equals('Echo: Bidirectional message #3'));
 
       print(
-          '✅ Bidirectional Streaming RPC через Caller/Responder работает отлично!');
+        '✅ Bidirectional Streaming RPC через Caller/Responder работает отлично!',
+      );
     });
 
     test('параллельные_rpc_вызовы_разных_типов', () async {
@@ -243,7 +246,8 @@ void main() {
             .then((responses) {
           expect(responses.length, equals(2));
           print(
-              '✅ Параллельный server streaming завершен: ${responses.length} ответов');
+            '✅ Параллельный server streaming завершен: ${responses.length} ответов',
+          );
         }),
       );
 
@@ -254,7 +258,8 @@ void main() {
       );
 
       print(
-          '✅ Все параллельные RPC вызовы через Caller/Responder завершены успешно!');
+        '✅ Все параллельные RPC вызовы через Caller/Responder завершены успешно!',
+      );
     });
   });
 }
@@ -307,7 +312,8 @@ final class TestServiceContract extends RpcResponderContract {
         }
 
         return RpcString(
-            'Received ${messages.length} client messages: ${messages.join(", ")}');
+          'Received ${messages.length} client messages: ${messages.join(", ")}',
+        );
       },
       requestCodec: RpcString.codec,
       responseCodec: RpcString.codec,

--- a/packages/rpc_dart_transports/test/isolate_crash_isolation_test.dart
+++ b/packages/rpc_dart_transports/test/isolate_crash_isolation_test.dart
@@ -33,8 +33,11 @@ void crashingServer(IRpcTransport transport, Map<String, dynamic> params) {
         switch (payload) {
           case 'PING':
             print('🏓 [Crashing Server] PONG от ${currentIsolate.debugName}');
-            await transport.sendDirectObject(message.streamId, 'PONG',
-                endStream: true);
+            await transport.sendDirectObject(
+              message.streamId,
+              'PONG',
+              endStream: true,
+            );
             break;
 
           case 'CRASH_NOW':
@@ -80,8 +83,11 @@ void stableServer(IRpcTransport transport, Map<String, dynamic> params) {
 
       if (payload is String && payload == 'PING') {
         print('🏓 [Stable Server] PONG от ${currentIsolate.debugName}');
-        await transport.sendDirectObject(message.streamId, 'PONG from stable',
-            endStream: true);
+        await transport.sendDirectObject(
+          message.streamId,
+          'PONG from stable',
+          endStream: true,
+        );
       }
     }
   });
@@ -132,8 +138,9 @@ void main() {
         final stableStreamId1 = stableResult.transport.createStream();
         final stablePingFuture1 = stableResult.transport
             .getMessagesForStream(stableStreamId1)
-            .where((msg) =>
-                msg.isDirect && msg.directPayload == 'PONG from stable')
+            .where(
+              (msg) => msg.isDirect && msg.directPayload == 'PONG from stable',
+            )
             .first
             .timeout(Duration(seconds: 2));
 
@@ -147,8 +154,10 @@ void main() {
         final crashStreamId2 = crashResult.transport.createStream();
 
         // Отправляем команду краша и ожидаем что соединение разорвется
-        await crashResult.transport
-            .sendDirectObject(crashStreamId2, 'CRASH_NOW');
+        await crashResult.transport.sendDirectObject(
+          crashStreamId2,
+          'CRASH_NOW',
+        );
 
         // Ждем немного чтобы краш произошел
         await Future.delayed(Duration(milliseconds: 100));
@@ -165,15 +174,17 @@ void main() {
         final stableStreamId2 = stableResult.transport.createStream();
         final stablePingFuture2 = stableResult.transport
             .getMessagesForStream(stableStreamId2)
-            .where((msg) =>
-                msg.isDirect && msg.directPayload == 'PONG from stable')
+            .where(
+              (msg) => msg.isDirect && msg.directPayload == 'PONG from stable',
+            )
             .first
             .timeout(Duration(seconds: 2));
 
         await stableResult.transport.sendDirectObject(stableStreamId2, 'PING');
         await stablePingFuture2;
         print(
-            '✅ Stable worker продолжает работать после краша другого изолята');
+          '✅ Stable worker продолжает работать после краша другого изолята',
+        );
 
         // Act 4 - проверяем что crashed worker действительно мертв
         print('💀 Проверяем что crashed worker действительно мертв...');
@@ -191,7 +202,8 @@ void main() {
           fail('Crashed worker не должен отвечать');
         } on TimeoutException {
           print(
-              '✅ Crashed worker действительно мертв (timeout при попытке связи)');
+            '✅ Crashed worker действительно мертв (timeout при попытке связи)',
+          );
         }
       } finally {
         // Cleanup
@@ -220,7 +232,7 @@ void main() {
         isolateResults.add((
           transport: result.transport,
           kill: result.kill,
-          name: isStable ? 'stable-$i' : 'crash-$i'
+          name: isStable ? 'stable-$i' : 'crash-$i',
         ));
       }
 
@@ -252,7 +264,8 @@ void main() {
           print('💀 Крашим ${crashIsolate.name}...');
           await crashIsolate.transport.sendDirectObject(streamId, 'CRASH_NOW');
           await Future.delayed(
-              Duration(milliseconds: 50)); // Даем время на краш
+            Duration(milliseconds: 50),
+          ); // Даем время на краш
         }
 
         // Act 3 - проверяем что stable изоляты все еще работают
@@ -264,8 +277,10 @@ void main() {
           final streamId = stableIsolate.transport.createStream();
           final pingFuture = stableIsolate.transport
               .getMessagesForStream(streamId)
-              .where((msg) =>
-                  msg.isDirect && msg.directPayload == 'PONG from stable')
+              .where(
+                (msg) =>
+                    msg.isDirect && msg.directPayload == 'PONG from stable',
+              )
               .first
               .timeout(Duration(seconds: 2));
 

--- a/packages/rpc_dart_transports/test/isolate_transport_test.dart
+++ b/packages/rpc_dart_transports/test/isolate_transport_test.dart
@@ -39,18 +39,19 @@ class TestLargeObject {
   static TestLargeObject generate(int size) {
     final random = Random();
     final data = List.generate(
-        size,
-        (index) => {
-              'id': index,
-              'value': random.nextDouble(),
-              'text': 'Item $index with random data ${random.nextInt(1000)}',
-              'nested': {
-                'level1': {
-                  'level2': 'deep value $index',
-                  'array': List.generate(5, (i) => 'item_${index}_$i'),
-                }
-              },
-            });
+      size,
+      (index) => {
+        'id': index,
+        'value': random.nextDouble(),
+        'text': 'Item $index with random data ${random.nextInt(1000)}',
+        'nested': {
+          'level1': {
+            'level2': 'deep value $index',
+            'array': List.generate(5, (i) => 'item_${index}_$i'),
+          },
+        },
+      },
+    );
     return TestLargeObject(data);
   }
 
@@ -176,8 +177,11 @@ void main() {
 
         // Assert
         for (final streamId in streamIds) {
-          expect(streamId % 2, equals(1),
-              reason: 'Stream ID должен быть нечетным');
+          expect(
+            streamId % 2,
+            equals(1),
+            reason: 'Stream ID должен быть нечетным',
+          );
         }
 
         // Cleanup
@@ -386,11 +390,17 @@ void main() {
 
         // Act
         await transport.sendMessage(
-            streamId1, Uint8List.fromList('message1'.codeUnits));
+          streamId1,
+          Uint8List.fromList('message1'.codeUnits),
+        );
         await transport.sendMessage(
-            streamId2, Uint8List.fromList('message2'.codeUnits));
+          streamId2,
+          Uint8List.fromList('message2'.codeUnits),
+        );
         await transport.sendMessage(
-            streamId1, Uint8List.fromList('message3'.codeUnits));
+          streamId1,
+          Uint8List.fromList('message3'.codeUnits),
+        );
 
         // Даем время для обработки в изоляте
         await Future.delayed(Duration(milliseconds: 200));
@@ -575,8 +585,10 @@ void main() {
         // Проверяем, что объект прошел без потерь и был модифицирован сервером
         expect(responseObject.id, equals(42));
         expect(responseObject.name, equals('Test User [PROCESSED]'));
-        expect(responseObject.metadata['roles'],
-            equals(['admin', 'user', 'zero-copy']));
+        expect(
+          responseObject.metadata['roles'],
+          equals(['admin', 'user', 'zero-copy']),
+        );
         expect(responseObject.tags.length, equals(3)); // добавился 'processed'
         expect(responseObject.isActive, equals(true));
 
@@ -601,7 +613,7 @@ void main() {
         // Act - отправляем разные типы данных
         final testCases = [
           {
-            'numbers': [1, 2, 3, 4, 5]
+            'numbers': [1, 2, 3, 4, 5],
           },
           'simple string',
           42,
@@ -610,7 +622,7 @@ void main() {
             1,
             'mixed',
             true,
-            {'nested': 'value'}
+            {'nested': 'value'},
           ],
         ];
 
@@ -650,8 +662,9 @@ void main() {
         );
 
         final transport = result.transport;
-        final largeObject =
-            TestLargeObject.generate(5000); // Увеличиваем размер
+        final largeObject = TestLargeObject.generate(
+          5000,
+        ); // Увеличиваем размер
 
         // Act & Assert - Zero-copy
         final stopwatchZeroCopy = Stopwatch()..start();
@@ -684,12 +697,15 @@ void main() {
 
         if (zeroCopyTime < serializedTime) {
           print(
-              '✅ Zero-copy быстрее в ${(serializedTime / zeroCopyTime).toStringAsFixed(2)}x раз');
+            '✅ Zero-copy быстрее в ${(serializedTime / zeroCopyTime).toStringAsFixed(2)}x раз',
+          );
         } else {
           print(
-              '⚠️ Для данного размера сериализация быстрее в ${(zeroCopyTime / serializedTime).toStringAsFixed(2)}x раз');
+            '⚠️ Для данного размера сериализация быстрее в ${(zeroCopyTime / serializedTime).toStringAsFixed(2)}x раз',
+          );
           print(
-              '💡 Zero-copy эффективен для очень больших или сложных объектов');
+            '💡 Zero-copy эффективен для очень больших или сложных объектов',
+          );
         }
 
         // Главное преимущество zero-copy - не нужна сериализация/десериализация
@@ -766,8 +782,11 @@ void main() {
         final released = transport.releaseStreamId(streamId);
 
         // Assert
-        expect(released, isTrue,
-            reason: 'Должен вернуть true для активного stream');
+        expect(
+          released,
+          isTrue,
+          reason: 'Должен вернуть true для активного stream',
+        );
 
         // Cleanup
         result.kill();
@@ -787,8 +806,11 @@ void main() {
         final released = transport.releaseStreamId(99999);
 
         // Assert
-        expect(released, isFalse,
-            reason: 'Должен вернуть false для несуществующего stream');
+        expect(
+          released,
+          isFalse,
+          reason: 'Должен вернуть false для несуществующего stream',
+        );
 
         // Cleanup
         result.kill();
@@ -810,10 +832,16 @@ void main() {
         final secondRelease = transport.releaseStreamId(streamId);
 
         // Assert
-        expect(firstRelease, isTrue,
-            reason: 'Первое освобождение должно быть успешным');
-        expect(secondRelease, isFalse,
-            reason: 'Повторное освобождение должно вернуть false');
+        expect(
+          firstRelease,
+          isTrue,
+          reason: 'Первое освобождение должно быть успешным',
+        );
+        expect(
+          secondRelease,
+          isFalse,
+          reason: 'Повторное освобождение должно вернуть false',
+        );
 
         // Cleanup
         result.kill();
@@ -835,8 +863,11 @@ void main() {
         final released = transport.releaseStreamId(streamId);
 
         // Assert
-        expect(released, isFalse,
-            reason: 'Должен вернуть false для закрытого транспорта');
+        expect(
+          released,
+          isFalse,
+          reason: 'Должен вернуть false для закрытого транспорта',
+        );
         expect(transport.isClosed, isTrue);
 
         // Cleanup
@@ -858,53 +889,61 @@ void main() {
         final results = streamIds.map(transport.releaseStreamId).toList();
 
         // Assert
-        expect(results.every((result) => result == true), isTrue,
-            reason: 'Все streams должны быть освобождены успешно');
+        expect(
+          results.every((result) => result == true),
+          isTrue,
+          reason: 'Все streams должны быть освобождены успешно',
+        );
 
         // Повторное освобождение должно вернуть false
         final secondResults = streamIds.map(transport.releaseStreamId).toList();
-        expect(secondResults.every((result) => result == false), isTrue,
-            reason: 'Повторное освобождение должно вернуть false');
-
-        // Cleanup
-        result.kill();
-      });
-
-      test('корректно_работает_с_отправкой_сообщений_после_освобождения',
-          () async {
-        // Arrange
-        final result = await RpcIsolateTransport.spawn(
-          entrypoint: _testEchoServer,
-          customParams: {},
-          isolateId: 'release-after-message-test',
+        expect(
+          secondResults.every((result) => result == false),
+          isTrue,
+          reason: 'Повторное освобождение должно вернуть false',
         );
 
-        final transport = result.transport;
-        final streamId = transport.createStream();
-        final receivedMessages = <RpcTransportMessage>[];
-
-        transport.incomingMessages.listen(receivedMessages.add);
-
-        // Act - отправляем сообщение
-        final testData = Uint8List.fromList('Test message'.codeUnits);
-        await transport.sendMessage(streamId, testData);
-
-        // Ждем ответ
-        await Future.delayed(Duration(milliseconds: 100));
-
-        // Освобождаем stream
-        final released = transport.releaseStreamId(streamId);
-
-        // Пытаемся отправить еще одно сообщение (не должно вызывать ошибку)
-        await transport.sendMessage(streamId, testData);
-
-        // Assert
-        expect(released, isTrue);
-        expect(receivedMessages.length, greaterThan(0));
-
         // Cleanup
         result.kill();
       });
+
+      test(
+        'корректно_работает_с_отправкой_сообщений_после_освобождения',
+        () async {
+          // Arrange
+          final result = await RpcIsolateTransport.spawn(
+            entrypoint: _testEchoServer,
+            customParams: {},
+            isolateId: 'release-after-message-test',
+          );
+
+          final transport = result.transport;
+          final streamId = transport.createStream();
+          final receivedMessages = <RpcTransportMessage>[];
+
+          transport.incomingMessages.listen(receivedMessages.add);
+
+          // Act - отправляем сообщение
+          final testData = Uint8List.fromList('Test message'.codeUnits);
+          await transport.sendMessage(streamId, testData);
+
+          // Ждем ответ
+          await Future.delayed(Duration(milliseconds: 100));
+
+          // Освобождаем stream
+          final released = transport.releaseStreamId(streamId);
+
+          // Пытаемся отправить еще одно сообщение (не должно вызывать ошибку)
+          await transport.sendMessage(streamId, testData);
+
+          // Assert
+          expect(released, isTrue);
+          expect(receivedMessages.length, greaterThan(0));
+
+          // Cleanup
+          result.kill();
+        },
+      );
     });
   });
 }
@@ -926,7 +965,9 @@ void _testEchoServer(IRpcTransport transport, Map<String, dynamic> params) {
 /// Сервер для тестирования параметров
 @pragma('vm:entry-point')
 void _testParameterServer(
-    IRpcTransport transport, Map<String, dynamic> params) {
+  IRpcTransport transport,
+  Map<String, dynamic> params,
+) {
   final responsePrefix = params['responsePrefix'] as String? ?? '[DEFAULT]: ';
 
   transport.incomingMessages.listen((message) async {
@@ -949,7 +990,9 @@ void _faultyServer(IRpcTransport transport, Map<String, dynamic> params) {
 /// Мульти-стрим сервер для тестирования фильтрации
 @pragma('vm:entry-point')
 void _testMultiStreamServer(
-    IRpcTransport transport, Map<String, dynamic> params) {
+  IRpcTransport transport,
+  Map<String, dynamic> params,
+) {
   transport.incomingMessages.listen((message) async {
     if (!message.isMetadataOnly && message.payload != null) {
       final originalText = String.fromCharCodes(message.payload!);
@@ -965,7 +1008,9 @@ void _testMultiStreamServer(
 /// Полный цикл сервер для интеграционных тестов
 @pragma('vm:entry-point')
 void _testFullCycleServer(
-    IRpcTransport transport, Map<String, dynamic> params) {
+  IRpcTransport transport,
+  Map<String, dynamic> params,
+) {
   final responseCount = params['responseCount'] as int? ?? 1;
 
   transport.incomingMessages.listen((message) async {
@@ -983,8 +1028,11 @@ void _testFullCycleServer(
 
       // Отправляем финальные метаданные
       final finalMetadata = RpcMetadata.forTrailer(RpcStatus.OK);
-      await transport.sendMetadata(message.streamId, finalMetadata,
-          endStream: true);
+      await transport.sendMetadata(
+        message.streamId,
+        finalMetadata,
+        endStream: true,
+      );
     }
   });
 }
@@ -995,10 +1043,15 @@ void _testErrorServer(IRpcTransport transport, Map<String, dynamic> params) {
   transport.incomingMessages.listen((message) async {
     if (!message.isMetadataOnly && message.payload != null) {
       // Отправляем ошибку
-      final errorMetadata =
-          RpcMetadata.forTrailer(RpcStatus.INTERNAL, message: 'Test error');
-      await transport.sendMetadata(message.streamId, errorMetadata,
-          endStream: true);
+      final errorMetadata = RpcMetadata.forTrailer(
+        RpcStatus.INTERNAL,
+        message: 'Test error',
+      );
+      await transport.sendMetadata(
+        message.streamId,
+        errorMetadata,
+        endStream: true,
+      );
     }
   });
 }
@@ -1043,8 +1096,11 @@ void _testZeroCopyServer(IRpcTransport transport, Map<String, dynamic> params) {
       );
 
       // Отправляем назад через zero-copy
-      await transport.sendDirectObject(message.streamId, modifiedObject,
-          endStream: true);
+      await transport.sendDirectObject(
+        message.streamId,
+        modifiedObject,
+        endStream: true,
+      );
     }
   });
 }
@@ -1052,7 +1108,9 @@ void _testZeroCopyServer(IRpcTransport transport, Map<String, dynamic> params) {
 /// Zero-copy сервер для примитивов и коллекций
 @pragma('vm:entry-point')
 void _testPrimitivesZeroCopyServer(
-    IRpcTransport transport, Map<String, dynamic> params) {
+  IRpcTransport transport,
+  Map<String, dynamic> params,
+) {
   transport.incomingMessages.listen((message) async {
     if (message.isDirect && message.directPayload != null) {
       // Получаем любой объект и отправляем эхо-ответ
@@ -1067,7 +1125,9 @@ void _testPrimitivesZeroCopyServer(
 /// Сервер для тестирования производительности
 @pragma('vm:entry-point')
 void _testPerformanceServer(
-    IRpcTransport transport, Map<String, dynamic> params) {
+  IRpcTransport transport,
+  Map<String, dynamic> params,
+) {
   transport.incomingMessages.listen((message) async {
     if (message.isDirect && message.directPayload != null) {
       // Просто отправляем подтверждение
@@ -1083,7 +1143,9 @@ void _testPerformanceServer(
 /// Zero-copy сервер с обработкой ошибок
 @pragma('vm:entry-point')
 void _testZeroCopyErrorServer(
-    IRpcTransport transport, Map<String, dynamic> params) {
+  IRpcTransport transport,
+  Map<String, dynamic> params,
+) {
   transport.incomingMessages.listen((message) async {
     if (message.isDirect && message.directPayload != null) {
       final receivedObject = message.directPayload as TestComplexObject;
@@ -1095,12 +1157,18 @@ void _testZeroCopyErrorServer(
           RpcStatus.INVALID_ARGUMENT,
           message: 'Invalid object ID: ${receivedObject.id}',
         );
-        await transport.sendMetadata(message.streamId, errorMetadata,
-            endStream: true);
+        await transport.sendMetadata(
+          message.streamId,
+          errorMetadata,
+          endStream: true,
+        );
       } else {
         // Обычная обработка
-        await transport.sendDirectObject(message.streamId, 'Success',
-            endStream: true);
+        await transport.sendDirectObject(
+          message.streamId,
+          'Success',
+          endStream: true,
+        );
       }
     }
   });

--- a/packages/rpc_dart_transports/test/isolate_verification_test.dart
+++ b/packages/rpc_dart_transports/test/isolate_verification_test.dart
@@ -43,10 +43,7 @@ class CpuIntensiveTask {
   final int iterations;
   final String taskId;
 
-  const CpuIntensiveTask({
-    required this.iterations,
-    required this.taskId,
-  });
+  const CpuIntensiveTask({required this.iterations, required this.taskId});
 }
 
 /// Результат CPU-интенсивной задачи
@@ -82,10 +79,7 @@ class MutationResult {
   final MutableCounter counter;
   final IsolateInfo isolateInfo;
 
-  const MutationResult({
-    required this.counter,
-    required this.isolateInfo,
-  });
+  const MutationResult({required this.counter, required this.isolateInfo});
 }
 
 // ============================================================================
@@ -114,10 +108,14 @@ void isolateInfoServer(IRpcTransport transport, Map<String, dynamic> params) {
         );
 
         print(
-            '📤 [Isolate Info Server] Отправляю информацию об изоляте: $isolateInfo');
+          '📤 [Isolate Info Server] Отправляю информацию об изоляте: $isolateInfo',
+        );
 
-        await transport.sendDirectObject(message.streamId, isolateInfo,
-            endStream: true);
+        await transport.sendDirectObject(
+          message.streamId,
+          isolateInfo,
+          endStream: true,
+        );
       }
     }
   });
@@ -140,7 +138,8 @@ void cpuIntensiveServer(IRpcTransport transport, Map<String, dynamic> params) {
         final stopwatch = Stopwatch()..start();
 
         print(
-            '🔥 [CPU Server] Начинаю CPU-интенсивную задачу: ${payload.taskId}');
+          '🔥 [CPU Server] Начинаю CPU-интенсивную задачу: ${payload.taskId}',
+        );
         print('   🔢 Итераций: ${payload.iterations}');
 
         // CPU-blocking операция - вычисляем числа Фибоначчи
@@ -183,11 +182,15 @@ void cpuIntensiveServer(IRpcTransport transport, Map<String, dynamic> params) {
         );
 
         print(
-            '✅ [CPU Server] Задача ${payload.taskId} завершена за ${stopwatch.elapsedMilliseconds}мс');
+          '✅ [CPU Server] Задача ${payload.taskId} завершена за ${stopwatch.elapsedMilliseconds}мс',
+        );
         print('   📊 Результат: $result');
 
-        await transport.sendDirectObject(message.streamId, taskResult,
-            endStream: true);
+        await transport.sendDirectObject(
+          message.streamId,
+          taskResult,
+          endStream: true,
+        );
       }
     }
   });
@@ -198,7 +201,9 @@ void cpuIntensiveServer(IRpcTransport transport, Map<String, dynamic> params) {
 /// Сервер для тестирования изоляции памяти
 @pragma('vm:entry-point')
 void memoryIsolationServer(
-    IRpcTransport transport, Map<String, dynamic> params) {
+  IRpcTransport transport,
+  Map<String, dynamic> params,
+) {
   final currentIsolate = Isolate.current;
 
   print('🖥️ [Memory Server] Запущен в изоляте ${currentIsolate.debugName}');
@@ -234,8 +239,11 @@ void memoryIsolationServer(
           isolateInfo: isolateInfo,
         );
 
-        await transport.sendDirectObject(message.streamId, result,
-            endStream: true);
+        await transport.sendDirectObject(
+          message.streamId,
+          result,
+          endStream: true,
+        );
       }
     }
   });
@@ -253,7 +261,8 @@ void main() {
       // Arrange
       final mainIsolate = Isolate.current;
       print(
-          '🔍 Main thread isolate: ${mainIsolate.debugName}, hashCode: ${mainIsolate.hashCode}');
+        '🔍 Main thread isolate: ${mainIsolate.debugName}, hashCode: ${mainIsolate.hashCode}',
+      );
 
       final result = await RpcIsolateTransport.spawn(
         entrypoint: isolateInfoServer,
@@ -279,12 +288,16 @@ void main() {
         // Assert
         print('📋 Comparison:');
         print(
-            '   🔸 Main isolate: ${mainIsolate.debugName} (${mainIsolate.hashCode})');
+          '   🔸 Main isolate: ${mainIsolate.debugName} (${mainIsolate.hashCode})',
+        );
         print(
-            '   🔸 Worker isolate: ${isolateInfo.isolateName} (${isolateInfo.isolateHashCode})');
+          '   🔸 Worker isolate: ${isolateInfo.isolateName} (${isolateInfo.isolateHashCode})',
+        );
 
         expect(
-            isolateInfo.isolateHashCode, isNot(equals(mainIsolate.hashCode)));
+          isolateInfo.isolateHashCode,
+          isNot(equals(mainIsolate.hashCode)),
+        );
         expect(isolateInfo.isolateName, contains('VerificationIsolate'));
 
         print('✅ Верификация пройдена: изоляты имеют разные идентификаторы');
@@ -325,8 +338,9 @@ void main() {
 
         // Пока задача выполняется в изоляте, основной поток должен оставаться отзывчивым
         var mainThreadCounter = 0;
-        final mainThreadTimer =
-            Timer.periodic(Duration(milliseconds: 1), (timer) {
+        final mainThreadTimer = Timer.periodic(Duration(milliseconds: 1), (
+          timer,
+        ) {
           mainThreadCounter++;
           if (mainThreadCounter >= 50) {
             // 50мс работы основного потока
@@ -339,7 +353,8 @@ void main() {
           taskFuture,
           mainThreadTimer.isActive
               ? Future.delayed(
-                  Duration(milliseconds: 60)) // Даем чуть больше времени
+                  Duration(milliseconds: 60),
+                ) // Даем чуть больше времени
               : Future.value(null),
         ]);
 
@@ -351,21 +366,26 @@ void main() {
         // Assert
         print('📊 CPU Task Results:');
         print(
-            '   ⏱️ Task processing time: ${taskResult.processingTime.inMilliseconds}ms');
+          '   ⏱️ Task processing time: ${taskResult.processingTime.inMilliseconds}ms',
+        );
         print('   🔢 Calculated value: ${taskResult.calculatedValue}');
         print(
-            '   🖥️ Processed in isolate: ${taskResult.isolateInfo.isolateName}');
+          '   🖥️ Processed in isolate: ${taskResult.isolateInfo.isolateName}',
+        );
         print(
-            '   🔄 Main thread counter: $mainThreadCounter (должно быть >= 50)');
+          '   🔄 Main thread counter: $mainThreadCounter (должно быть >= 50)',
+        );
         print(
-            '   ⏱️ Main thread total time: ${mainThreadStopwatch.elapsedMilliseconds}ms');
+          '   ⏱️ Main thread total time: ${mainThreadStopwatch.elapsedMilliseconds}ms',
+        );
 
         expect(taskResult.taskId, equals(task.taskId));
         expect(taskResult.processingTime.inMilliseconds, greaterThan(0));
         expect(taskResult.isolateInfo.isolateName, contains('CpuWorker'));
 
         print(
-            '✅ CPU-интенсивная задача выполнена в изоляте без блокировки основного потока');
+          '✅ CPU-интенсивная задача выполнена в изоляте без блокировки основного потока',
+        );
       } finally {
         await transport.close();
         result.kill();
@@ -403,14 +423,18 @@ void main() {
         print('📊 Memory Isolation Results:');
         print('   📝 Original counter (main thread): ${originalCounter.value}');
         print(
-            '   📝 Mutated counter (from isolate): ${mutationResult.counter.value}');
+          '   📝 Mutated counter (from isolate): ${mutationResult.counter.value}',
+        );
         print(
-            '   🖥️ Mutation happened in: ${mutationResult.isolateInfo.isolateName}');
+          '   🖥️ Mutation happened in: ${mutationResult.isolateInfo.isolateName}',
+        );
 
         // Проверяем что изолят получил копию и мутировал её
         expect(mutationResult.counter.value, equals(13)); // 10 + 3 increments
         expect(
-            mutationResult.isolateInfo.isolateName, contains('MemoryWorker'));
+          mutationResult.isolateInfo.isolateName,
+          contains('MemoryWorker'),
+        );
 
         // ВАЖНО: В Dart isolates, объекты копируются, поэтому оригинал не должен измениться
         // НО: если используется zero-copy (что и происходит), то изменения могут быть видны
@@ -418,7 +442,8 @@ void main() {
 
         print('✅ Память корректно обрабатывается между изолятами');
         print(
-            '   ℹ️ Zero-copy позволяет эффективную передачу без полного копирования');
+          '   ℹ️ Zero-copy позволяет эффективную передачу без полного копирования',
+        );
       } finally {
         await transport.close();
         result.kill();
@@ -456,7 +481,8 @@ void main() {
           final taskFuture = transport
               .getMessagesForStream(streamId)
               .where(
-                  (msg) => msg.isDirect && msg.directPayload is CpuTaskResult)
+                (msg) => msg.isDirect && msg.directPayload is CpuTaskResult,
+              )
               .first
               .then((msg) => msg.directPayload as CpuTaskResult);
 
@@ -473,13 +499,15 @@ void main() {
 
         print('📊 Parallel Execution Results:');
         print(
-            '   ⏱️ Total parallel execution time: ${stopwatch.elapsedMilliseconds}ms');
+          '   ⏱️ Total parallel execution time: ${stopwatch.elapsedMilliseconds}ms',
+        );
 
         final isolateNames = <String>{};
         for (int i = 0; i < results.length; i++) {
           final result = results[i];
           print(
-              '   🔸 Task $i: ${result.taskId} in ${result.isolateInfo.isolateName} (${result.processingTime.inMilliseconds}ms)');
+            '   🔸 Task $i: ${result.taskId} in ${result.isolateInfo.isolateName} (${result.processingTime.inMilliseconds}ms)',
+          );
           isolateNames.add(result.isolateInfo.isolateName);
         }
 
@@ -492,14 +520,14 @@ void main() {
                 .reduce((a, b) => a + b) /
             results.length;
         expect(
-            stopwatch.elapsedMilliseconds,
-            lessThan(averageTaskTime *
-                isolateCount *
-                0.8)); // Должно быть как минимум на 20% быстрее
+          stopwatch.elapsedMilliseconds,
+          lessThan(averageTaskTime * isolateCount * 0.8),
+        ); // Должно быть как минимум на 20% быстрее
 
         print('✅ Множественные изоляты работают параллельно и эффективно');
         print(
-            '   📈 Ускорение параллелизма: ${(averageTaskTime * isolateCount / stopwatch.elapsedMilliseconds).toStringAsFixed(2)}x');
+          '   📈 Ускорение параллелизма: ${(averageTaskTime * isolateCount / stopwatch.elapsedMilliseconds).toStringAsFixed(2)}x',
+        );
       } finally {
         // Cleanup
         for (final result in isolateResults) {

--- a/packages/rpc_dart_transports/test/isolate_zero_copy_demo_test.dart
+++ b/packages/rpc_dart_transports/test/isolate_zero_copy_demo_test.dart
@@ -37,14 +37,15 @@ class TestDataModel {
         'size': size,
         'generatedAt': DateTime.now().toIso8601String(),
         'complexData': List.generate(
-            100,
-            (i) => {
-                  'index': i,
-                  'value': random.nextDouble(),
-                  'nested': {
-                    'level1': {'level2': 'value_$i'}
-                  },
-                }),
+          100,
+          (i) => {
+            'index': i,
+            'value': random.nextDouble(),
+            'nested': {
+              'level1': {'level2': 'value_$i'},
+            },
+          },
+        ),
       },
     );
   }
@@ -109,10 +110,14 @@ void processingServer(IRpcTransport transport, Map<String, dynamic> params) {
         );
 
         print(
-            '✅ [Processing Server] Обработка завершена за ${stopwatch.elapsedMilliseconds}мс');
+          '✅ [Processing Server] Обработка завершена за ${stopwatch.elapsedMilliseconds}мс',
+        );
 
-        await transport.sendDirectObject(message.streamId, result,
-            endStream: true);
+        await transport.sendDirectObject(
+          message.streamId,
+          result,
+          endStream: true,
+        );
       }
     }
   });
@@ -143,7 +148,8 @@ void main() {
         final responsesFuture = transport
             .getMessagesForStream(streamId)
             .where(
-                (msg) => msg.isDirect && msg.directPayload is ProcessingResult)
+              (msg) => msg.isDirect && msg.directPayload is ProcessingResult,
+            )
             .first;
 
         await transport.sendDirectObject(streamId, testData);
@@ -162,7 +168,8 @@ void main() {
         print('   📈 Сумма: ${processingResult.sum.toStringAsFixed(2)}');
         print('   📈 Среднее: ${processingResult.average.toStringAsFixed(2)}');
         print(
-            '   ⏱️ Время: ${processingResult.processingTime.inMilliseconds}мс');
+          '   ⏱️ Время: ${processingResult.processingTime.inMilliseconds}мс',
+        );
       } finally {
         await transport.close();
         result.kill();
@@ -186,7 +193,8 @@ void main() {
         final responsesFuture = transport
             .getMessagesForStream(streamId)
             .where(
-                (msg) => msg.isDirect && msg.directPayload is ProcessingResult)
+              (msg) => msg.isDirect && msg.directPayload is ProcessingResult,
+            )
             .first;
 
         final stopwatch = Stopwatch()..start();
@@ -199,18 +207,23 @@ void main() {
         // Assert
         expect(processingResult.originalId, equals(largeData.id));
         expect(processingResult.processedCount, equals(5000));
-        expect(stopwatch.elapsedMilliseconds,
-            lessThan(1000)); // Максимум 1 секунда
+        expect(
+          stopwatch.elapsedMilliseconds,
+          lessThan(1000),
+        ); // Максимум 1 секунда
 
         print('🚀 Performance тест пройден:');
         print('   📊 Размер: 5000 чисел + сложные метаданные');
         print('   ⏱️ Время клиент-сервер: ${stopwatch.elapsedMilliseconds}мс');
         print(
-            '   ⚙️ Время обработки в изоляте: ${processingResult.processingTime.inMilliseconds}мс');
+          '   ⚙️ Время обработки в изоляте: ${processingResult.processingTime.inMilliseconds}мс',
+        );
         print(
-            '   📈 Результат: sum=${processingResult.sum.toStringAsFixed(2)}, avg=${processingResult.average.toStringAsFixed(2)}');
+          '   📈 Результат: sum=${processingResult.sum.toStringAsFixed(2)}, avg=${processingResult.average.toStringAsFixed(2)}',
+        );
         print(
-            '   ⚡ Zero-copy эффективность: ${(processingResult.processingTime.inMilliseconds / stopwatch.elapsedMilliseconds * 100).toStringAsFixed(1)}%');
+          '   ⚡ Zero-copy эффективность: ${(processingResult.processingTime.inMilliseconds / stopwatch.elapsedMilliseconds * 100).toStringAsFixed(1)}%',
+        );
       } finally {
         await transport.close();
         result.kill();

--- a/packages/rpc_dart_transports/test/websocket_transport_test.dart
+++ b/packages/rpc_dart_transports/test/websocket_transport_test.dart
@@ -54,8 +54,9 @@ void main() {
     });
 
     /// Удобный хелпер: ждём первое входящее WS-подключение
-    Future<WebSocket> nextServerSocket(
-        {Duration timeout = const Duration(seconds: 2)}) {
+    Future<WebSocket> nextServerSocket({
+      Duration timeout = const Duration(seconds: 2),
+    }) {
       return socketEvents.stream.first.timeout(timeout);
     }
 
@@ -125,8 +126,9 @@ void main() {
       final serverMessages = <RpcTransportMessage>[];
       final sub = serverTransport.incomingMessages.listen(serverMessages.add);
 
-      final metadata =
-          RpcMetadata.forClientRequestWithPath('/test.Service/TestMethod');
+      final metadata = RpcMetadata.forClientRequestWithPath(
+        '/test.Service/TestMethod',
+      );
       await clientTransport.sendMetadata(streamId, metadata);
 
       // Дадим очереди событий обработаться
@@ -140,13 +142,17 @@ void main() {
 
       final headers = received.metadata!.headers;
       expect(
-          headers.any(
-              (h) => h.name == 'content-type' && h.value == 'application/grpc'),
-          isTrue);
+        headers.any(
+          (h) => h.name == 'content-type' && h.value == 'application/grpc',
+        ),
+        isTrue,
+      );
       expect(
-          headers.any((h) =>
-              h.name == ':path' && h.value == '/test.Service/TestMethod'),
-          isTrue);
+        headers.any(
+          (h) => h.name == ':path' && h.value == '/test.Service/TestMethod',
+        ),
+        isTrue,
+      );
 
       await sub.cancel();
       await clientTransport.close();


### PR DESCRIPTION
## Summary
- add health/reconnect primitives to the core RPC endpoint and transport APIs
- implement health and reconnect reporting across in-memory, router, HTTP/2, WebSocket and isolate transports
- document the new diagnostics features and cover them with unit tests

## Testing
- not run (Dart SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cffd46d9a883339e2d3e6914f8b50d