### PR TITLE
feat: add endpoint ping support

### DIFF
--- a/packages/rpc_dart/lib/src/endpoint/_index.dart
+++ b/packages/rpc_dart/lib/src/endpoint/_index.dart
@@ -87,7 +87,7 @@ final class RpcEndpointPingResult {
   /// Все заголовки ответа в удобном для чтения формате.
   final Map<String, String> responseHeaders;
 
-  const RpcEndpointPingResult({
+  RpcEndpointPingResult({
     required this.sentAt,
     required this.receivedAt,
     required this.roundTrip,

--- a/packages/rpc_dart/lib/src/endpoint/_index.dart
+++ b/packages/rpc_dart/lib/src/endpoint/_index.dart
@@ -37,6 +37,67 @@ final class RpcEndpointHealth {
   RpcHealthStatus? get transportStatus => dependencies['transport'];
 }
 
+/// Константы и метаданные протокола ping между эндпоинтами.
+abstract final class RpcEndpointPingProtocol {
+  /// Имя служебного сервиса для ping запросов.
+  static const String serviceName = '_rpc.System';
+
+  /// Имя служебного метода для ping запросов.
+  static const String methodName = 'Ping';
+
+  /// Полный ключ метода (service.method).
+  static const String methodKey = '$serviceName.$methodName';
+
+  /// HTTP/2 путь метода /Service/Method.
+  static const String methodPath = '/$serviceName/$methodName';
+
+  /// Заголовок с отметкой времени отправки ping от клиента.
+  static const String requestTimestampHeader = 'x-rpc-ping-timestamp';
+
+  /// Заголовок с отметкой времени обработки ping на стороне responder.
+  static const String responseTimestampHeader = 'x-rpc-pong-timestamp';
+
+  /// Заголовок с debug label responder эндпоинта.
+  static const String responseDebugLabelHeader = 'x-rpc-pong-endpoint';
+
+  /// Заголовок с типом транспорта responder эндпоинта.
+  static const String responseTransportHeader = 'x-rpc-pong-transport';
+}
+
+/// Результат ping-запроса между эндпоинтами.
+final class RpcEndpointPingResult {
+  /// Время отправки ping-запроса.
+  final DateTime sentAt;
+
+  /// Время получения ответа.
+  final DateTime receivedAt;
+
+  /// Полный круговой трип (RTT) ping-запроса.
+  final Duration roundTrip;
+
+  /// Отметка времени обработки ping на responder, если была передана.
+  final DateTime? responderTimestamp;
+
+  /// Debug label responder эндпоинта, если указан.
+  final String? responderDebugLabel;
+
+  /// Тип транспорта responder эндпоинта, если передан.
+  final String? responderTransportType;
+
+  /// Все заголовки ответа в удобном для чтения формате.
+  final Map<String, String> responseHeaders;
+
+  const RpcEndpointPingResult({
+    required this.sentAt,
+    required this.receivedAt,
+    required this.roundTrip,
+    this.responderTimestamp,
+    this.responderDebugLabel,
+    this.responderTransportType,
+    Map<String, String>? responseHeaders,
+  }) : responseHeaders = Map.unmodifiable(responseHeaders ?? const {});
+}
+
 /// Базовый класс для всех RPC эндпоинтов
 abstract base class RpcEndpointBase {
   final IRpcTransport _transport;

--- a/packages/rpc_dart/lib/src/endpoint/caller_endpoint.dart
+++ b/packages/rpc_dart/lib/src/endpoint/caller_endpoint.dart
@@ -117,7 +117,7 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
     final completer = Completer<RpcEndpointPingResult>();
     StreamSubscription<RpcTransportMessage>? subscription;
 
-    Map<String, String> _metadataToMap(RpcMetadata metadata) {
+    Map<String, String> metadataToMap(RpcMetadata metadata) {
       final map = <String, String>{};
       for (final header in metadata.headers) {
         map[header.name] = header.value;
@@ -143,7 +143,7 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
           return;
         }
 
-        final headersMap = _metadataToMap(message.metadata!);
+        final headersMap = metadataToMap(message.metadata!);
 
         if (!headersMap.containsKey(RpcConstants.GRPC_STATUS_HEADER)) {
           logger.internal(
@@ -222,7 +222,7 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
       await transport.sendMetadata(streamId, metadata);
       await transport.finishSending(streamId);
     } catch (error, stackTrace) {
-      await subscription?.cancel();
+      await subscription.cancel();
       logger.error(
         'Ошибка при отправке ping [streamId: $streamId]',
         error: error,
@@ -250,7 +250,7 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
     try {
       return await future;
     } finally {
-      await subscription?.cancel();
+      await subscription.cancel();
     }
   }
 

--- a/packages/rpc_dart/lib/src/endpoint/caller_endpoint.dart
+++ b/packages/rpc_dart/lib/src/endpoint/caller_endpoint.dart
@@ -43,6 +43,217 @@ final class RpcCallerEndpoint extends RpcEndpointBase {
     _validateClientTransport();
   }
 
+  /// Выполняет ping-запрос к responder эндпоинту и возвращает результат.
+  Future<RpcEndpointPingResult> ping({
+    Duration? timeout,
+    RpcContext? context,
+  }) async {
+    if (!isActive) {
+      throw StateError(
+        'RpcCallerEndpoint закрыт и не может выполнять ping',
+      );
+    }
+
+    if (transport.isClosed) {
+      throw StateError(
+        'Транспорт закрыт и не может отправлять ping',
+      );
+    }
+
+    final streamId = transport.createStream();
+    final sentAt = DateTime.now().toUtc();
+
+    logger.internal('Подготовка ping запроса [streamId: $streamId]');
+
+    final baseContext = _ensureContext(context);
+    final routingContext = baseContext.withAdditionalHeaders({
+      'x-route-service': RpcEndpointPingProtocol.serviceName,
+    });
+
+    // Проверяем отмену и deadline до отправки ping.
+    routingContext.cancellationToken?.throwIfCancelled();
+    if (routingContext.isExpired) {
+      throw RpcDeadlineExceededException(
+        routingContext.deadline!,
+        Duration.zero,
+      );
+    }
+
+    final baseMetadata = RpcMetadata.forClientRequest(
+      RpcEndpointPingProtocol.serviceName,
+      RpcEndpointPingProtocol.methodName,
+    );
+
+    final headers = List<RpcHeader>.from(baseMetadata.headers);
+
+    for (final entry in routingContext.headers.entries) {
+      headers.add(RpcHeader(entry.key, entry.value));
+    }
+
+    if (routingContext.traceId != null) {
+      headers.add(RpcHeader('x-trace-id', routingContext.traceId!));
+    }
+
+    headers.add(RpcHeader('x-request-id', routingContext.requestId));
+
+    if (routingContext.deadline != null) {
+      headers.add(
+        RpcHeader(
+          'x-deadline',
+          routingContext.deadline!.millisecondsSinceEpoch.toString(),
+        ),
+      );
+    }
+
+    headers.add(
+      RpcHeader(
+        RpcEndpointPingProtocol.requestTimestampHeader,
+        sentAt.toIso8601String(),
+      ),
+    );
+
+    final metadata = RpcMetadata(headers);
+
+    final completer = Completer<RpcEndpointPingResult>();
+    StreamSubscription<RpcTransportMessage>? subscription;
+
+    Map<String, String> _metadataToMap(RpcMetadata metadata) {
+      final map = <String, String>{};
+      for (final header in metadata.headers) {
+        map[header.name] = header.value;
+      }
+      return map;
+    }
+
+    void completeSuccess(RpcEndpointPingResult result) {
+      if (!completer.isCompleted) {
+        completer.complete(result);
+      }
+    }
+
+    void completeError(Object error, [StackTrace? stackTrace]) {
+      if (!completer.isCompleted) {
+        completer.completeError(error, stackTrace);
+      }
+    }
+
+    subscription = transport.getMessagesForStream(streamId).listen(
+      (message) {
+        if (!message.isMetadataOnly || message.metadata == null) {
+          return;
+        }
+
+        final headersMap = _metadataToMap(message.metadata!);
+
+        if (!headersMap.containsKey(RpcConstants.GRPC_STATUS_HEADER)) {
+          logger.internal(
+            'Получены начальные метаданные ответа ping [streamId: $streamId]',
+          );
+          return;
+        }
+
+        final statusCode = int.tryParse(
+              headersMap[RpcConstants.GRPC_STATUS_HEADER] ?? '',
+            ) ??
+            RpcStatus.UNKNOWN;
+
+        final receivedAt = DateTime.now().toUtc();
+
+        if (statusCode != RpcStatus.OK) {
+          final statusMessage =
+              headersMap[RpcConstants.GRPC_MESSAGE_HEADER] ?? 'Unknown error';
+          logger.warning(
+            'Ping завершился с ошибкой: status=$statusCode, message=$statusMessage [streamId: $streamId]',
+          );
+          completeError(
+            RpcException(
+              'Ping failed with status $statusCode: $statusMessage',
+            ),
+          );
+          return;
+        }
+
+        DateTime? responderTimestamp;
+        final responderTimestampRaw =
+            headersMap[RpcEndpointPingProtocol.responseTimestampHeader];
+        if (responderTimestampRaw != null) {
+          responderTimestamp = DateTime.tryParse(responderTimestampRaw);
+        }
+
+        final result = RpcEndpointPingResult(
+          sentAt: sentAt,
+          receivedAt: receivedAt,
+          roundTrip: receivedAt.difference(sentAt),
+          responderTimestamp: responderTimestamp,
+          responderDebugLabel:
+              headersMap[RpcEndpointPingProtocol.responseDebugLabelHeader],
+          responderTransportType:
+              headersMap[RpcEndpointPingProtocol.responseTransportHeader],
+          responseHeaders: headersMap,
+        );
+
+        logger.internal(
+          'Ping успешно завершен, RTT=${result.roundTrip.inMilliseconds}мс [streamId: $streamId]',
+        );
+
+        completeSuccess(result);
+      },
+      onError: (error, stackTrace) {
+        logger.error(
+          'Ошибка при получении ответа ping [streamId: $streamId]',
+          error: error,
+          stackTrace: stackTrace,
+        );
+        completeError(error, stackTrace);
+      },
+      onDone: () {
+        if (!completer.isCompleted) {
+          completeError(
+            StateError(
+              'Ping stream завершен без трейлеров [streamId: $streamId]',
+            ),
+          );
+        }
+      },
+    );
+
+    try {
+      logger.internal('Отправка ping запроса [streamId: $streamId]');
+      await transport.sendMetadata(streamId, metadata);
+      await transport.finishSending(streamId);
+    } catch (error, stackTrace) {
+      await subscription?.cancel();
+      logger.error(
+        'Ошибка при отправке ping [streamId: $streamId]',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+
+    Future<RpcEndpointPingResult> future = completer.future;
+
+    if (timeout != null) {
+      future = future.timeout(
+        timeout,
+        onTimeout: () {
+          logger.warning(
+            'Ping превысил время ожидания ${timeout.inMilliseconds}мс [streamId: $streamId]',
+          );
+          throw TimeoutException(
+            'Ping не завершился за ${timeout.inMilliseconds}мс',
+          );
+        },
+      );
+    }
+
+    try {
+      return await future;
+    } finally {
+      await subscription?.cancel();
+    }
+  }
+
   /// Создает ключ для реестра токенов из имени сервиса и метода
   String _createMethodKey(String serviceName, String methodName) {
     return '$serviceName/$methodName';

--- a/packages/rpc_dart/lib/src/endpoint/responder_endpoint.dart
+++ b/packages/rpc_dart/lib/src/endpoint/responder_endpoint.dart
@@ -142,6 +142,101 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     return parts.join(' ');
   }
 
+  bool _isPingMethod(String serviceName, String methodName) {
+    return serviceName == RpcEndpointPingProtocol.serviceName &&
+        methodName == RpcEndpointPingProtocol.methodName;
+  }
+
+  bool _isPingMethodKey(String methodKey) =>
+      methodKey == RpcEndpointPingProtocol.methodKey;
+
+  void _handlePingRequest(int streamId, RpcContext context) {
+    unawaited(() async {
+      final responderTimestamp = DateTime.now().toUtc();
+
+      try {
+        await transport.sendMetadata(
+          streamId,
+          RpcMetadata.forServerInitialResponse(),
+        );
+
+        final responseHeaders = <RpcHeader>[
+          RpcHeader(
+            RpcEndpointPingProtocol.responseTimestampHeader,
+            responderTimestamp.toIso8601String(),
+          ),
+          RpcHeader(
+            RpcEndpointPingProtocol.responseTransportHeader,
+            transport.runtimeType.toString(),
+          ),
+          RpcHeader(
+            RpcConstants.GRPC_STATUS_HEADER,
+            RpcStatus.OK.toString(),
+          ),
+        ];
+
+        if (debugLabel != null && debugLabel!.isNotEmpty) {
+          responseHeaders.add(
+            RpcHeader(
+              RpcEndpointPingProtocol.responseDebugLabelHeader,
+              debugLabel!,
+            ),
+          );
+        }
+
+        await transport.sendMetadata(
+          streamId,
+          RpcMetadata(responseHeaders),
+          endStream: true,
+        );
+
+        _logWithContext(
+          'Ping обработан успешно',
+          context: context,
+          streamId: streamId,
+          methodKey: RpcEndpointPingProtocol.methodKey,
+        );
+      } catch (error, stackTrace) {
+        _logErrorWithContext(
+          'Ошибка при обработке ping',
+          context: context,
+          streamId: streamId,
+          methodKey: RpcEndpointPingProtocol.methodKey,
+          error: error,
+          stackTrace: stackTrace,
+        );
+
+        try {
+          await transport.sendMetadata(
+            streamId,
+            RpcMetadata([
+              RpcHeader(
+                RpcConstants.GRPC_STATUS_HEADER,
+                RpcStatus.INTERNAL.toString(),
+              ),
+              RpcHeader(
+                RpcConstants.GRPC_MESSAGE_HEADER,
+                'Ping handling error: $error',
+              ),
+            ]),
+            endStream: true,
+          );
+        } catch (sendError, sendStackTrace) {
+          _logErrorWithContext(
+            'Не удалось отправить ошибку ping',
+            context: context,
+            streamId: streamId,
+            methodKey: RpcEndpointPingProtocol.methodKey,
+            error: sendError,
+            stackTrace: sendStackTrace,
+          );
+        }
+      } finally {
+        _cleanupStream(streamId);
+      }
+    }());
+  }
+
   /// Получает контекст для stream ID (создает если нужно)
   RpcContext _getOrCreateContextForStream(int streamId) {
     final metadataMessage = _streamMetadata[streamId];
@@ -244,6 +339,17 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
     if (message.isEndOfStream) {
       final methodKey = _streamMethods[streamId];
       if (methodKey != null) {
+        if (_isPingMethodKey(methodKey)) {
+          _logWithContext(
+            'Получен финальный фрейм ping',
+            context: _getOrCreateContextForStream(streamId),
+            streamId: streamId,
+            methodKey: methodKey,
+          );
+          // Очистка произойдет в _handlePingRequest после отправки ответа
+          return;
+        }
+
         final method = _methods[methodKey];
 
         // СПЕЦИАЛЬНАЯ ОБРАБОТКА для Client Streaming - создаем респондер ТОЛЬКО СЕЙЧАС
@@ -312,6 +418,22 @@ final class RpcResponderEndpoint extends RpcEndpointBase {
 
     // Создаем контекст из метаданных для логирования
     final context = _createContextFromMessage(message);
+
+    if (_isPingMethod(serviceName, methodName)) {
+      _logWithContext(
+        'Получен ping запрос',
+        context: context,
+        streamId: streamId,
+        methodKey: methodKey,
+      );
+
+      // Сохраняем информацию о потоке для корректной очистки и контекста
+      _streamMethods[streamId] = methodKey;
+      _streamMetadata[streamId] = message;
+
+      _handlePingRequest(streamId, context);
+      return;
+    }
 
     _logWithContext(
       'Получено сообщение метаданных',

--- a/packages/rpc_dart/lib/src/rpc/core/transport.dart
+++ b/packages/rpc_dart/lib/src/rpc/core/transport.dart
@@ -219,25 +219,65 @@ abstract class IRpcTransport {
 /// - ID 0 зарезервирован для управления соединением
 /// - Максимальное значение ID - 2^31-1 (2,147,483,647)
 ///
-/// После достижения максимального значения необходимо установить новое соединение.
+/// При достижении максимального значения ID менеджер пытается переиспользовать
+/// освобожденные идентификаторы (если активные потоки не занимают весь диапазон).
+/// Если же все возможные Stream ID находятся в использовании, выбрасывается
+/// [RpcException] и требуется дождаться освобождения либо переподключить транспорт.
 final class RpcStreamIdManager {
+  /// Максимально допустимое значение ID (2^31-1)
+  static const int maxId = 0x7FFFFFFF; // 2,147,483,647
+
   /// Определяет роль (клиент/сервер) для генерации ID
   final bool isClient;
 
   /// Последний сгенерированный ID
   int _lastId;
 
-  /// Максимально допустимое значение ID (2^31-1)
-  static const int maxId = 0x7FFFFFFF; // 2,147,483,647
+  /// Максимальное значение ID, которое может быть назначено с учетом четности
+  final int _maxAssignableId;
+
+  /// Первый допустимый ID для текущей роли (1 для клиента, 2 для сервера)
+  final int _firstAssignableId;
 
   /// Набор активных (используемых) ID
-  final Set<int> _activeIds = {};
+  final SplayTreeSet<int> _activeIds = SplayTreeSet<int>();
 
   /// Создает менеджер ID с указанной ролью.
   ///
   /// [isClient] Если true - генерирует ID для клиента (нечетные),
   ///            иначе - для сервера (четные)
-  RpcStreamIdManager({required this.isClient}) : _lastId = isClient ? -1 : 0;
+  /// [customMaxId] Позволяет задать альтернативный верхний предел ID
+  ///               (используется в тестах и специализированных транспортах).
+  RpcStreamIdManager({
+    required this.isClient,
+    int? customMaxId,
+  })  : _lastId = isClient ? -1 : 0,
+        _firstAssignableId = isClient ? 1 : 2,
+        _maxAssignableId = _computeMaxAssignableId(
+          isClient: isClient,
+          maxIdOverride: customMaxId,
+        );
+
+  /// Вычисляет верхнюю границу ID с учетом четности роли.
+  static int _computeMaxAssignableId({
+    required bool isClient,
+    int? maxIdOverride,
+  }) {
+    final effectiveMax = maxIdOverride ?? maxId;
+    final adjustedMax = isClient
+        ? (effectiveMax.isOdd ? effectiveMax : effectiveMax - 1)
+        : (effectiveMax.isEven ? effectiveMax : effectiveMax - 1);
+
+    if (adjustedMax < (isClient ? 1 : 2)) {
+      throw ArgumentError.value(
+        effectiveMax,
+        'customMaxId',
+        'Недостаточно допустимых значений Stream ID для указанной роли',
+      );
+    }
+
+    return adjustedMax;
+  }
 
   /// Генерирует новый уникальный ID для потока.
   ///
@@ -247,17 +287,30 @@ final class RpcStreamIdManager {
     // Вычисляем следующий ID в зависимости от роли
     final nextId = _lastId + 2;
 
-    // Проверяем, не достигли ли мы предела
-    if (nextId > maxId) {
+    if (nextId <= _maxAssignableId) {
+      _lastId = nextId;
+      _activeIds.add(nextId);
+      return nextId;
+    }
+
+    // Если все потоки завершены, можем безопасно перезапустить последовательность
+    if (_activeIds.isEmpty) {
+      final restartId = _firstAssignableId;
+      _lastId = restartId;
+      _activeIds.add(restartId);
+      return restartId;
+    }
+
+    final recycledId = _findReusableId();
+    if (recycledId == null) {
       throw RpcException(
-        'Достигнут максимальный ID стрима ($maxId). '
-        'Необходимо установить новое соединение.',
+        'Все ${_sideLabel} Stream ID заняты. '
+        'Дождитесь завершения активных потоков или установите новое соединение.',
       );
     }
 
-    _lastId = nextId;
-    _activeIds.add(nextId);
-    return nextId;
+    _activeIds.add(recycledId);
+    return recycledId;
   }
 
   /// Освобождает ID после завершения потока.
@@ -286,5 +339,35 @@ final class RpcStreamIdManager {
   void reset() {
     _activeIds.clear();
     _lastId = isClient ? -1 : 0;
+  }
+
+  String get _sideLabel => isClient ? 'клиентские' : 'серверные';
+
+  int? _findReusableId() {
+    var candidate = _firstAssignableId;
+
+    for (final activeId in _activeIds) {
+      if (candidate < activeId) {
+        return candidate;
+      }
+
+      if (candidate == activeId) {
+        candidate = _advanceCandidate(activeId);
+      }
+    }
+
+    if (!_activeIds.contains(candidate)) {
+      return candidate;
+    }
+
+    return null;
+  }
+
+  int _advanceCandidate(int current) {
+    final next = current + 2;
+    if (next > _maxAssignableId) {
+      return _firstAssignableId;
+    }
+    return next;
   }
 }

--- a/packages/rpc_dart/lib/src/rpc/core/transport.dart
+++ b/packages/rpc_dart/lib/src/rpc/core/transport.dart
@@ -304,7 +304,7 @@ final class RpcStreamIdManager {
     final recycledId = _findReusableId();
     if (recycledId == null) {
       throw RpcException(
-        'Все ${_sideLabel} Stream ID заняты. '
+        'Все $_sideLabel Stream ID заняты. '
         'Дождитесь завершения активных потоков или установите новое соединение.',
       );
     }

--- a/packages/rpc_dart/test/core/rpc_stream_id_manager_test.dart
+++ b/packages/rpc_dart/test/core/rpc_stream_id_manager_test.dart
@@ -83,6 +83,67 @@ void main() {
       // В реальных условиях приложение должно создавать новое соединение
       // при достижении этого ограничения.
     });
+
+    test('Переиспользует освобожденные ID при достижении предела', () {
+      final manager = RpcStreamIdManager(
+        isClient: true,
+        customMaxId: 9,
+      );
+
+      final id1 = manager.generateId();
+      final id2 = manager.generateId();
+      final id3 = manager.generateId();
+
+      expect(id1, equals(1));
+      expect(id2, equals(3));
+      expect(id3, equals(5));
+
+      expect(manager.releaseId(id1), isTrue);
+      expect(manager.releaseId(id2), isTrue);
+
+      expect(manager.generateId(), equals(7));
+      expect(manager.generateId(), equals(9));
+
+      // После достижения максимального значения ID должны переиспользоваться
+      expect(manager.generateId(), equals(1));
+      expect(manager.generateId(), equals(3));
+    });
+
+    test('Сбрасывает последовательность при полном освобождении', () {
+      final manager = RpcStreamIdManager(
+        isClient: false,
+        customMaxId: 10,
+      );
+
+      final allocated = <int>[];
+      for (var i = 0; i < 5; i++) {
+        allocated.add(manager.generateId());
+      }
+
+      expect(allocated, equals([2, 4, 6, 8, 10]));
+
+      for (final id in allocated) {
+        expect(manager.releaseId(id), isTrue);
+      }
+
+      expect(manager.generateId(), equals(2));
+    });
+
+    test('Выбрасывает исключение если нет свободных ID', () {
+      final manager = RpcStreamIdManager(
+        isClient: true,
+        customMaxId: 5,
+      );
+
+      expect(manager.generateId(), equals(1));
+      expect(manager.generateId(), equals(3));
+      expect(manager.generateId(), equals(5));
+
+      expect(
+        () => manager.generateId(),
+        throwsA(isA<RpcException>()),
+      );
+    });
   });
 
   group('Интеграция с транспортом', () {

--- a/packages/rpc_dart/test/endpoint/rpc_endpoint_ping_test.dart
+++ b/packages/rpc_dart/test/endpoint/rpc_endpoint_ping_test.dart
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025 Karim "nogipx" Mamatkazin <nogipx@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+import 'package:rpc_dart/rpc_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RpcEndpoint ping', () {
+    late IRpcTransport clientTransport;
+    late IRpcTransport serverTransport;
+    late RpcCallerEndpoint callerEndpoint;
+    late RpcResponderEndpoint responderEndpoint;
+
+    setUp(() {
+      final pair = RpcInMemoryTransport.pair();
+      clientTransport = pair.$1;
+      serverTransport = pair.$2;
+
+      callerEndpoint = RpcCallerEndpoint(
+        transport: clientTransport,
+        debugLabel: 'caller-test',
+      );
+
+      responderEndpoint = RpcResponderEndpoint(
+        transport: serverTransport,
+        debugLabel: 'responder-test',
+      );
+
+      responderEndpoint.start();
+    });
+
+    tearDown(() async {
+      await callerEndpoint.close();
+      await responderEndpoint.close();
+    });
+
+    test('ping возвращает успешный ответ с метаданными', () async {
+      final result = await callerEndpoint.ping();
+
+      expect(result.roundTrip.isNegative, isFalse);
+      expect(result.responderTimestamp, isNotNull);
+      expect(
+        result.responseHeaders[RpcConstants.GRPC_STATUS_HEADER],
+        equals(RpcStatus.OK.toString()),
+      );
+      expect(
+        result.responseHeaders
+            .containsKey(RpcEndpointPingProtocol.responseTimestampHeader),
+        isTrue,
+      );
+      expect(result.responderTransportType, contains('RpcInMemoryTransport'));
+    });
+
+    test('ping включает debug label responder эндпоинта', () async {
+      final result = await callerEndpoint.ping();
+
+      expect(result.responderDebugLabel, equals('responder-test'));
+    });
+  });
+}

--- a/packages/rpc_dart_transports/example/transports/websocket_example.dart
+++ b/packages/rpc_dart_transports/example/transports/websocket_example.dart
@@ -11,7 +11,7 @@ import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 /// Пример: реальный WebSocket-сервер + клиент.
-/// Серверная часть: shelf_web_socket -> Stream<WebSocketChannel> -> RpcWebSocketServer.
+/// Серверная часть: shelf_web_socket -> Stream(WebSocketChannel) -> RpcWebSocketServer.
 /// Клиент: WebSocketChannel.connect -> RpcWebSocketCallerTransport.
 Future<void> main() async {
   // 1) Логирование


### PR DESCRIPTION
## Summary
- add RpcEndpointPingProtocol constants and RpcEndpointPingResult container for the built-in ping handshake
- implement RpcCallerEndpoint.ping() and responder-side handling to exchange ping metadata
- add endpoint-level tests that verify successful ping responses and metadata
- update RpcStreamIdManager to compute role-aware limits, recycle released IDs after hitting the stream cap, and guard against invalid overrides
- preserve compatibility with long-running transports by resetting when all streams complete and surfacing clearer errors when every ID is in use
- extend the stream ID manager tests with wrap-around, reset, and exhaustion scenarios using a tunable max ID


## Testing
- not run (dart / fvm tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d033b4c2d48333a638e8be0ea8e8af