### PR TITLE
docs: refresh changelog entries for 2.3.0 releases

### DIFF
--- a/packages/rpc_dart/CHANGELOG.md
+++ b/packages/rpc_dart/CHANGELOG.md
@@ -1,8 +1,20 @@
 # 2.3.0
 
-- Added health() and reconnect() APIs for endpoints and transports.
-- Added health diagnostics for RpcInMemoryTransport and RpcTransportRouter.
-- Updated documentation with health monitoring examples.
+- Added aggregated diagnostics for caller and responder endpoints with
+  `health()`/`reconnect()` snapshots that combine endpoint metrics and
+  transport status via `RpcEndpointHealth` and `RpcHealthStatus`.
+- Implemented a built-in ping protocol between endpoints that exposes
+  round-trip timing, responder metadata and debug labels through
+  `RpcCallerEndpoint.ping()`.
+- Extended transport infrastructure with `IRpcTransport.health()` and
+  `IRpcTransport.reconnect()` plus detailed implementations for
+  `RpcInMemoryTransport`, `RpcTransportRouter` and the transport toolkit,
+  including automatic partner shutdown to avoid close deadlocks.
+- Improved `RpcStreamIdManager` so stream identifiers are recycled after
+  hitting the HTTP/2 limit, preventing allocation failures during
+  long-lived workloads.
+- Updated documentation and examples with health monitoring guidance and
+  diagnostics-driven workflows.
 
 # Changelog
 

--- a/packages/rpc_dart_transports/CHANGELOG.md
+++ b/packages/rpc_dart_transports/CHANGELOG.md
@@ -1,9 +1,15 @@
 # 1.2.0
 
-- Added health() and reconnect() implementations for HTTP/2, WebSocket and
-  isolate transports.
-- Improved WebSocket client reconnection support with automatic listeners.
-- Updated documentation with diagnostics overview.
+- Implemented rich `health()`/`reconnect()` diagnostics for HTTP/2,
+  WebSocket and isolate transports, exposing connection metadata and
+  supported flags for automation.
+- Introduced `WebSocketReconnectManager` with configurable backoff
+  strategies and automatic listener re-registration to stabilize client
+  reconnections.
+- Fixed isolate transport shutdown and health reporting so both host and
+  worker isolates surface accurate closed/degraded statuses.
+- Updated documentation and examples with diagnostics guidance for
+  transport consumers.
 
 # Changelog
 


### PR DESCRIPTION
## Summary
- expand the rpc_dart 2.3.0 notes with endpoint health, ping, transport diagnostics, and stream ID recycling details
- document the rpc_dart_transports 1.2.0 diagnostics, reconnection tooling, and isolate health fixes

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d0599b9cf0833387c918a40fe1dd68