### PR TITLE
Fix HTTP/2 gRPC framing and add integration test

### DIFF
--- a/packages/rpc_dart/lib/src/rpc/core/transport.dart
+++ b/packages/rpc_dart/lib/src/rpc/core/transport.dart
@@ -149,7 +149,7 @@ abstract class IRpcTransport {
   /// Отправляет сообщение для конкретного stream.
   ///
   /// [streamId] Уникальный идентификатор HTTP/2 stream
-  /// [data] Байты для отправки
+  /// [data] Байты gRPC-фрейма (5-байтовый префикс + полезная нагрузка)
   /// [endStream] Флаг завершения потока данных
   Future<void> sendMessage(
     int streamId,

--- a/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_caller_transport.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_caller_transport.dart
@@ -225,11 +225,13 @@ class RpcHttp2CallerTransport implements IRpcTransport {
       'Отправка данных для stream $streamId: ${data.length} байт (endStream: $endStream)',
     );
 
-    // Упаковываем данные в gRPC frame формат
-    final framedData = packGrpcMessage(data);
+    assert(
+      isGrpcFrame(data),
+      'IRpcTransport.sendMessage ожидает gRPC frame с 5-байтовым префиксом',
+    );
 
-    // Отправляем данные через HTTP/2
-    stream.sendData(framedData, endStream: endStream);
+    // Отправляем данные через HTTP/2 как уже сформированный gRPC frame
+    stream.sendData(data, endStream: endStream);
 
     _logger?.internal('Данные отправлены для stream $streamId');
   }
@@ -375,9 +377,10 @@ class RpcHttp2CallerTransport implements IRpcTransport {
 
       // Отправляем каждое сообщение отдельно
       for (final msgData in messages) {
+        final framedMessage = ensureGrpcFrame(msgData);
         final transportMessage = RpcTransportMessage(
           streamId: streamId,
-          payload: msgData,
+          payload: framedMessage,
           isEndOfStream: message.endStream && msgData == messages.last,
           methodPath: methodPath,
         );

--- a/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_common.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_common.dart
@@ -68,9 +68,41 @@ RpcMetadata http2HeadersToRpcMetadata(List<http2.Header> headers) {
   return RpcMetadata(rpcHeaders);
 }
 
-/// Упаковывает данные в gRPC frame формат используя RpcMessageFrame
+/// Гарантирует, что данные представляют собой корректно сформированный gRPC frame.
 ///
-/// Делегирует упаковку стандартному классу из rpc_dart
-Uint8List packGrpcMessage(Uint8List data) {
+/// Если входные [data] уже содержат валидный 5-байтный префикс и длину,
+/// возвращает исходный буфер без копирования. В противном случае добавляет
+/// gRPC префикс, предполагая отсутствие сжатия.
+Uint8List ensureGrpcFrame(Uint8List data) {
+  if (data.length >= RpcConstants.MESSAGE_PREFIX_SIZE) {
+    try {
+      final header = RpcMessageFrame.parseHeader(data);
+      final expectedLength =
+          RpcConstants.MESSAGE_PREFIX_SIZE + header.messageLength;
+
+      if (expectedLength == data.length) {
+        return data;
+      }
+    } catch (_) {
+      // Игнорируем ошибку и упаковываем данные заново.
+    }
+  }
+
   return RpcMessageFrame.encode(data, compressed: false);
+}
+
+/// Проверяет, что данные имеют валидный gRPC префикс и соответствующую длину.
+bool isGrpcFrame(Uint8List data) {
+  if (data.length < RpcConstants.MESSAGE_PREFIX_SIZE) {
+    return false;
+  }
+
+  try {
+    final header = RpcMessageFrame.parseHeader(data);
+    final expectedLength =
+        RpcConstants.MESSAGE_PREFIX_SIZE + header.messageLength;
+    return expectedLength == data.length;
+  } catch (_) {
+    return false;
+  }
 }

--- a/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_responder_transport.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/http2/rpc_http2_responder_transport.dart
@@ -202,9 +202,10 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
 
       // Отправляем каждое сообщение отдельно
       for (final msgData in messages) {
+        final framedMessage = ensureGrpcFrame(msgData);
         final transportMessage = RpcTransportMessage(
           streamId: streamId,
-          payload: msgData,
+          payload: framedMessage,
           isEndOfStream: message.endStream && msgData == messages.last,
         );
 
@@ -350,11 +351,13 @@ class RpcHttp2ResponderTransport implements IRpcTransport {
     );
 
     try {
-      // Упаковываем данные в gRPC frame формат
-      final framedData = packGrpcMessage(data);
+      assert(
+        isGrpcFrame(data),
+        'IRpcTransport.sendMessage ожидает gRPC frame с 5-байтовым префиксом',
+      );
 
-      // Отправляем данные через HTTP/2
-      incomingStream.sendData(framedData, endStream: endStream);
+      // Отправляем данные через HTTP/2 как уже сформированный gRPC frame
+      incomingStream.sendData(data, endStream: endStream);
 
       _logger?.internal('Ответные данные отправлены для stream $streamId');
     } catch (e) {

--- a/packages/rpc_dart_transports/test/http2_rpc_integration_test.dart
+++ b/packages/rpc_dart_transports/test/http2_rpc_integration_test.dart
@@ -12,12 +12,22 @@ void main() {
     late IRpcServer testServer;
     late RpcHttp2CallerTransport clientTransport;
     late RpcCallerEndpoint callerEndpoint;
+    late StreamController<Uint8List> serverRequestPayloads;
 
     setUpAll(() async {
+      serverRequestPayloads = StreamController<Uint8List>.broadcast();
+
       testServer = RpcHttp2Server(
         port: 10101,
-        onEndpointCreated: (endpoint) =>
-            endpoint.registerServiceContract(TestServiceContract()),
+        onEndpointCreated: (endpoint) {
+          endpoint.transport.incomingMessages.listen((message) {
+            if (!message.isMetadataOnly && message.payload != null) {
+              serverRequestPayloads.add(Uint8List.fromList(message.payload!));
+            }
+          });
+
+          endpoint.registerServiceContract(TestServiceContract());
+        },
       );
       await testServer.start();
 
@@ -36,7 +46,40 @@ void main() {
     tearDownAll(() async {
       await callerEndpoint.close();
       await testServer.stop();
+      await serverRequestPayloads.close();
       print('🔒 Долгоживущее RPC соединение закрыто');
+    });
+
+    test('http2_unary_payload_has_single_grpc_prefix', () async {
+      final request = RpcString('Check nested prefix elimination');
+      final serializedRequest = RpcString.codec.serialize(request);
+      final payloadFuture = serverRequestPayloads.stream.first;
+
+      final response = await callerEndpoint.unaryRequest<RpcString, RpcString>(
+        serviceName: 'TestService',
+        methodName: 'Echo',
+        requestCodec: RpcString.codec,
+        responseCodec: RpcString.codec,
+        request: request,
+      );
+
+      expect(
+        response.value,
+        equals('Server Echo: Check nested prefix elimination'),
+      );
+
+      final rawFrame = await payloadFuture.timeout(
+        Duration(seconds: 5),
+        onTimeout: () =>
+            throw TimeoutException('Timeout waiting for unary payload frame'),
+      );
+
+      final header = RpcMessageFrame.parseHeader(rawFrame);
+      expect(header.messageLength, equals(serializedRequest.length));
+
+      final payloadWithoutPrefix =
+          rawFrame.sublist(RpcConstants.MESSAGE_PREFIX_SIZE);
+      expect(payloadWithoutPrefix, equals(serializedRequest));
     });
 
     test('unary_rpc_через_caller_и_responder', () async {


### PR DESCRIPTION
## Summary
- treat HTTP/2 transport `sendMessage` payloads as pre-framed data and assert they look like gRPC frames
- normalise incoming HTTP/2 payloads to single gRPC frames using shared helpers and update transport docs accordingly
- extend the HTTP/2 integration suite to capture server-side frames and verify unary requests have only one prefix

## Testing
- `dart test packages/rpc_dart_transports/test/http2_rpc_integration_test.dart` *(fails: `dart` command not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b987eed08333a0014bd364abbea4