### PR TITLE
Implement Licensify-based secure transport adapter

### DIFF
--- a/docs/ru/transports/encryption.md
+++ b/docs/ru/transports/encryption.md
@@ -1,0 +1,191 @@
+# Шифрованный транспорт на базе Licensify
+
+Ниже описан обновлённый слой защищённого транспорта, который использует пакет
+[`licensify`](https://pub.dev/packages/licensify). Licensify инкапсулирует
+сообщения рукопожатия в токены PASETO v4 и гарантирует их подлинность, поэтому
+нам не нужно поддерживать собственную схему подписей. Слой оформлен как
+адаптер поверх любого транспорта: caller и responder автоматически договариваются
+о ключах, а каждый фрейм шифруется с помощью AEAD без правок существующих
+реализаций транспортов.
+
+## Цели
+
+- **Композиционность** – зашифрованный слой оборачивает любой транспорт через
+  `SecureTransportAdapter`, не требуя правок конструкторов.
+- **Минимум настроек** – эндпоинты хранят только долгосрочные ключи подписей,
+  а все сессионные данные обмениваются через токены Licensify при запуске.
+- **Прямая секретность** – сессионные ключи выводятся из одноразовых
+  случайных значений и уничтожаются после ротации.
+- **Независимость от транспорта** – требуется лишь упорядоченная доставка
+  сообщений, что подходит для HTTP/2, WebSocket, isolates, TURN и т. д.
+
+## Зависимости и ключи
+
+1. Добавьте Licensify в пакеты, где создаются транспорты:
+
+   ```dart
+   dependencies:
+     licensify: ^3.1.0
+   ```
+
+2. Сгенерируйте долгосрочную пару ключей и сохраните её рядом с конфигурацией
+   эндпоинта:
+
+   ```dart
+   final keys = await Licensify.generateSigningKeys();
+   await savePrivateKey(keys.privateKeyBytes);
+   await savePublicKey(keys.publicKeyBytes);
+   ```
+
+   Публичный ключ публикуется во внешнем каталоге/конфигурации, приватный
+   остаётся только на узле.
+
+## Рукопожатие на токенах Licensify
+
+Рукопожатие проходит по управляющему потоку `0` до начала обмена RPC. Каждое
+сообщение — токен Licensify с временем жизни пять минут, чтобы исключить
+повторные атаки.
+
+```text
+Caller                                      Responder
+------                                      ---------
+Долгосрочный ключ KC                        Долгосрочный ключ KR
+Общие публичные ключи Pc, Pr                Общие публичные ключи Pc, Pr
+
+1. SecureHello = Licensify.createLicense(
+     privateKey: KC.priv,
+     appId: 'rpc.secure',
+     expirationDate: now + 5 minutes,
+     type: LicenseType.standard,
+     features: {
+       'protocol': 'rpc+secure/1',
+       'nonce': base64(nc),
+     },
+     metadata: {
+       'seed': base64(sc),          // 32 случайных байта
+       'transportId': callerTransportId,
+     },
+   )
+   ->
+                                             проверить подпись через Pc
+                                             извлечь `sc`, `nc`
+                                             hc = HKDF(sc || nc, 'rpc:handshake:caller')
+                                             выбрать sr (32 случайных байта) и nr
+                                             SecureAck = Licensify.createLicense(
+                                               privateKey: KR.priv,
+                                               appId: 'rpc.secure',
+                                               expirationDate: now + 5 minutes,
+                                               type: LicenseType.standard,
+                                               features: {
+                                                 'protocol': 'rpc+secure/1',
+                                                 'nonce': base64(nr),
+                                               },
+                                               metadata: {
+                                                 'seed': base64(sr),
+                                                 'peerNonce': base64(nc),
+                                               },
+                                             )
+2. <- SecureAck
+   проверить подпись через Pr
+   убедиться, что `metadata.peerNonce == nc`
+   hr = HKDF(sc || sr || nr, 'rpc:handshake:responder')
+
+3. После валидации обе стороны получают финальные сессионные ключи:
+   sendKeyBytes = HKDF(sc || sr || nc || nr, 'rpc:data:send' || role)
+   recvKeyBytes = HKDF(sc || sr || nc || nr, 'rpc:data:recv' || role)
+   sendKey = Licensify.encryptionKeyFromBytes(sendKeyBytes)
+   recvKey = Licensify.encryptionKeyFromBytes(recvKeyBytes)
+```
+
+- Licensify гарантирует подлинность сообщений `SecureHello` и `SecureAck`.
+- Случайные nonce связывают ответы с исходным запросом и защищают от повторов.
+- Данные рукопожатия затираются из памяти после вывода сессионных ключей.
+
+## Защита фреймов
+
+Каждый последующий фрейм упаковывается в токен PASETO v4.local. Адаптер ведёт
+монотонный счётчик `sequence` для каждого направления, кодирует оригинальный
+фрейм в Base64 и передаёт его в Licensify, который сам управляет nonce и тегами
+целостности. Значение `handshakeTranscriptHash` — это дайджест, покрывающий оба
+токена рукопожатия (например, `SHA256(SecureHello || SecureAck)`), чтобы фреймы
+криптографически привязывались к согласованной сессии:
+
+```dart
+final frameBytes = codec.encode(originalFrame);
+final assertion = base64Encode(handshakeTranscriptHash);
+final token = await Licensify.encryptData(
+  data: {
+    'payload': base64Encode(frameBytes),
+    'transportId': transportId,
+    'streamId': streamId,
+    'protocol': 'rpc+secure/1',
+    'sequence': sequence,
+  },
+  encryptionKey: sendKey,
+  implicitAssertion: assertion,
+);
+```
+
+- На провод уходит строковый токен вместо исходных байт фрейма. Инварианты
+  (`transportId`, версия протокола, stream ID, sequence) передаются внутри токена,
+  чтобы принимающая сторона могла их проверить до декодирования полезной
+  нагрузки.
+- На приёме вызывается `await Licensify.decryptData` с тем же `recvKey` и
+  `implicitAssertion`. Если проверка подписи или метаданных не проходит, фрейм
+  отвергается и соединение закрывается как небезопасное.
+- Успешная расшифровка возвращает `Map<String, dynamic>`; полезная нагрузка
+  восстанавливается обратным преобразованием Base64:
+
+  ```dart
+  final decoded = await Licensify.decryptData(
+    encryptedToken: token,
+    encryptionKey: recvKey,
+    implicitAssertion: assertion,
+  );
+  final restoredFrame = codec.decode(base64Decode(decoded['payload'] as String));
+  ```
+- После завершения сессии освободите симметричные ключи вызовами
+  `sendKey.dispose()` / `recvKey.dispose()`, чтобы стереть их из памяти.
+
+## Ротация ключей
+
+- Сессионные ключи истекают по таймеру (по умолчанию 12 часов) или количеству
+  фреймов. Повторное рукопожатие запускается на управляющем потоке, пока
+  пользовательские стримы приостановлены.
+- Для смены идентичностей публикуйте новый публичный ключ Licensify и храните
+  предыдущие в кэше на время миграции. Как только peer принимает новый ключ,
+  защищённый канал продолжает работу без разрыва.
+
+## Шаги реализации
+
+1. Добавьте связку `SecureChannelNegotiator` и `SecureTransportAdapter`, которая
+   завершает рукопожатие и оборачивает фреймы после успешной валидации Licensify.
+2. Напишите тесты:
+   - успешное рукопожатие для каждого транспорта;
+   - отказ при проверке токена с неподходящим публичным ключом;
+   - повторное рукопожатие после ротации ключей.
+3. Собирайте метрики: длительность рукопожатия, число отказов, ошибки фреймов,
+   количество ротаций.
+
+## Использование
+
+```dart
+final baseCaller = await RpcWebSocketCallerTransport.connect(
+  Uri.parse('wss://api.example.com/rpc'),
+);
+final secureCaller = SecureTransportAdapter.wrap(
+  baseCaller,
+  keyStore: callerKeyStore,
+);
+
+final baseResponder = RpcWebSocketResponderTransport(channel);
+final secureResponder = SecureTransportAdapter.wrap(
+  baseResponder,
+  keyStore: responderKeyStore,
+);
+```
+
+После обёртки транспорт автоматически запускает рукопожатие на Licensify и
+предоставляет аутентифицированный зашифрованный канал до начала RPC. Один и тот
+же адаптер подходит для каналов isolate, HTTP/2, WebSocket и собственных
+реализаций транспорта.

--- a/docs/transports/encryption.md
+++ b/docs/transports/encryption.md
@@ -1,0 +1,193 @@
+# Licensify-backed encrypted transport
+
+This document updates the secure transport overlay to rely on the
+[`licensify`](https://pub.dev/packages/licensify) package. Licensify wraps
+PASETO v4 tokens around structured payloads, giving us authenticated and tamper
+proof handshake messages without having to maintain a bespoke signature
+implementation. The overlay is packaged as an adapter that wraps any existing
+transport, so caller and responder agree on session keys automatically and
+every frame is protected with AEAD without modifying the underlying transport
+implementations.
+
+## Design goals
+
+- **Compositional** – the encrypted overlay wraps any existing transport using a
+  `SecureTransportAdapter`, leaving the original constructors untouched.
+- **Hands-off configuration** – endpoints only store their long-term signing
+  keys. All session material is exchanged through Licensify tokens during
+  startup.
+- **Forward secrecy** – session keys are derived from per-connection seeds and
+  thrown away after rekeying.
+- **Transport agnostic** – the overlay only requires ordered, reliable delivery
+  and therefore works for HTTP/2, WebSocket, isolates, TURN, etc.
+
+## Dependencies and key material
+
+1. Add Licensify to any package that instantiates transports:
+
+   ```dart
+   dependencies:
+     licensify: ^3.1.0
+   ```
+
+2. Generate long-term signing keys once and persist them next to the endpoint
+   configuration:
+
+   ```dart
+   final keys = await Licensify.generateSigningKeys();
+   await savePrivateKey(keys.privateKeyBytes);
+   await savePublicKey(keys.publicKeyBytes);
+   ```
+
+   The public portion is shared out-of-band (service discovery, config push)
+   while the private key never leaves the endpoint.
+
+## Handshake using Licensify tokens
+
+The handshake rides on stream `0` before any RPC payloads. All messages are
+Licensify licenses with a five minute TTL to guard against replay.
+
+```text
+Caller                                      Responder
+------                                      ---------
+Long-term signing key KC                    Long-term signing key KR
+Shared public keys Pc (caller), Pr (resp)   Shared public keys Pc, Pr
+
+1. SecureHello = Licensify.createLicense(
+     privateKey: KC.priv,
+     appId: 'rpc.secure',
+     expirationDate: now + 5 minutes,
+     type: LicenseType.standard,
+     features: {
+       'protocol': 'rpc+secure/1',
+       'nonce': base64(nc),
+     },
+     metadata: {
+       'seed': base64(sc),          // 32 random bytes
+       'transportId': callerTransportId,
+     },
+   )
+   ->
+                                             validate using Pc
+                                             extract `sc`, `nc`
+                                             derive hc = HKDF(sc || nc, 'rpc:handshake:caller')
+                                             pick sr (32 random bytes) and nr
+                                             SecureAck = Licensify.createLicense(
+                                               privateKey: KR.priv,
+                                               appId: 'rpc.secure',
+                                               expirationDate: now + 5 minutes,
+                                               type: LicenseType.standard,
+                                               features: {
+                                                 'protocol': 'rpc+secure/1',
+                                                 'nonce': base64(nr),
+                                               },
+                                               metadata: {
+                                                 'seed': base64(sr),
+                                                 'peerNonce': base64(nc),
+                                               },
+                                             )
+2. <- SecureAck
+   validate using Pr
+   ensure `metadata.peerNonce` matches `nc`
+   derive hr = HKDF(sc || sr || nr, 'rpc:handshake:responder')
+
+3. Both sides compute the final session keys once both messages are verified:
+   sendKeyBytes = HKDF(sc || sr || nc || nr, 'rpc:data:send' || role)
+   recvKeyBytes = HKDF(sc || sr || nc || nr, 'rpc:data:recv' || role)
+   sendKey = Licensify.encryptionKeyFromBytes(sendKeyBytes)
+   recvKey = Licensify.encryptionKeyFromBytes(recvKeyBytes)
+```
+
+- Licensify guarantees authenticity of `SecureHello` and `SecureAck`.
+- Random nonces prevent replay and tie responses to the initiating hello.
+- Handshake state is wiped from memory after the session keys are derived.
+
+## Frame protection
+
+Each subsequent frame is sealed as a PASETO v4.local token. The overlay keeps a
+monotonic `sequence` per direction, encodes the original frame bytes as
+Base64, and relies on Licensify to manage nonces and authentication tags
+internally. The `handshakeTranscriptHash` value can be any digest that covers
+both handshake tokens (for example `SHA256(SecureHello || SecureAck)`) so that
+frames are cryptographically tied to the negotiated session:
+
+```dart
+final frameBytes = codec.encode(originalFrame);
+final assertion = base64Encode(handshakeTranscriptHash);
+final token = await Licensify.encryptData(
+  data: {
+    'payload': base64Encode(frameBytes),
+    'transportId': transportId,
+    'streamId': streamId,
+    'protocol': 'rpc+secure/1',
+    'sequence': sequence,
+  },
+  encryptionKey: sendKey,
+  implicitAssertion: assertion,
+);
+```
+
+- The returned token string is transmitted instead of the raw frame bytes. The
+  invariant fields (`transportId`, protocol version, stream ID, sequence) travel
+  inside the token so the recipient can validate them before decoding.
+- The responder calls `await Licensify.decryptData` with the matching
+  `recvKey` and the same implicit assertion. It rejects the frame if the token
+  fails integrity checks or if the decoded metadata does not match the expected
+  transport context.
+- A successful decryption yields a `Map<String, dynamic>`; decode the
+  Base64-encoded payload to recover the original frame bytes:
+
+  ```dart
+  final decoded = await Licensify.decryptData(
+    encryptedToken: token,
+    encryptionKey: recvKey,
+    implicitAssertion: assertion,
+  );
+  final restoredFrame = codec.decode(base64Decode(decoded['payload'] as String));
+  ```
+- After the session ends, dispose of the symmetric keys with
+  `sendKey.dispose()` / `recvKey.dispose()` to wipe them from memory.
+
+## Rekeying and rotation
+
+- Session keys expire after a configurable number of frames or time window
+  (default: 12 hours). Either side starts a background handshake on a control
+  stream while suspending application streams.
+- To rotate long-term identities, publish the new Licensify public key and cache
+  the previous ones for a grace period. As soon as the peer accepts the new key
+  the secure overlay seamlessly continues.
+
+## Implementation checklist
+
+1. Introduce a `SecureChannelNegotiator` and `SecureTransportAdapter` pair that
+   sits between transports and wraps all outbound/inbound frames after the
+   Licensify handshake succeeds.
+2. Provide unit tests covering:
+   - successful negotiation over each bundled transport;
+   - rejection when validating Licensify tokens with the wrong public key;
+   - re-handshake after triggering a key rotation.
+3. Expose metrics: handshake duration, rejected handshakes, frame failures,
+   rekey counts.
+
+## Developer experience
+
+```dart
+final baseCaller = await RpcWebSocketCallerTransport.connect(
+  Uri.parse('wss://api.example.com/rpc'),
+);
+final secureCaller = SecureTransportAdapter.wrap(
+  baseCaller,
+  keyStore: callerKeyStore,
+);
+
+final baseResponder = RpcWebSocketResponderTransport(channel);
+final secureResponder = SecureTransportAdapter.wrap(
+  baseResponder,
+  keyStore: responderKeyStore,
+);
+```
+
+Wrapping the transport opt-in enables the Licensify handshake and exposes an
+authenticated, encrypted channel before any RPC payload is sent. The same
+adapter can wrap isolate pipes, HTTP/2 streams, or any custom transport that
+implements the shared interface.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - WebSocket: transports/websocket.md
       - Isolate: transports/isolate.md
       - TURN relay: transports/turn-relay.md
+      - Encrypted overlay: transports/encryption.md
       - Transport toolkit: transports/transport-toolkit.md
   - Русский:
       - Обзор: ru/index.md
@@ -37,6 +38,7 @@ nav:
           - Isolate: ru/transports/isolate.md
           - TURN релейный: ru/transports/turn-relay.md
           - Кастомные транспорты: ru/transports/custom.md
+          - Шифрованный слой: ru/transports/encryption.md
 
 theme:
   name: material

--- a/packages/rpc_dart_transports/lib/src/transports/_index.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/_index.dart
@@ -8,3 +8,4 @@ export 'websocket/_index.dart';
 export '../server/rpc_server_bootstrap.dart';
 export 'isolate/isolate_transport.dart';
 export 'relay/_index.dart';
+export 'secure/_index.dart';

--- a/packages/rpc_dart_transports/lib/src/transports/secure/_index.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/secure/_index.dart
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2025 Karim "nogipx" Mamatkazin <nogipx@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+export 'secure_transport_adapter.dart';

--- a/packages/rpc_dart_transports/lib/src/transports/secure/secure_transport_adapter.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/secure/secure_transport_adapter.dart
@@ -1,0 +1,710 @@
+// SPDX-FileCopyrightText: 2025 Karim "nogipx" Mamatkazin <nogipx@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart' show Hmac, sha256;
+import 'package:licensify/licensify.dart';
+import 'package:rpc_dart/rpc_dart.dart';
+
+const _handshakeHeader = 'x-rpc-secure-handshake';
+const _metadataHeader = 'x-rpc-secure-metadata';
+const _protocolLabel = 'rpc+secure/1';
+const _infoCallerToResponder = 'rpc:data:caller->responder';
+const _infoResponderToCaller = 'rpc:data:responder->caller';
+
+/// Configuration for the [SecureTransportAdapter].
+class SecureTransportConfig {
+  const SecureTransportConfig({
+    this.handshakeTimeout = const Duration(seconds: 15),
+    this.handshakeTokenTtl = const Duration(minutes: 5),
+  });
+
+  /// Maximum time to wait for handshake messages.
+  final Duration handshakeTimeout;
+
+  /// Time-to-live for Licensify handshake tokens.
+  final Duration handshakeTokenTtl;
+}
+
+/// Holds the long-term identity material used by the secure overlay.
+class SecureTransportKeyStore {
+  const SecureTransportKeyStore({
+    required this.transportId,
+    required this.privateKey,
+    required this.peerPublicKey,
+  });
+
+  /// Identifier advertised to the remote peer.
+  final String transportId;
+
+  /// Local signing key used to produce handshake tokens.
+  final LicensifyPrivateKey privateKey;
+
+  /// Remote signing key used to validate handshake tokens.
+  final LicensifyPublicKey peerPublicKey;
+}
+
+enum _SecureFrameType { data, metadata }
+
+class _SessionState {
+  _SessionState({
+    required this.sendKey,
+    required this.recvKey,
+    required this.assertion,
+    required this.peerTransportId,
+  });
+
+  final LicensifySymmetricKey sendKey;
+  final LicensifySymmetricKey recvKey;
+  final String assertion;
+  final String peerTransportId;
+
+  void dispose() {
+    sendKey.dispose();
+    recvKey.dispose();
+  }
+}
+
+class _DecryptedFrame {
+  _DecryptedFrame(this.payload, this.type);
+
+  final Uint8List payload;
+  final _SecureFrameType type;
+}
+
+/// Wraps any [IRpcTransport] with a Licensify-backed encrypted overlay.
+class SecureTransportAdapter implements IRpcTransport {
+  SecureTransportAdapter._(
+    this._inner,
+    this._keyStore,
+    this._config,
+    this._logger,
+  ) {
+    _handshakeFuture = _performHandshake();
+    _innerSubscription = _inner.incomingMessages.listen(
+      (message) => unawaited(_processIncoming(message)),
+      onError: (error, stackTrace) {
+        if (!_incomingController.isClosed) {
+          _incomingController.addError(error, stackTrace);
+        }
+      },
+      onDone: () async {
+        if (!_incomingController.isClosed) {
+          await _incomingController.close();
+        }
+      },
+    );
+  }
+
+  /// Wraps a transport instance with encryption.
+  factory SecureTransportAdapter.wrap(
+    IRpcTransport inner, {
+    required SecureTransportKeyStore keyStore,
+    SecureTransportConfig config = const SecureTransportConfig(),
+    RpcLogger? logger,
+  }) {
+    return SecureTransportAdapter._(inner, keyStore, config, logger);
+  }
+
+  final IRpcTransport _inner;
+  final SecureTransportKeyStore _keyStore;
+  final SecureTransportConfig _config;
+  final RpcLogger? _logger;
+
+  final StreamController<RpcTransportMessage> _incomingController =
+      StreamController<RpcTransportMessage>.broadcast();
+  final StreamController<String> _handshakeTokens = StreamController<String>();
+  final List<RpcTransportMessage> _pendingMessages = <RpcTransportMessage>[];
+
+  late final StreamSubscription<RpcTransportMessage> _innerSubscription;
+  late final Future<_SessionState> _handshakeFuture;
+
+  _SessionState? _session;
+  bool _closed = false;
+  int _outboundSequence = 0;
+  int _expectedInboundSequence = 0;
+
+  /// Exposes a future that completes when the secure channel is ready.
+  Future<void> get ready async {
+    await _handshakeFuture;
+  }
+
+  @override
+  bool get isClient => _inner.isClient;
+
+  @override
+  bool get isClosed => _closed || _inner.isClosed;
+
+  @override
+  bool get supportsZeroCopy => false;
+
+  @override
+  Stream<RpcTransportMessage> get incomingMessages =>
+      _incomingController.stream;
+
+  @override
+  int createStream() => _inner.createStream();
+
+  @override
+  bool releaseStreamId(int streamId) => _inner.releaseStreamId(streamId);
+
+  @override
+  Future<void> sendMetadata(
+    int streamId,
+    RpcMetadata metadata, {
+    bool endStream = false,
+  }) async {
+    final session = await _handshakeFuture;
+    _logger?.debug('[SecureTransportAdapter] Encrypting metadata for stream $streamId');
+    final payload = _serializeMetadata(metadata);
+    final token = await _encryptFrame(
+      session: session,
+      streamId: streamId,
+      type: _SecureFrameType.metadata,
+      payload: payload,
+    );
+    final wrappedMetadata = RpcMetadata([
+      RpcHeader(_metadataHeader, token),
+    ]);
+    await _inner.sendMetadata(streamId, wrappedMetadata, endStream: endStream);
+  }
+
+  @override
+  Future<void> sendMessage(
+    int streamId,
+    Uint8List data, {
+    bool endStream = false,
+  }) async {
+    final session = await _handshakeFuture;
+    _logger?.debug('[SecureTransportAdapter] Encrypting payload for stream $streamId');
+    final token = await _encryptFrame(
+      session: session,
+      streamId: streamId,
+      type: _SecureFrameType.data,
+      payload: data,
+    );
+    final bytes = Uint8List.fromList(utf8.encode(token));
+    await _inner.sendMessage(streamId, bytes, endStream: endStream);
+  }
+
+  @override
+  Future<void> finishSending(int streamId) async {
+    await _handshakeFuture;
+    await _inner.finishSending(streamId);
+  }
+
+  @override
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+
+    await _innerSubscription.cancel();
+
+    if (!_handshakeTokens.isClosed) {
+      await _handshakeTokens.close();
+    }
+
+    final session = _session;
+    if (session != null) {
+      session.dispose();
+    }
+
+    if (!_incomingController.isClosed) {
+      await _incomingController.close();
+    }
+
+    await _inner.close();
+  }
+
+  @override
+  Future<RpcHealthStatus> health() async {
+    if (_closed) {
+      return RpcHealthStatus.closed(
+        component: 'SecureTransportAdapter',
+        message: 'Secure transport closed',
+        details: {
+          'transportId': _keyStore.transportId,
+        },
+      );
+    }
+
+    if (_session == null) {
+      return RpcHealthStatus.degraded(
+        component: 'SecureTransportAdapter',
+        message: 'Handshake pending',
+        details: {
+          'transportId': _keyStore.transportId,
+        },
+      );
+    }
+
+    final base = await _inner.health();
+    return RpcHealthStatus(
+      component: 'SecureTransportAdapter',
+      level: base.level,
+      message: base.message,
+      details: {
+        ...base.details,
+        'transportId': _keyStore.transportId,
+        'secure': true,
+      },
+    );
+  }
+
+  @override
+  Future<RpcHealthStatus> reconnect() async {
+    return RpcHealthStatus.degraded(
+      component: 'SecureTransportAdapter',
+      message: 'Reconnect is not supported by SecureTransportAdapter yet',
+      details: {
+        'transportId': _keyStore.transportId,
+        'supported': false,
+      },
+    );
+  }
+
+  Future<void> _processIncoming(RpcTransportMessage message) async {
+    if (_closed) return;
+
+    if (message.streamId == 0 && message.metadata != null) {
+      final token = message.metadata!.getHeaderValue(_handshakeHeader);
+      if (token != null && !_handshakeTokens.isClosed) {
+        _handshakeTokens.add(token);
+        return;
+      }
+    }
+
+    final session = _session;
+    if (session == null) {
+      _pendingMessages.add(message);
+      return;
+    }
+
+    await _deliverProtectedMessage(message, session);
+  }
+
+  Future<_SessionState> _performHandshake() async {
+    try {
+      final result = _inner.isClient
+          ? await _performCallerHandshake()
+          : await _performResponderHandshake();
+      _session = result;
+      _flushPendingMessages();
+      return result;
+    } catch (error, stackTrace) {
+      _logger?.error('Secure handshake failed: $error', error: error, stackTrace: stackTrace);
+      if (!_incomingController.isClosed) {
+        _incomingController.addError(error, stackTrace);
+      }
+      rethrow;
+    }
+  }
+
+  Future<_SessionState> _performCallerHandshake() async {
+    final seedCaller = _randomBytes(32);
+    final nonceCaller = _randomBytes(24);
+
+    final helloLicense = await Licensify.createLicense(
+      privateKey: _keyStore.privateKey,
+      appId: 'rpc.secure',
+      expirationDate: DateTime.now().toUtc().add(_config.handshakeTokenTtl),
+      type: LicenseType.standard,
+      features: {
+        'protocol': _protocolLabel,
+        'nonce': base64Encode(nonceCaller),
+      },
+      metadata: {
+        'seed': base64Encode(seedCaller),
+        'transportId': _keyStore.transportId,
+      },
+    );
+
+    final helloToken = helloLicense.token;
+    await _inner.sendMetadata(
+      0,
+      RpcMetadata([
+        RpcHeader(_handshakeHeader, helloToken),
+      ]),
+    );
+
+    final ackToken = await _waitForHandshakeToken();
+    final ack = await Licensify.fromToken(
+      token: ackToken,
+      publicKey: _keyStore.peerPublicKey,
+    );
+
+    final ackFeatures = await ack.features;
+    final ackMetadata = await ack.metadata ?? <String, dynamic>{};
+
+    _ensureProtocol(ackFeatures['protocol']);
+
+    final peerNonceBase64 = ackMetadata['peerNonce'] as String?;
+    if (peerNonceBase64 == null || peerNonceBase64 != base64Encode(nonceCaller)) {
+      throw StateError('Responder returned unexpected peer nonce');
+    }
+
+    final seedResponderBase64 = ackMetadata['seed'] as String?;
+    if (seedResponderBase64 == null) {
+      throw StateError('Responder did not provide seed');
+    }
+
+    final transportId = ackMetadata['transportId'] as String?;
+    if (transportId == null) {
+      throw StateError('Responder did not provide transportId');
+    }
+
+    final seedResponder = Uint8List.fromList(base64Decode(seedResponderBase64));
+    final nonceResponderBase64 = ackFeatures['nonce'] as String?;
+    if (nonceResponderBase64 == null) {
+      throw StateError('Responder did not provide nonce');
+    }
+
+    final nonceResponder = Uint8List.fromList(base64Decode(nonceResponderBase64));
+
+    final secretMaterial = Uint8List.fromList([
+      ...seedCaller,
+      ...seedResponder,
+      ...nonceCaller,
+      ...nonceResponder,
+    ]);
+
+    final sendKeyBytes = _hkdf(secretMaterial, info: utf8.encode(_infoCallerToResponder));
+    final recvKeyBytes = _hkdf(secretMaterial, info: utf8.encode(_infoResponderToCaller));
+
+    final sendKey = Licensify.encryptionKeyFromBytes(sendKeyBytes);
+    final recvKey = Licensify.encryptionKeyFromBytes(recvKeyBytes);
+
+    final handshakeHash = _computeHandshakeHash(helloToken, ackToken);
+
+    return _SessionState(
+      sendKey: sendKey,
+      recvKey: recvKey,
+      assertion: base64Encode(handshakeHash),
+      peerTransportId: transportId,
+    );
+  }
+
+  Future<_SessionState> _performResponderHandshake() async {
+    final helloToken = await _waitForHandshakeToken();
+    final hello = await Licensify.fromToken(
+      token: helloToken,
+      publicKey: _keyStore.peerPublicKey,
+    );
+
+    final helloFeatures = await hello.features;
+    final helloMetadata = await hello.metadata ?? <String, dynamic>{};
+
+    _ensureProtocol(helloFeatures['protocol']);
+
+    final seedCallerBase64 = helloMetadata['seed'] as String?;
+    if (seedCallerBase64 == null) {
+      throw StateError('Caller did not include seed');
+    }
+
+    final transportId = helloMetadata['transportId'] as String?;
+    if (transportId == null) {
+      throw StateError('Caller did not include transportId');
+    }
+
+    final seedCaller = Uint8List.fromList(base64Decode(seedCallerBase64));
+    final nonceCallerBase64 = helloFeatures['nonce'] as String?;
+    if (nonceCallerBase64 == null) {
+      throw StateError('Caller did not include nonce');
+    }
+
+    final nonceCaller = Uint8List.fromList(base64Decode(nonceCallerBase64));
+
+    final seedResponder = _randomBytes(32);
+    final nonceResponder = _randomBytes(24);
+
+    final ackLicense = await Licensify.createLicense(
+      privateKey: _keyStore.privateKey,
+      appId: 'rpc.secure',
+      expirationDate: DateTime.now().toUtc().add(_config.handshakeTokenTtl),
+      type: LicenseType.standard,
+      features: {
+        'protocol': _protocolLabel,
+        'nonce': base64Encode(nonceResponder),
+      },
+      metadata: {
+        'seed': base64Encode(seedResponder),
+        'peerNonce': base64Encode(nonceCaller),
+        'transportId': _keyStore.transportId,
+      },
+    );
+
+    final ackToken = ackLicense.token;
+
+    await _inner.sendMetadata(
+      0,
+      RpcMetadata([
+        RpcHeader(_handshakeHeader, ackToken),
+      ]),
+    );
+
+    final secretMaterial = Uint8List.fromList([
+      ...seedCaller,
+      ...seedResponder,
+      ...nonceCaller,
+      ...nonceResponder,
+    ]);
+
+    final sendKeyBytes = _hkdf(secretMaterial, info: utf8.encode(_infoResponderToCaller));
+    final recvKeyBytes = _hkdf(secretMaterial, info: utf8.encode(_infoCallerToResponder));
+
+    final sendKey = Licensify.encryptionKeyFromBytes(sendKeyBytes);
+    final recvKey = Licensify.encryptionKeyFromBytes(recvKeyBytes);
+
+    final handshakeHash = _computeHandshakeHash(helloToken, ackToken);
+
+    return _SessionState(
+      sendKey: sendKey,
+      recvKey: recvKey,
+      assertion: base64Encode(handshakeHash),
+      peerTransportId: transportId,
+    );
+  }
+
+  Future<void> _deliverProtectedMessage(
+    RpcTransportMessage message,
+    _SessionState session,
+  ) async {
+    if (message.metadata != null) {
+      final token = message.metadata!.getHeaderValue(_metadataHeader);
+      if (token == null) {
+        throw StateError('Received unprotected metadata on secure channel');
+      }
+
+      final decrypted = await _decryptFrame(
+        token: token,
+        session: session,
+        streamId: message.streamId,
+        expected: _SecureFrameType.metadata,
+      );
+
+      final metadata = _deserializeMetadata(decrypted.payload);
+      _incomingController.add(
+        RpcTransportMessage(
+          metadata: metadata,
+          streamId: message.streamId,
+          isEndOfStream: message.isEndOfStream,
+          methodPath: metadata.methodPath,
+        ),
+      );
+      return;
+    }
+
+    if (message.payload != null) {
+      final token = utf8.decode(message.payload!);
+      final decrypted = await _decryptFrame(
+        token: token,
+        session: session,
+        streamId: message.streamId,
+        expected: _SecureFrameType.data,
+      );
+
+      _incomingController.add(
+        RpcTransportMessage(
+          payload: decrypted.payload,
+          streamId: message.streamId,
+          isEndOfStream: message.isEndOfStream,
+        ),
+      );
+      return;
+    }
+
+    if (message.isEndOfStream) {
+      _incomingController.add(
+        RpcTransportMessage(
+          streamId: message.streamId,
+          isEndOfStream: true,
+        ),
+      );
+    }
+  }
+
+  Future<String> _waitForHandshakeToken() async {
+    try {
+      return await _handshakeTokens.stream
+          .first
+          .timeout(_config.handshakeTimeout);
+    } on TimeoutException catch (error) {
+      throw StateError('Handshake timed out: ${error.message ?? ''}');
+    }
+  }
+
+  Uint8List _serializeMetadata(RpcMetadata metadata) {
+    final headers = metadata.headers
+        .map((header) => {'name': header.name, 'value': header.value})
+        .toList(growable: false);
+    final jsonData = json.encode({'headers': headers});
+    return Uint8List.fromList(utf8.encode(jsonData));
+  }
+
+  RpcMetadata _deserializeMetadata(Uint8List payload) {
+    final jsonData = json.decode(utf8.decode(payload)) as Map<String, dynamic>;
+    final headers = <RpcHeader>[];
+    final rawHeaders = jsonData['headers'];
+    if (rawHeaders is List) {
+      for (final entry in rawHeaders) {
+        if (entry is Map<String, dynamic>) {
+          final name = entry['name'];
+          final value = entry['value'];
+          if (name is String && value is String) {
+            headers.add(RpcHeader(name, value));
+          }
+        }
+      }
+    }
+    return RpcMetadata(headers);
+  }
+
+  Future<String> _encryptFrame({
+    required _SessionState session,
+    required int streamId,
+    required _SecureFrameType type,
+    required Uint8List payload,
+  }) async {
+    final sequence = _outboundSequence++;
+    final token = await Licensify.encryptData(
+      data: {
+        'payload': base64Encode(payload),
+        'transportId': _keyStore.transportId,
+        'streamId': streamId,
+        'protocol': _protocolLabel,
+        'sequence': sequence,
+        'type': type.name,
+      },
+      encryptionKey: session.sendKey,
+      implicitAssertion: session.assertion,
+    );
+    return token;
+  }
+
+  Future<_DecryptedFrame> _decryptFrame({
+    required String token,
+    required _SessionState session,
+    required int streamId,
+    required _SecureFrameType expected,
+  }) async {
+    final decoded = await Licensify.decryptData(
+      encryptedToken: token,
+      encryptionKey: session.recvKey,
+      implicitAssertion: session.assertion,
+    );
+
+    final protocol = decoded['protocol'];
+    _ensureProtocol(protocol);
+
+    final transportId = decoded['transportId'];
+    if (transportId is! String || transportId != session.peerTransportId) {
+      throw StateError('Unexpected transportId in secure frame');
+    }
+
+    final frameStreamId = decoded['streamId'];
+    if (frameStreamId is! num || frameStreamId.toInt() != streamId) {
+      throw StateError('Secure frame stream mismatch');
+    }
+
+    final typeValue = decoded['type'];
+    if (typeValue is! String) {
+      throw StateError('Secure frame missing type');
+    }
+
+    final type = _SecureFrameType.values.firstWhere(
+      (value) => value.name == typeValue,
+      orElse: () => throw StateError('Unknown secure frame type: $typeValue'),
+    );
+
+    if (type != expected) {
+      throw StateError('Secure frame type mismatch');
+    }
+
+    final sequenceValue = decoded['sequence'];
+    if (sequenceValue is! num) {
+      throw StateError('Secure frame missing sequence');
+    }
+
+    final sequence = sequenceValue.toInt();
+    if (sequence != _expectedInboundSequence) {
+      throw StateError('Secure frame sequence mismatch');
+    }
+    _expectedInboundSequence++;
+
+    final payload = decoded['payload'];
+    if (payload is! String) {
+      throw StateError('Secure frame payload missing');
+    }
+
+    return _DecryptedFrame(
+      Uint8List.fromList(base64Decode(payload)),
+      type,
+    );
+  }
+
+  void _flushPendingMessages() {
+    if (_session == null || _pendingMessages.isEmpty) {
+      return;
+    }
+
+    final pending = List<RpcTransportMessage>.from(_pendingMessages);
+    _pendingMessages.clear();
+
+    for (final message in pending) {
+      unawaited(_deliverProtectedMessage(message, _session!));
+    }
+  }
+
+  void _ensureProtocol(Object? value) {
+    if (value is! String || value != _protocolLabel) {
+      throw StateError('Unsupported secure protocol: $value');
+    }
+  }
+
+  Uint8List _computeHandshakeHash(String helloToken, String ackToken) {
+    final digest = sha256.convert(
+      <int>[
+        ...utf8.encode(helloToken),
+        0,
+        ...utf8.encode(ackToken),
+      ],
+    );
+    return Uint8List.fromList(digest.bytes);
+  }
+
+  Uint8List _hkdf(
+    Uint8List input, {
+    required List<int> info,
+    int length = 32,
+  }) {
+    final salt = List<int>.filled(sha256.blockSize, 0);
+    final prk = Hmac(sha256, salt).convert(input).bytes;
+    final hmac = Hmac(sha256, prk);
+
+    final iterations = (length / sha256.convert(<int>[]).bytes.length).ceil();
+    final okm = <int>[];
+    var previous = <int>[];
+
+    for (var i = 1; i <= iterations; i++) {
+      final buffer = <int>[...previous, ...info, i];
+      previous = hmac.convert(buffer).bytes;
+      okm.addAll(previous);
+    }
+
+    return Uint8List.fromList(okm.sublist(0, length));
+  }
+
+  Uint8List _randomBytes(int length) {
+    final random = Random.secure();
+    final bytes = Uint8List(length);
+    for (var i = 0; i < length; i++) {
+      bytes[i] = random.nextInt(256);
+    }
+    return bytes;
+  }
+}

--- a/packages/rpc_dart_transports/pubspec.yaml
+++ b/packages/rpc_dart_transports/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
   args: ^2.7.0
   http2: ^2.3.1
   universal_io: ^2.2.2
+  licensify: ^3.1.0
+  crypto: ^3.0.5
 
 #dependency_overrides:
 #  rpc_dart:


### PR DESCRIPTION
## Summary
- add a SecureTransportAdapter that negotiates Licensify handshakes and encrypts every transport frame
- wire the secure adapter into the transport exports and expose helper key store/config types
- declare licensify and crypto dependencies for the transports package

## Testing
- not run (dart tooling unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d94b1065dc833392c4a097016db773