### PR TITLE
Optimize ping metadata send

### DIFF
--- a/packages/rpc_dart/lib/src/endpoint/ping.dart
+++ b/packages/rpc_dart/lib/src/endpoint/ping.dart
@@ -188,8 +188,11 @@ final class RpcEndpointPingExchange {
 
     try {
       logger.internal('Отправка ping запроса [streamId: $streamId]');
-      await transport.sendMetadata(streamId, metadata);
-      await transport.finishSending(streamId);
+      await transport.sendMetadata(
+        streamId,
+        metadata,
+        endStream: true,
+      );
     } catch (error, stackTrace) {
       await subscription.cancel();
       logger.error(


### PR DESCRIPTION
## Summary
- end the ping metadata send with endStream: true to avoid a trailing finishSending call

## Testing
- dart test packages/rpc_dart/test/endpoint/rpc_endpoint_ping_test.dart *(fails: dart executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9bfd3a1a883338f2dc92e658d8e05