### PR TITLE
Add TURN authentication enforcement

### DIFF
--- a/packages/rpc_dart_transports/lib/src/transports/relay/_index.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/relay/_index.dart
@@ -4,6 +4,7 @@
 
 export 'rpc_turn_relay_peer.dart';
 export 'rpc_turn_relay_transport.dart';
+export 'turn_credentials.dart';
 export 'turn_allocation.dart';
 export 'turn_message.dart';
 export 'turn_relay_client.dart';

--- a/packages/rpc_dart_transports/lib/src/transports/relay/turn_credentials.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/relay/turn_credentials.dart
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2025 Karim "nogipx" Mamatkazin <nogipx@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart' show md5;
+
+/// Credential store used by [TurnRelayServer] for TURN authentication.
+abstract interface class TurnCredentialStore {
+  /// TURN authentication realm advertised to clients.
+  String get realm;
+
+  /// Authentication nonce that clients must echo in requests.
+  String get nonce;
+
+  /// Validates that [nonce] is accepted for the current challenge.
+  bool validateNonce(String nonce);
+
+  /// Returns the credential registered for [username] if available.
+  TurnCredential? lookup(String username);
+}
+
+/// Representation of credentials used during TURN authentication.
+final class TurnCredential {
+  TurnCredential({
+    required this.username,
+    required this.password,
+    this.type = TurnCredentialType.longTerm,
+  });
+
+  /// Username advertised via the USERNAME attribute.
+  final String username;
+
+  /// Shared secret or password used to derive the message integrity key.
+  final String password;
+
+  /// TURN credential type used to derive the HMAC key.
+  final TurnCredentialType type;
+
+  /// Derives the HMAC key for [realm] according to RFC 5389 section 15.4.
+  Uint8List deriveKey(String realm) {
+    switch (type) {
+      case TurnCredentialType.shortTerm:
+        return Uint8List.fromList(utf8.encode(password));
+      case TurnCredentialType.longTerm:
+        final material = utf8.encode('$username:$realm:$password');
+        return Uint8List.fromList(md5.convert(material).bytes);
+    }
+  }
+}
+
+/// Credential store backed by an in-memory map of usernames.
+final class StaticTurnCredentialStore implements TurnCredentialStore {
+  StaticTurnCredentialStore({
+    required this.realm,
+    required this.nonce,
+    Map<String, TurnCredential>? credentials,
+  }) : _credentials = Map.unmodifiable(credentials ?? const {});
+
+  final Map<String, TurnCredential> _credentials;
+
+  @override
+  final String realm;
+
+  @override
+  final String nonce;
+
+  @override
+  bool validateNonce(String nonce) => nonce == this.nonce;
+
+  @override
+  TurnCredential? lookup(String username) => _credentials[username];
+}
+
+/// Supported TURN authentication mechanisms.
+enum TurnCredentialType {
+  shortTerm,
+  longTerm,
+}

--- a/packages/rpc_dart_transports/lib/src/transports/relay/turn_message.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/relay/turn_message.dart
@@ -181,6 +181,7 @@ final class TurnMessage {
   TurnMessage buildErrorResponse({
     required int code,
     required String reason,
+    List<TurnAttribute>? attributes,
   }) {
     final buffer = BytesBuilder();
     final errorData = ByteData(4);
@@ -190,15 +191,16 @@ final class TurnMessage {
     buffer.add(errorData.buffer.asUint8List());
     buffer.add(Uint8List.fromList(reason.codeUnits));
 
-    final attributes = [
-      TurnAttribute(TurnAttributeType.errorCode, buffer.toBytes())
+    final attrs = [
+      TurnAttribute(TurnAttributeType.errorCode, buffer.toBytes()),
+      ...?attributes,
     ];
 
     return TurnMessage(
       method: method,
       messageClass: TurnMessageClass.errorResponse,
       transactionId: transactionId,
-      attributes: attributes,
+      attributes: attrs,
     );
   }
 
@@ -256,10 +258,14 @@ final class TurnMessage {
 
 /// TURN attribute type constants used in this implementation.
 abstract final class TurnAttributeType {
+  static const int username = 0x0006;
+  static const int messageIntegrity = 0x0008;
   static const int channelNumber = 0x000C;
   static const int lifetime = 0x000D;
   static const int xorPeerAddress = 0x0012;
   static const int data = 0x0013;
+  static const int realm = 0x0014;
+  static const int nonce = 0x0015;
   static const int xorRelayedAddress = 0x0016;
   static const int requestedTransport = 0x0019;
   static const int xorMappedAddress = 0x0020;

--- a/packages/rpc_dart_transports/lib/src/transports/relay/turn_relay_server.dart
+++ b/packages/rpc_dart_transports/lib/src/transports/relay/turn_relay_server.dart
@@ -3,10 +3,13 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:crypto/crypto.dart' show Hmac, sha1;
 import 'package:universal_io/io.dart';
 
+import 'turn_credentials.dart';
 import 'turn_allocation.dart';
 import 'turn_message.dart';
 import 'turn_relay_logger.dart';
@@ -23,6 +26,7 @@ final class TurnRelayServer {
     this.permissionLifetime = const Duration(minutes: 5),
     this.channelLifetime = const Duration(minutes: 10),
     this.software = 'turn_relay/0.1.0',
+    this.credentialStore,
     TurnRelayLogger? logger,
   })  : relayAddress = relayAddress ?? bindAddress,
         _logger = logger?.child('TurnRelayServer');
@@ -47,6 +51,9 @@ final class TurnRelayServer {
 
   /// Value exposed through the SOFTWARE attribute.
   final String software;
+
+  /// Optional credential store used to authenticate TURN requests.
+  final TurnCredentialStore? credentialStore;
 
   final TurnRelayLogger? _logger;
 
@@ -188,15 +195,27 @@ final class TurnRelayServer {
         unawaited(_processAllocateRequest(context, message));
         break;
       case TurnMethod.refresh:
+        if (!_ensureAuthenticated(context, message)) {
+          return;
+        }
         _handleRefreshRequest(context, message);
         break;
       case TurnMethod.createPermission:
+        if (!_ensureAuthenticated(context, message)) {
+          return;
+        }
         _handleCreatePermissionRequest(context, message);
         break;
       case TurnMethod.channelBind:
+        if (!_ensureAuthenticated(context, message)) {
+          return;
+        }
         _handleChannelBindRequest(context, message);
         break;
       case TurnMethod.connectRequest:
+        if (!_ensureAuthenticated(context, message)) {
+          return;
+        }
         _handleConnectRequest(context, message);
         break;
       default:
@@ -214,6 +233,10 @@ final class TurnRelayServer {
     _TurnRelayConnectionContext context,
     TurnMessage message,
   ) async {
+    if (!_ensureAuthenticated(context, message)) {
+      return;
+    }
+
     final existing = context.allocation;
     if (existing != null && !existing.isExpired) {
       existing.refresh(allocationLifetime);
@@ -666,9 +689,143 @@ final class TurnRelayServer {
     TurnMessage request, {
     required int code,
     required String reason,
+    List<TurnAttribute> attributes = const [],
   }) {
-    final response = request.buildErrorResponse(code: code, reason: reason);
+    final response = request.buildErrorResponse(
+      code: code,
+      reason: reason,
+      attributes: attributes.isEmpty ? null : attributes,
+    );
     _sendTurnMessage(context, response);
+  }
+
+  bool _ensureAuthenticated(
+    _TurnRelayConnectionContext context,
+    TurnMessage message,
+  ) {
+    final store = credentialStore;
+    if (store == null) {
+      return true;
+    }
+
+    final usernameAttr = message.firstAttribute(TurnAttributeType.username);
+    final realmAttr = message.firstAttribute(TurnAttributeType.realm);
+    final nonceAttr = message.firstAttribute(TurnAttributeType.nonce);
+    final integrityAttr =
+        message.firstAttribute(TurnAttributeType.messageIntegrity);
+
+    if (usernameAttr == null ||
+        realmAttr == null ||
+        nonceAttr == null ||
+        integrityAttr == null) {
+      _sendUnauthorized(context, message, staleNonce: false);
+      return false;
+    }
+
+    String username;
+    String realm;
+    String nonce;
+    try {
+      username = utf8.decode(usernameAttr);
+      realm = utf8.decode(realmAttr);
+      nonce = utf8.decode(nonceAttr);
+    } on FormatException {
+      _sendUnauthorized(context, message, staleNonce: false);
+      return false;
+    }
+
+    if (realm != store.realm) {
+      _sendUnauthorized(context, message, staleNonce: false);
+      return false;
+    }
+
+    if (!store.validateNonce(nonce)) {
+      _sendUnauthorized(context, message, staleNonce: true);
+      return false;
+    }
+
+    if (integrityAttr.length != 20) {
+      _sendUnauthorized(context, message, staleNonce: false);
+      return false;
+    }
+
+    final existingUser = context.authenticatedUsername;
+    if (existingUser != null && existingUser != username) {
+      _sendUnauthorized(context, message, staleNonce: false);
+      return false;
+    }
+
+    final credential = store.lookup(username);
+    if (credential == null) {
+      _sendUnauthorized(context, message, staleNonce: false);
+      return false;
+    }
+
+    final key = credential.deriveKey(realm);
+    final expected = _computeMessageIntegrity(message, key);
+    if (expected == null || !_constantTimeEquals(expected, integrityAttr)) {
+      _sendUnauthorized(context, message, staleNonce: false);
+      return false;
+    }
+
+    context.authenticatedUsername = username;
+    return true;
+  }
+
+  Uint8List? _computeMessageIntegrity(TurnMessage message, List<int> key) {
+    final encoded = message.encode();
+    var offset = 20;
+    for (final attribute in message.attributes) {
+      final length = attribute.value.length;
+      final paddedLength = (length + 3) & ~3;
+      if (attribute.type == TurnAttributeType.messageIntegrity) {
+        final data = encoded.sublist(0, offset);
+        final digest = Hmac(sha1, key).convert(data);
+        return Uint8List.fromList(digest.bytes);
+      }
+      offset += 4 + paddedLength;
+    }
+    return null;
+  }
+
+  bool _constantTimeEquals(Uint8List a, Uint8List b) {
+    if (a.length != b.length) {
+      return false;
+    }
+    var diff = 0;
+    for (var i = 0; i < a.length; i++) {
+      diff |= a[i] ^ b[i];
+    }
+    return diff == 0;
+  }
+
+  void _sendUnauthorized(
+    _TurnRelayConnectionContext context,
+    TurnMessage request, {
+    required bool staleNonce,
+  }) {
+    final store = credentialStore;
+    final attributes = <TurnAttribute>[];
+    if (store != null) {
+      attributes.addAll([
+        TurnAttribute(
+          TurnAttributeType.realm,
+          Uint8List.fromList(utf8.encode(store.realm)),
+        ),
+        TurnAttribute(
+          TurnAttributeType.nonce,
+          Uint8List.fromList(utf8.encode(store.nonce)),
+        ),
+      ]);
+    }
+
+    _sendError(
+      context,
+      request,
+      code: staleNonce ? 438 : 401,
+      reason: staleNonce ? 'Stale Nonce' : 'Unauthorized',
+      attributes: attributes,
+    );
   }
 
   void _sendTurnMessage(
@@ -715,6 +872,7 @@ final class _TurnRelayConnectionContext {
   bool _disposed = false;
 
   TurnAllocation? allocation;
+  String? authenticatedUsername;
 
   InternetAddress get clientAddress => socket.remoteAddress;
   int get clientPort => socket.remotePort;

--- a/packages/rpc_dart_transports/test/relay/turn_relay_server_test.dart
+++ b/packages/rpc_dart_transports/test/relay/turn_relay_server_test.dart
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
 
+import 'package:crypto/crypto.dart' show Hmac, sha1;
 import 'package:rpc_dart_transports/rpc_dart_transports.dart';
 import 'package:test/test.dart';
 import 'package:universal_io/io.dart';
@@ -223,4 +226,204 @@ void main() {
       });
     }
   });
+
+  group('TurnRelayServer with authentication', () {
+    const username = 'alice';
+    const password = 'p@ssw0rd';
+    const realm = 'example.org';
+    const nonce = 'nonce-token';
+
+    late TurnRelayServer server;
+    late StaticTurnCredentialStore credentialStore;
+    late TurnCredential credential;
+
+    setUp(() async {
+      credentialStore = StaticTurnCredentialStore(
+        realm: realm,
+        nonce: nonce,
+        credentials: {
+          username: TurnCredential(
+            username: username,
+            password: password,
+            type: TurnCredentialType.longTerm,
+          ),
+        },
+      );
+      credential = credentialStore.lookup(username)!;
+
+      server = TurnRelayServer(
+        bindAddress: InternetAddress.loopbackIPv4,
+        bindPort: 0,
+        credentialStore: credentialStore,
+      );
+      await server.start();
+    });
+
+    tearDown(() async {
+      await server.stop();
+    });
+
+    test('rejects unauthenticated allocate request', () async {
+      final socket = await Socket.connect(server.bindAddress, server.port);
+      final turnMessages = StreamController<TurnMessage>.broadcast();
+      final frameDecoder = TurnTcpFrameDecoder(
+        onTurnMessage: turnMessages.add,
+        onChannelData: (_, __) {},
+      );
+
+      final socketSub = socket.listen((Uint8List data) {
+        if (data.isNotEmpty) {
+          frameDecoder.addChunk(data);
+        }
+      });
+
+      addTearDown(() async {
+        await socketSub.cancel();
+        await turnMessages.close();
+        await socket.close();
+      });
+
+      final allocateRequest = TurnMessage(
+        method: TurnMethod.allocate,
+        messageClass: TurnMessageClass.request,
+        attributes: [
+          TurnAttribute(
+            TurnAttributeType.requestedTransport,
+            Uint8List.fromList(<int>[TurnRequestedTransport.tcp, 0, 0, 0]),
+          ),
+        ],
+      );
+
+      socket.add(allocateRequest.encode());
+
+      final response = await turnMessages.stream.first.timeout(
+        const Duration(seconds: 1),
+        onTimeout: () => throw StateError('allocate response timeout'),
+      );
+
+      expect(response.messageClass, TurnMessageClass.errorResponse);
+      final errorAttr = response.firstAttribute(TurnAttributeType.errorCode);
+      expect(errorAttr, isNotNull);
+      expect(_decodeErrorCode(errorAttr!), 401);
+      expect(server.allocations, isEmpty);
+    });
+
+    test('accepts authenticated allocate request', () async {
+      final socket = await Socket.connect(server.bindAddress, server.port);
+      final turnMessages = StreamController<TurnMessage>.broadcast();
+      final frameDecoder = TurnTcpFrameDecoder(
+        onTurnMessage: turnMessages.add,
+        onChannelData: (_, __) {},
+      );
+
+      final socketSub = socket.listen((Uint8List data) {
+        if (data.isNotEmpty) {
+          frameDecoder.addChunk(data);
+        }
+      });
+
+      addTearDown(() async {
+        await socketSub.cancel();
+        await turnMessages.close();
+        await socket.close();
+      });
+
+      final request = _buildAuthenticatedRequest(
+        method: TurnMethod.allocate,
+        additional: [
+          TurnAttribute(
+            TurnAttributeType.requestedTransport,
+            Uint8List.fromList(<int>[TurnRequestedTransport.tcp, 0, 0, 0]),
+          ),
+        ],
+        credential: credential,
+        store: credentialStore,
+      );
+
+      socket.add(request.encode());
+
+      final response = await turnMessages.stream.first.timeout(
+        const Duration(seconds: 1),
+        onTimeout: () => throw StateError('allocate response timeout'),
+      );
+
+      expect(response.messageClass, TurnMessageClass.successResponse);
+      expect(server.allocations, isNotEmpty);
+    });
+  });
+}
+
+int _decodeErrorCode(Uint8List errorAttribute) {
+  final data = ByteData.sublistView(errorAttribute);
+  final classValue = data.getUint8(2);
+  final number = data.getUint8(3);
+  return classValue * 100 + number;
+}
+
+TurnMessage _buildAuthenticatedRequest({
+  required int method,
+  required List<TurnAttribute> additional,
+  required TurnCredential credential,
+  required TurnCredentialStore store,
+}) {
+  final transactionId = TurnMessage.generateTransactionId();
+  final attributes = <TurnAttribute>[
+    TurnAttribute(
+      TurnAttributeType.username,
+      Uint8List.fromList(utf8.encode(credential.username)),
+    ),
+    TurnAttribute(
+      TurnAttributeType.realm,
+      Uint8List.fromList(utf8.encode(store.realm)),
+    ),
+    TurnAttribute(
+      TurnAttributeType.nonce,
+      Uint8List.fromList(utf8.encode(store.nonce)),
+    ),
+    ...additional,
+  ];
+
+  final placeholder = TurnAttribute(
+    TurnAttributeType.messageIntegrity,
+    Uint8List(20),
+  );
+  final unsigned = TurnMessage(
+    method: method,
+    messageClass: TurnMessageClass.request,
+    transactionId: transactionId,
+    attributes: [...attributes, placeholder],
+  );
+
+  final key = credential.deriveKey(store.realm);
+  return _signMessage(unsigned, key);
+}
+
+TurnMessage _signMessage(TurnMessage message, Uint8List key) {
+  final encoded = message.encode();
+  var offset = 20;
+  late int integrityIndex;
+  for (var i = 0; i < message.attributes.length; i++) {
+    final attribute = message.attributes[i];
+    final length = attribute.value.length;
+    final paddedLength = (length + 3) & ~3;
+    if (attribute.type == TurnAttributeType.messageIntegrity) {
+      integrityIndex = i;
+      break;
+    }
+    offset += 4 + paddedLength;
+  }
+
+  final hmac = Hmac(sha1, key).convert(encoded.sublist(0, offset));
+  final attributes = [...message.attributes];
+  attributes[integrityIndex] = TurnAttribute(
+    TurnAttributeType.messageIntegrity,
+    Uint8List.fromList(hmac.bytes),
+  );
+
+  return TurnMessage(
+    method: message.method,
+    messageClass: message.messageClass,
+    transactionId: message.transactionId,
+    attributes: attributes,
+  );
 }


### PR DESCRIPTION
## Summary
- add a credential store abstraction and expose it from the relay transport package
- require TURN requests to include valid USERNAME/REALM/NONCE/MESSAGE-INTEGRITY attributes before provisioning allocations or other resources
- extend server tests to cover unauthenticated failures and successful authenticated allocations

## Testing
- Not run (dart CLI tooling is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dacda73ce883338654b863635a89c4