### PR TITLE
Add rpc_dart_analytics Flutter package

### DIFF
--- a/packages/rpc_dart_analytics/CHANGELOG.md
+++ b/packages/rpc_dart_analytics/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.4.0
+
+- Added per-event delivery hints that stay on-device and surface during upload
+  so applications can route sealed batches to custom backends.
+- Extended diagnostics snapshots to include delivery hints for easier
+  verification during development.
+- Migrated the local store to keep optional delivery metadata alongside
+  encrypted tokens.
+
 ## 0.3.0
 
 - Added fetch/acknowledge RPCs and a high-level `uploadPendingEvents()` helper

--- a/packages/rpc_dart_analytics/CHANGELOG.md
+++ b/packages/rpc_dart_analytics/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+- Added fetch/acknowledge RPCs and a high-level `uploadPendingEvents()` helper
+  for forwarding sealed analytics batches to backend services.
+
 ## 0.2.0
 
 - Added opt-in diagnostics buffers with `RpcAnalyticsDiagnosticsOptions` and a

--- a/packages/rpc_dart_analytics/CHANGELOG.md
+++ b/packages/rpc_dart_analytics/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+- Initial implementation of the encrypted, isolate-backed analytics runtime.

--- a/packages/rpc_dart_analytics/CHANGELOG.md
+++ b/packages/rpc_dart_analytics/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0
+
+- Added opt-in diagnostics buffers with `RpcAnalyticsDiagnosticsOptions` and a
+  new `diagnostics()` client API for inspecting recent events during
+  development.
+
 ## 0.1.0
 
 - Initial implementation of the isolate-backed analytics runtime with Licensify

--- a/packages/rpc_dart_analytics/CHANGELOG.md
+++ b/packages/rpc_dart_analytics/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## 0.1.0
 
-- Initial implementation of the encrypted, isolate-backed analytics runtime.
+- Initial implementation of the isolate-backed analytics runtime with Licensify
+  public-key sealed event storage.

--- a/packages/rpc_dart_analytics/README.md
+++ b/packages/rpc_dart_analytics/README.md
@@ -1,0 +1,16 @@
+# rpc_dart_analytics
+
+`rpc_dart_analytics` is a privacy-centric analytics layer for Flutter applications.
+It runs the collection pipeline inside an isolate via `RpcIsolateTransport`, keeps
+all events on-device using the encrypted storage primitives from `rpc_dart_data`,
+and requires a `LicensifyPublicKey` to operate.
+
+## Features
+
+- 🧩 Designed for integration with existing `rpc_dart` stacks.
+- 🔐 Transparent SQLCipher encryption for every stored payload.
+- 📶 Works fully offline — no network connection is required to collect events.
+- 🧵 Runs in a background isolate to isolate disk IO from the UI thread.
+- 🧹 Offers a one-shot `disableAndClear()` helper to wipe all telemetry.
+
+See `lib/rpc_dart_analytics.dart` for the public API surface.

--- a/packages/rpc_dart_analytics/README.md
+++ b/packages/rpc_dart_analytics/README.md
@@ -18,6 +18,8 @@ application.
 - 🧵 Runs in a background isolate to isolate disk IO from the UI thread.
 - 🧹 Offers a one-shot `disableAndClear()` helper to wipe all telemetry.
 - 🛠️ Ships with optional in-memory diagnostics buffers for development builds.
+- ☁️ Exposes fetch + acknowledge APIs (and a helper) for forwarding sealed
+  events to your backend.
 
 See `lib/rpc_dart_analytics.dart` for the public API surface.
 
@@ -33,6 +35,30 @@ final analytics = await RpcAnalytics.initialize(
 
 await analytics.logEvent('app_launch');
 ```
+
+### Forwarding events to a backend
+
+Because the worker stores Licensify-sealed tokens, you can upload them without
+ever touching the raw payloads. Fetch the encrypted batches, send them to your
+API, and acknowledge them so they are removed locally:
+
+```dart
+final uploaded = await analytics.uploadPendingEvents(
+  (events) async {
+    await backendClient.sendAnalytics(events.map((e) => <String, dynamic>{
+          'id': e.id,
+          'createdAt': e.createdAt.toIso8601String(),
+          'sealed': e.encryptedToken,
+        }));
+  },
+  batchSize: 100,
+);
+
+debugPrint('Uploaded $uploaded events');
+```
+
+If you prefer manual control, call `fetchForUpload()` to retrieve a batch and
+`acknowledgeUpload()` once your backend confirms persistence.
 
 ### Developer diagnostics
 

--- a/packages/rpc_dart_analytics/README.md
+++ b/packages/rpc_dart_analytics/README.md
@@ -20,6 +20,8 @@ application.
 - 🛠️ Ships with optional in-memory diagnostics buffers for development builds.
 - ☁️ Exposes fetch + acknowledge APIs (and a helper) for forwarding sealed
   events to your backend.
+- 🎯 Supports per-event delivery hints so the app chooses how and where to send
+  encrypted batches.
 
 See `lib/rpc_dart_analytics.dart` for the public API surface.
 
@@ -34,6 +36,15 @@ final analytics = await RpcAnalytics.initialize(
 );
 
 await analytics.logEvent('app_launch');
+
+await analytics.logEvent(
+  'subscription_purchase',
+  properties: {'plan': 'pro'},
+  deliveryHints: {'route': 'billing'},
+);
+
+Delivery hints stay local to the device and are exposed when you fetch upload
+batches so the host app can decide which transport should handle them.
 ```
 
 ### Forwarding events to a backend
@@ -45,17 +56,41 @@ API, and acknowledge them so they are removed locally:
 ```dart
 final uploaded = await analytics.uploadPendingEvents(
   (events) async {
-    await backendClient.sendAnalytics(events.map((e) => <String, dynamic>{
-          'id': e.id,
-          'createdAt': e.createdAt.toIso8601String(),
-          'sealed': e.encryptedToken,
-        }));
+    // Route batches based on the delivery hints each event carries.
+    final marketingEvents = <Map<String, dynamic>>[];
+    final billingEvents = <Map<String, dynamic>>[];
+
+    for (final event in events) {
+      final target = event.deliveryHints?['route'];
+      final payload = <String, dynamic>{
+        'id': event.id,
+        'createdAt': event.createdAt.toIso8601String(),
+        'sealed': event.encryptedToken,
+      };
+
+      if (target == 'billing') {
+        billingEvents.add(payload);
+      } else {
+        marketingEvents.add(payload);
+      }
+    }
+
+    if (marketingEvents.isNotEmpty) {
+      await backendClient.sendAnalytics(marketingEvents);
+    }
+    if (billingEvents.isNotEmpty) {
+      await billingClient.sendAnalytics(billingEvents);
+    }
   },
   batchSize: 100,
 );
 
 debugPrint('Uploaded $uploaded events');
 ```
+
+Delivery hints never leave the device unencrypted; they simply help you decide
+which transport or API client should receive a batch before you forward the
+sealed payloads.
 
 If you prefer manual control, call `fetchForUpload()` to retrieve a batch and
 `acknowledgeUpload()` once your backend confirms persistence.

--- a/packages/rpc_dart_analytics/README.md
+++ b/packages/rpc_dart_analytics/README.md
@@ -17,6 +17,7 @@ application.
 - 📶 Works fully offline — no network connection is required to collect events.
 - 🧵 Runs in a background isolate to isolate disk IO from the UI thread.
 - 🧹 Offers a one-shot `disableAndClear()` helper to wipe all telemetry.
+- 🛠️ Ships with optional in-memory diagnostics buffers for development builds.
 
 See `lib/rpc_dart_analytics.dart` for the public API surface.
 
@@ -31,4 +32,30 @@ final analytics = await RpcAnalytics.initialize(
 );
 
 await analytics.logEvent('app_launch');
+```
+
+### Developer diagnostics
+
+To inspect recent events during development, enable the diagnostics buffer in the
+configuration. The worker keeps the latest `maxEvents` payloads (unencrypted) in
+memory and exposes them via `RpcAnalytics.diagnostics()`. The encrypted store on
+disk is unaffected.
+
+```dart
+final analytics = await RpcAnalytics.initialize(
+  RpcAnalyticsConfig(
+    licenseKeyPaserk: 'k4.public.your-app-key-here',
+    databasePath: '/path/to/analytics.sqlite',
+    diagnosticsOptions: const RpcAnalyticsDiagnosticsOptions(
+      enabled: true,
+      maxEvents: 100,
+    ),
+  ),
+);
+
+final diagnostics = await analytics.diagnostics();
+debugPrint('Diagnostics enabled: ${diagnostics.diagnosticsEnabled}');
+for (final event in diagnostics.recentEvents) {
+  debugPrint('${event.timestamp}: ${event.eventName}');
+}
 ```

--- a/packages/rpc_dart_analytics/README.md
+++ b/packages/rpc_dart_analytics/README.md
@@ -3,14 +3,32 @@
 `rpc_dart_analytics` is a privacy-centric analytics layer for Flutter applications.
 It runs the collection pipeline inside an isolate via `RpcIsolateTransport`, keeps
 all events on-device using the encrypted storage primitives from `rpc_dart_data`,
-and requires a `LicensifyPublicKey` to operate.
+and requires a `Licensify` PASERK `k4.public` key supplied by the host
+application.
+
+> **Important:** The PASERK string must be bundled with the app (not derived from
+> a password at runtime) and is used directly to seal every analytics payload
+> through Licensify.
 
 ## Features
 
 - 🧩 Designed for integration with existing `rpc_dart` stacks.
-- 🔐 Transparent SQLCipher encryption for every stored payload.
+- 🔐 Every event is sealed with your Licensify public key before it reaches disk.
 - 📶 Works fully offline — no network connection is required to collect events.
 - 🧵 Runs in a background isolate to isolate disk IO from the UI thread.
 - 🧹 Offers a one-shot `disableAndClear()` helper to wipe all telemetry.
 
 See `lib/rpc_dart_analytics.dart` for the public API surface.
+
+## Usage
+
+```dart
+final analytics = await RpcAnalytics.initialize(
+  const RpcAnalyticsConfig(
+    licenseKeyPaserk: 'k4.public.your-app-key-here',
+    databasePath: '/path/to/analytics.sqlite',
+  ),
+);
+
+await analytics.logEvent('app_launch');
+```

--- a/packages/rpc_dart_analytics/analysis_options.yaml
+++ b/packages/rpc_dart_analytics/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    public_member_api_docs: true
+    avoid_print: true

--- a/packages/rpc_dart_analytics/lib/rpc_dart_analytics.dart
+++ b/packages/rpc_dart_analytics/lib/rpc_dart_analytics.dart
@@ -3,4 +3,4 @@ library rpc_dart_analytics;
 export 'src/analytics_client.dart';
 export 'src/config.dart';
 export 'src/messages.dart'
-    show AnalyticsStatusSnapshot;
+    show AnalyticsStatusSnapshot, AnalyticsDiagnosticsSnapshot, AnalyticsDiagnosticsEvent;

--- a/packages/rpc_dart_analytics/lib/rpc_dart_analytics.dart
+++ b/packages/rpc_dart_analytics/lib/rpc_dart_analytics.dart
@@ -3,4 +3,9 @@ library rpc_dart_analytics;
 export 'src/analytics_client.dart';
 export 'src/config.dart';
 export 'src/messages.dart'
-    show AnalyticsStatusSnapshot, AnalyticsDiagnosticsSnapshot, AnalyticsDiagnosticsEvent;
+    show
+        AnalyticsStatusSnapshot,
+        AnalyticsDiagnosticsSnapshot,
+        AnalyticsDiagnosticsEvent,
+        AnalyticsUploadEnvelope,
+        AnalyticsUploadBatch;

--- a/packages/rpc_dart_analytics/lib/rpc_dart_analytics.dart
+++ b/packages/rpc_dart_analytics/lib/rpc_dart_analytics.dart
@@ -1,0 +1,6 @@
+library rpc_dart_analytics;
+
+export 'src/analytics_client.dart';
+export 'src/config.dart';
+export 'src/messages.dart'
+    show AnalyticsStatusSnapshot;

--- a/packages/rpc_dart_analytics/lib/src/analytics_client.dart
+++ b/packages/rpc_dart_analytics/lib/src/analytics_client.dart
@@ -56,15 +56,20 @@ class RpcAnalytics {
   }
 
   /// Records a new analytics event.
+  ///
+  /// [deliveryHints] stay on-device and are surfaced when fetching upload
+  /// batches so the application can decide where to forward sealed events.
   Future<void> logEvent(
     String eventName, {
     Map<String, dynamic>? properties,
+    Map<String, dynamic>? deliveryHints,
     DateTime? timestamp,
   }) async {
     _throwIfDisposed();
     final request = AnalyticsLogEventRequest(
       eventName: eventName,
       properties: properties,
+      deliveryHints: deliveryHints,
       timestamp: (timestamp ?? DateTime.now()).toUtc(),
     );
 
@@ -97,6 +102,9 @@ class RpcAnalytics {
   }
 
   /// Fetches a batch of encrypted events ready to be uploaded.
+  ///
+  /// The returned envelopes include any [AnalyticsUploadEnvelope.deliveryHints]
+  /// that were supplied when logging the events.
   Future<AnalyticsUploadBatch> fetchForUpload({int limit = 50}) {
     _throwIfDisposed();
     if (limit <= 0) {
@@ -124,8 +132,10 @@ class RpcAnalytics {
   /// Convenience helper that iterates through stored events and uploads them.
   ///
   /// The provided [uploader] receives the encrypted batch; once it completes
-  /// without throwing, the events are removed from local storage. Returns the
-  /// total number of uploaded events.
+  /// without throwing, the events are removed from local storage. Use
+  /// [AnalyticsUploadEnvelope.deliveryHints] to decide which backend or
+  /// transport should receive the sealed payloads. Returns the total number of
+  /// uploaded events.
   Future<int> uploadPendingEvents(
     Future<void> Function(List<AnalyticsUploadEnvelope> events) uploader, {
     int batchSize = 50,

--- a/packages/rpc_dart_analytics/lib/src/analytics_client.dart
+++ b/packages/rpc_dart_analytics/lib/src/analytics_client.dart
@@ -1,0 +1,213 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:licensify/licensify.dart';
+import 'package:rpc_dart/rpc_dart.dart';
+import 'package:rpc_dart_transports/rpc_dart_transports.dart';
+
+import 'analytics_worker.dart';
+import 'config.dart';
+import 'messages.dart';
+
+/// High-level analytics facade consumed by Flutter applications.
+class RpcAnalytics {
+  RpcAnalytics._(
+    this._caller,
+    this._endpoint,
+    this._killIsolate,
+  );
+
+  final _AnalyticsCaller _caller;
+  final RpcCallerEndpoint _endpoint;
+  final void Function() _killIsolate;
+
+  bool _disposed = false;
+
+  /// Spawns the analytics worker isolate and prepares the RPC stack.
+  static Future<RpcAnalytics> initialize(RpcAnalyticsConfig config) async {
+    final encryptionKey = _deriveEncryptionKey(config.licenseKey);
+
+    final spawnResult = await RpcIsolateTransport.spawn(
+      entrypoint: analyticsWorkerEntrypoint,
+      customParams: <String, dynamic>{
+        'databasePath': config.databasePath,
+        'encryptionKey': encryptionKey,
+        'enabled': config.enabledByDefault,
+        'logStatements': config.logSqlStatements,
+      },
+      debugName: 'rpc_dart_analytics_worker',
+    );
+
+    final endpoint = RpcCallerEndpoint(
+      transport: spawnResult.transport,
+      debugLabel: 'rpc_dart_analytics_client',
+    );
+    final caller = _AnalyticsCaller(endpoint);
+
+    // Ensure the worker is fully initialized before returning control.
+    await caller.getStatus();
+
+    // Best-effort wipe of the derived key once the worker consumed it.
+    encryptionKey.fillRange(0, encryptionKey.length, 0);
+
+    return RpcAnalytics._(
+      caller,
+      endpoint,
+      spawnResult.kill,
+    );
+  }
+
+  /// Records a new analytics event.
+  Future<void> logEvent(
+    String eventName, {
+    Map<String, dynamic>? properties,
+    DateTime? timestamp,
+  }) async {
+    _throwIfDisposed();
+    final request = AnalyticsLogEventRequest(
+      eventName: eventName,
+      properties: properties,
+      timestamp: (timestamp ?? DateTime.now()).toUtc(),
+    );
+
+    final ack = await _caller.logEvent(request);
+    if (!ack.success && ack.message == 'disabled') {
+      return;
+    }
+
+    if (!ack.success) {
+      throw StateError(ack.message ?? 'Analytics event rejected');
+    }
+  }
+
+  /// Updates the enabled state of the analytics worker.
+  Future<AnalyticsStatusSnapshot> setEnabled(bool enabled) async {
+    _throwIfDisposed();
+    return _caller.setEnabled(AnalyticsSetEnabledRequest(enabled));
+  }
+
+  /// Returns the current storage snapshot.
+  Future<AnalyticsStatusSnapshot> status() async {
+    _throwIfDisposed();
+    return _caller.getStatus();
+  }
+
+  /// Removes all stored events without disabling the pipeline.
+  Future<AnalyticsStatusSnapshot> clear() async {
+    _throwIfDisposed();
+    return _caller.clear();
+  }
+
+  /// Disables analytics and wipes the encrypted store.
+  Future<AnalyticsStatusSnapshot> disableAndClear() async {
+    _throwIfDisposed();
+    return _caller.disableAndClear();
+  }
+
+  /// Gracefully shuts down the analytics worker and releases resources.
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+
+    try {
+      await _caller.shutdown();
+    } catch (_) {
+      // Ignore shutdown errors – the isolate will be killed anyway.
+    }
+
+    await _endpoint.close();
+    _killIsolate();
+  }
+
+  void _throwIfDisposed() {
+    if (_disposed) {
+      throw StateError('RpcAnalytics has been disposed');
+    }
+  }
+}
+
+class _AnalyticsCaller extends RpcCallerContract {
+  _AnalyticsCaller(RpcCallerEndpoint endpoint)
+      : super(
+          AnalyticsContract.serviceName,
+          endpoint,
+          dataTransferMode: RpcDataTransferMode.codec,
+        );
+
+  Future<AnalyticsAck> logEvent(AnalyticsLogEventRequest request) {
+    return callUnary<AnalyticsLogEventRequest, AnalyticsAck>(
+      methodName: AnalyticsContract.methodLogEvent,
+      request: request,
+      requestCodec: AnalyticsLogEventRequest.codec,
+      responseCodec: AnalyticsAck.codec,
+    );
+  }
+
+  Future<AnalyticsStatusSnapshot> setEnabled(
+    AnalyticsSetEnabledRequest request,
+  ) {
+    return callUnary<AnalyticsSetEnabledRequest, AnalyticsStatusSnapshot>(
+      methodName: AnalyticsContract.methodSetEnabled,
+      request: request,
+      requestCodec: AnalyticsSetEnabledRequest.codec,
+      responseCodec: AnalyticsStatusSnapshot.codec,
+    );
+  }
+
+  Future<AnalyticsStatusSnapshot> clear() {
+    return callUnary<AnalyticsClearRequest, AnalyticsStatusSnapshot>(
+      methodName: AnalyticsContract.methodClear,
+      request: const AnalyticsClearRequest(),
+      requestCodec: AnalyticsClearRequest.codec,
+      responseCodec: AnalyticsStatusSnapshot.codec,
+    );
+  }
+
+  Future<AnalyticsStatusSnapshot> disableAndClear() {
+    return callUnary<AnalyticsDisableAndClearRequest, AnalyticsStatusSnapshot>(
+      methodName: AnalyticsContract.methodDisableAndClear,
+      request: const AnalyticsDisableAndClearRequest(),
+      requestCodec: AnalyticsDisableAndClearRequest.codec,
+      responseCodec: AnalyticsStatusSnapshot.codec,
+    );
+  }
+
+  Future<AnalyticsStatusSnapshot> getStatus() {
+    return callUnary<AnalyticsClearRequest, AnalyticsStatusSnapshot>(
+      methodName: AnalyticsContract.methodGetStatus,
+      request: const AnalyticsClearRequest(),
+      requestCodec: AnalyticsClearRequest.codec,
+      responseCodec: AnalyticsStatusSnapshot.codec,
+    );
+  }
+
+  Future<void> shutdown() async {
+    await callUnary<AnalyticsShutdownRequest, AnalyticsAck>(
+      methodName: AnalyticsContract.methodShutdown,
+      request: const AnalyticsShutdownRequest(),
+      requestCodec: AnalyticsShutdownRequest.codec,
+      responseCodec: AnalyticsAck.codec,
+    );
+  }
+}
+
+Uint8List _deriveEncryptionKey(LicensifyPublicKey publicKey) {
+  final serialized = _serializePublicKey(publicKey);
+  final digest = sha256.convert(utf8.encode(serialized));
+  return Uint8List.fromList(digest.bytes);
+}
+
+String _serializePublicKey(LicensifyPublicKey publicKey) {
+  try {
+    final dynamic dynamicKey = publicKey;
+    final paserk = dynamicKey.toPaserk();
+    if (paserk is String && paserk.isNotEmpty) {
+      return paserk;
+    }
+  } catch (_) {
+    // Fall through to the `toString()` fallback below.
+  }
+  return publicKey.toString();
+}

--- a/packages/rpc_dart_analytics/lib/src/analytics_client.dart
+++ b/packages/rpc_dart_analytics/lib/src/analytics_client.dart
@@ -1,8 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
-import 'dart:typed_data';
-
-import 'package:crypto/crypto.dart';
 import 'package:licensify/licensify.dart';
 import 'package:rpc_dart/rpc_dart.dart';
 import 'package:rpc_dart_transports/rpc_dart_transports.dart';
@@ -27,13 +23,15 @@ class RpcAnalytics {
 
   /// Spawns the analytics worker isolate and prepares the RPC stack.
   static Future<RpcAnalytics> initialize(RpcAnalyticsConfig config) async {
-    final encryptionKey = _deriveEncryptionKey(config.licenseKey);
+    final trimmed = config.licenseKeyPaserk.trim();
+    // Validate the PASERK string eagerly so configuration errors surface early.
+    LicensifyPublicKey.fromPaserk(paserk: trimmed);
 
     final spawnResult = await RpcIsolateTransport.spawn(
       entrypoint: analyticsWorkerEntrypoint,
       customParams: <String, dynamic>{
         'databasePath': config.databasePath,
-        'encryptionKey': encryptionKey,
+        'licenseKeyPaserk': trimmed,
         'enabled': config.enabledByDefault,
         'logStatements': config.logSqlStatements,
       },
@@ -48,9 +46,6 @@ class RpcAnalytics {
 
     // Ensure the worker is fully initialized before returning control.
     await caller.getStatus();
-
-    // Best-effort wipe of the derived key once the worker consumed it.
-    encryptionKey.fillRange(0, encryptionKey.length, 0);
 
     return RpcAnalytics._(
       caller,
@@ -193,21 +188,3 @@ class _AnalyticsCaller extends RpcCallerContract {
   }
 }
 
-Uint8List _deriveEncryptionKey(LicensifyPublicKey publicKey) {
-  final serialized = _serializePublicKey(publicKey);
-  final digest = sha256.convert(utf8.encode(serialized));
-  return Uint8List.fromList(digest.bytes);
-}
-
-String _serializePublicKey(LicensifyPublicKey publicKey) {
-  try {
-    final dynamic dynamicKey = publicKey;
-    final paserk = dynamicKey.toPaserk();
-    if (paserk is String && paserk.isNotEmpty) {
-      return paserk;
-    }
-  } catch (_) {
-    // Fall through to the `toString()` fallback below.
-  }
-  return publicKey.toString();
-}

--- a/packages/rpc_dart_analytics/lib/src/analytics_client.dart
+++ b/packages/rpc_dart_analytics/lib/src/analytics_client.dart
@@ -96,6 +96,65 @@ class RpcAnalytics {
     return _caller.getDiagnostics();
   }
 
+  /// Fetches a batch of encrypted events ready to be uploaded.
+  Future<AnalyticsUploadBatch> fetchForUpload({int limit = 50}) {
+    _throwIfDisposed();
+    if (limit <= 0) {
+      throw ArgumentError.value(limit, 'limit', 'must be greater than zero');
+    }
+
+    return _caller.fetchForUpload(
+      AnalyticsUploadFetchRequest(limit: limit),
+    );
+  }
+
+  /// Removes uploaded events from local storage once the backend confirms.
+  Future<void> acknowledgeUpload(Iterable<int> eventIds) async {
+    _throwIfDisposed();
+    final uniqueIds = eventIds.toSet().toList(growable: false);
+    if (uniqueIds.isEmpty) {
+      return;
+    }
+
+    await _caller.acknowledgeUpload(
+      AnalyticsUploadAcknowledgeRequest(eventIds: uniqueIds),
+    );
+  }
+
+  /// Convenience helper that iterates through stored events and uploads them.
+  ///
+  /// The provided [uploader] receives the encrypted batch; once it completes
+  /// without throwing, the events are removed from local storage. Returns the
+  /// total number of uploaded events.
+  Future<int> uploadPendingEvents(
+    Future<void> Function(List<AnalyticsUploadEnvelope> events) uploader, {
+    int batchSize = 50,
+  }) async {
+    _throwIfDisposed();
+    if (batchSize <= 0) {
+      throw ArgumentError.value(batchSize, 'batchSize', 'must be positive');
+    }
+
+    var uploaded = 0;
+    while (true) {
+      final batch = await fetchForUpload(limit: batchSize);
+      final events = batch.events;
+      if (events.isEmpty) {
+        break;
+      }
+
+      await uploader(events);
+      await acknowledgeUpload(events.map((e) => e.id));
+      uploaded += events.length;
+
+      if (!batch.hasMore) {
+        break;
+      }
+    }
+
+    return uploaded;
+  }
+
   /// Removes all stored events without disabling the pipeline.
   Future<AnalyticsStatusSnapshot> clear() async {
     _throwIfDisposed();
@@ -192,6 +251,30 @@ class _AnalyticsCaller extends RpcCallerContract {
       requestCodec: AnalyticsDiagnosticsRequest.codec,
       responseCodec: AnalyticsDiagnosticsSnapshot.codec,
     );
+  }
+
+  Future<AnalyticsUploadBatch> fetchForUpload(
+    AnalyticsUploadFetchRequest request,
+  ) {
+    return callUnary<AnalyticsUploadFetchRequest, AnalyticsUploadBatch>(
+      methodName: AnalyticsContract.methodFetchForUpload,
+      request: request,
+      requestCodec: AnalyticsUploadFetchRequest.codec,
+      responseCodec: AnalyticsUploadBatch.codec,
+    );
+  }
+
+  Future<void> acknowledgeUpload(AnalyticsUploadAcknowledgeRequest request) {
+    return callUnary<AnalyticsUploadAcknowledgeRequest, AnalyticsAck>(
+      methodName: AnalyticsContract.methodAcknowledgeUpload,
+      request: request,
+      requestCodec: AnalyticsUploadAcknowledgeRequest.codec,
+      responseCodec: AnalyticsAck.codec,
+    ).then((value) {
+      if (!value.success) {
+        throw StateError(value.message ?? 'Failed to acknowledge analytics events');
+      }
+    });
   }
 
   Future<void> shutdown() async {

--- a/packages/rpc_dart_analytics/lib/src/analytics_client.dart
+++ b/packages/rpc_dart_analytics/lib/src/analytics_client.dart
@@ -34,6 +34,7 @@ class RpcAnalytics {
         'licenseKeyPaserk': trimmed,
         'enabled': config.enabledByDefault,
         'logStatements': config.logSqlStatements,
+        'diagnostics': config.diagnosticsOptions.toJson(),
       },
       debugName: 'rpc_dart_analytics_worker',
     );
@@ -87,6 +88,12 @@ class RpcAnalytics {
   Future<AnalyticsStatusSnapshot> status() async {
     _throwIfDisposed();
     return _caller.getStatus();
+  }
+
+  /// Returns a diagnostics snapshot with recent buffered events.
+  Future<AnalyticsDiagnosticsSnapshot> diagnostics() async {
+    _throwIfDisposed();
+    return _caller.getDiagnostics();
   }
 
   /// Removes all stored events without disabling the pipeline.
@@ -175,6 +182,15 @@ class _AnalyticsCaller extends RpcCallerContract {
       request: const AnalyticsClearRequest(),
       requestCodec: AnalyticsClearRequest.codec,
       responseCodec: AnalyticsStatusSnapshot.codec,
+    );
+  }
+
+  Future<AnalyticsDiagnosticsSnapshot> getDiagnostics() {
+    return callUnary<AnalyticsDiagnosticsRequest, AnalyticsDiagnosticsSnapshot>(
+      methodName: AnalyticsContract.methodDiagnostics,
+      request: const AnalyticsDiagnosticsRequest(),
+      requestCodec: AnalyticsDiagnosticsRequest.codec,
+      responseCodec: AnalyticsDiagnosticsSnapshot.codec,
     );
   }
 

--- a/packages/rpc_dart_analytics/lib/src/analytics_worker.dart
+++ b/packages/rpc_dart_analytics/lib/src/analytics_worker.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:meta/meta.dart';
@@ -368,9 +369,21 @@ final class AnalyticsStorageManager {
       'CREATE TABLE IF NOT EXISTS analytics_events ('
       'id INTEGER PRIMARY KEY AUTOINCREMENT,'
       'created_at_ms INTEGER NOT NULL,'
-      'encrypted_token TEXT NOT NULL'
+      'encrypted_token TEXT NOT NULL,'
+      'delivery_hints TEXT'
       ')',
     );
+
+    final columns = await _storage.database
+        .customSelect('PRAGMA table_info(analytics_events)')
+        .get();
+    final hasDeliveryHints = columns
+        .any((row) => row.read<String>('name') == 'delivery_hints');
+    if (!hasDeliveryHints) {
+      await _storage.database.customStatement(
+        'ALTER TABLE analytics_events ADD COLUMN delivery_hints TEXT',
+      );
+    }
 
     _schemaReady = true;
   }
@@ -388,8 +401,19 @@ final class AnalyticsStorageManager {
             properties: request.properties == null
                 ? null
                 : Map<String, dynamic>.from(request.properties!),
+            deliveryHints: request.deliveryHints == null
+                ? null
+                : Map<String, dynamic>.from(request.deliveryHints!),
           )
         : null;
+    String? deliveryHintsJson;
+    if (request.deliveryHints != null) {
+      try {
+        deliveryHintsJson = jsonEncode(request.deliveryHints);
+      } catch (_) {
+        deliveryHintsJson = null;
+      }
+    }
     final encryptedToken = await Licensify.encryptDataForPublicKey(
       data: <String, dynamic>{
         'event': request.eventName,
@@ -400,11 +424,12 @@ final class AnalyticsStorageManager {
     );
 
     await _storage.database.customStatement(
-      'INSERT INTO analytics_events (created_at_ms, encrypted_token) '
-      'VALUES (?, ?)',
+      'INSERT INTO analytics_events (created_at_ms, encrypted_token, delivery_hints) '
+      'VALUES (?, ?, ?)',
       <Object?>[
         DateTime.now().toUtc().millisecondsSinceEpoch,
         encryptedToken,
+        deliveryHintsJson,
       ],
     );
 
@@ -481,7 +506,7 @@ final class AnalyticsStorageManager {
     await _ensureSchema();
     final rows = await _storage.database
         .customSelect(
-          'SELECT id, created_at_ms, encrypted_token '
+          'SELECT id, created_at_ms, encrypted_token, delivery_hints '
           'FROM analytics_events ORDER BY id ASC LIMIT ?',
           <Object?>[limit],
         )
@@ -489,14 +514,29 @@ final class AnalyticsStorageManager {
 
     final events = rows
         .map(
-          (row) => AnalyticsUploadEnvelope(
-            id: row.read<int>('id'),
-            createdAt: DateTime.fromMillisecondsSinceEpoch(
-              row.read<int>('created_at_ms'),
-              isUtc: true,
-            ).toUtc(),
-            encryptedToken: row.read<String>('encrypted_token'),
-          ),
+          (row) {
+            Map<String, dynamic>? hints;
+            final hintsJson = row.read<String?>('delivery_hints');
+            if (hintsJson != null && hintsJson.isNotEmpty) {
+              try {
+                final decoded = jsonDecode(hintsJson);
+                if (decoded is Map) {
+                  hints = Map<String, dynamic>.from(decoded as Map);
+                }
+              } catch (_) {
+                hints = null;
+              }
+            }
+            return AnalyticsUploadEnvelope(
+              id: row.read<int>('id'),
+              createdAt: DateTime.fromMillisecondsSinceEpoch(
+                row.read<int>('created_at_ms'),
+                isUtc: true,
+              ).toUtc(),
+              encryptedToken: row.read<String>('encrypted_token'),
+              deliveryHints: hints,
+            );
+          },
         )
         .toList(growable: false);
 

--- a/packages/rpc_dart_analytics/lib/src/analytics_worker.dart
+++ b/packages/rpc_dart_analytics/lib/src/analytics_worker.dart
@@ -1,0 +1,354 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:rpc_dart/rpc_dart.dart';
+import 'package:rpc_dart_data/rpc_dart_data.dart';
+
+import 'messages.dart';
+
+/// Entry point invoked inside the analytics isolate.
+void analyticsWorkerEntrypoint(
+  IRpcTransport transport,
+  Map<String, dynamic> customParams,
+) {
+  // Run async initialization without blocking isolate startup.
+  // ignore: discarded_futures
+  runZonedGuarded<Future<void>>(
+    () async {
+      final config = _WorkerBootstrapParams.fromMap(customParams);
+      final storage = await AnalyticsStorageManager.open(
+        databasePath: config.databasePath,
+        encryptionKey: config.encryptionKey,
+        enabledByDefault: config.enabledByDefault,
+        logSqlStatements: config.logSqlStatements,
+      );
+
+      final endpoint = RpcResponderEndpoint(
+        transport: transport,
+        debugLabel: 'rpc_dart_analytics_worker',
+      );
+      final responder = AnalyticsResponder(storage: storage);
+      endpoint.registerServiceContract(responder);
+      endpoint.start();
+    },
+    (error, stackTrace) {
+      stderr.writeln('rpc_dart_analytics worker crashed: $error');
+      stderr.writeln(stackTrace);
+    },
+  );
+}
+
+@immutable
+class _WorkerBootstrapParams {
+  const _WorkerBootstrapParams({
+    required this.databasePath,
+    required this.encryptionKey,
+    required this.enabledByDefault,
+    required this.logSqlStatements,
+  });
+
+  factory _WorkerBootstrapParams.fromMap(Map<String, dynamic> raw) {
+    final keyData = raw['encryptionKey'];
+    late final Uint8List encryptionKey;
+    if (keyData is Uint8List) {
+      encryptionKey = Uint8List.fromList(keyData);
+    } else if (keyData is List<int>) {
+      encryptionKey = Uint8List.fromList(keyData);
+    } else {
+      throw ArgumentError('Invalid encryptionKey payload: ${keyData.runtimeType}');
+    }
+
+    final databasePath = raw['databasePath'] as String?;
+    if (databasePath == null || databasePath.isEmpty) {
+      throw ArgumentError('databasePath must be provided for analytics worker');
+    }
+
+    return _WorkerBootstrapParams(
+      databasePath: databasePath,
+      encryptionKey: encryptionKey,
+      enabledByDefault: raw['enabled'] as bool? ?? true,
+      logSqlStatements: raw['logStatements'] as bool? ?? false,
+    );
+  }
+
+  final String databasePath;
+  final Uint8List encryptionKey;
+  final bool enabledByDefault;
+  final bool logSqlStatements;
+}
+
+final class AnalyticsResponder extends RpcResponderContract {
+  AnalyticsResponder({required AnalyticsStorageManager storage})
+      : _storage = storage,
+        super(
+          AnalyticsContract.serviceName,
+          dataTransferMode: RpcDataTransferMode.codec,
+        );
+
+  final AnalyticsStorageManager _storage;
+
+  bool _disposed = false;
+
+  @override
+  void setup() {
+    addUnaryMethod<AnalyticsLogEventRequest, AnalyticsAck>(
+      methodName: AnalyticsContract.methodLogEvent,
+      requestCodec: AnalyticsLogEventRequest.codec,
+      responseCodec: AnalyticsAck.codec,
+      handler: _handleLogEvent,
+    );
+
+    addUnaryMethod<AnalyticsSetEnabledRequest, AnalyticsStatusSnapshot>(
+      methodName: AnalyticsContract.methodSetEnabled,
+      requestCodec: AnalyticsSetEnabledRequest.codec,
+      responseCodec: AnalyticsStatusSnapshot.codec,
+      handler: _handleSetEnabled,
+    );
+
+    addUnaryMethod<AnalyticsClearRequest, AnalyticsStatusSnapshot>(
+      methodName: AnalyticsContract.methodClear,
+      requestCodec: AnalyticsClearRequest.codec,
+      responseCodec: AnalyticsStatusSnapshot.codec,
+      handler: _handleClear,
+    );
+
+    addUnaryMethod<AnalyticsDisableAndClearRequest, AnalyticsStatusSnapshot>(
+      methodName: AnalyticsContract.methodDisableAndClear,
+      requestCodec: AnalyticsDisableAndClearRequest.codec,
+      responseCodec: AnalyticsStatusSnapshot.codec,
+      handler: _handleDisableAndClear,
+    );
+
+    addUnaryMethod<AnalyticsClearRequest, AnalyticsStatusSnapshot>(
+      methodName: AnalyticsContract.methodGetStatus,
+      requestCodec: AnalyticsClearRequest.codec,
+      responseCodec: AnalyticsStatusSnapshot.codec,
+      handler: (request, {context}) => _storage.snapshot(),
+    );
+
+    addUnaryMethod<AnalyticsShutdownRequest, AnalyticsAck>(
+      methodName: AnalyticsContract.methodShutdown,
+      requestCodec: AnalyticsShutdownRequest.codec,
+      responseCodec: AnalyticsAck.codec,
+      handler: _handleShutdown,
+    );
+  }
+
+  Future<AnalyticsAck> _handleLogEvent(
+    AnalyticsLogEventRequest request, {
+    RpcContext? context,
+  }) async {
+    if (_disposed) {
+      return const AnalyticsAck(
+        success: false,
+        message: 'analytics storage disposed',
+      );
+    }
+
+    final accepted = await _storage.insertEvent(request);
+    return AnalyticsAck(
+      success: accepted,
+      message: accepted ? 'stored' : 'disabled',
+    );
+  }
+
+  Future<AnalyticsStatusSnapshot> _handleSetEnabled(
+    AnalyticsSetEnabledRequest request, {
+    RpcContext? context,
+  }) {
+    if (_disposed) {
+      return Future.value(
+        const AnalyticsStatusSnapshot(
+          enabled: false,
+          eventCount: 0,
+        ),
+      );
+    }
+    return _storage.setEnabled(request.enabled);
+  }
+
+  Future<AnalyticsStatusSnapshot> _handleClear(
+    AnalyticsClearRequest request, {
+    RpcContext? context,
+  }) {
+    if (_disposed) {
+      return Future.value(
+        const AnalyticsStatusSnapshot(
+          enabled: false,
+          eventCount: 0,
+        ),
+      );
+    }
+    return _storage.clear();
+  }
+
+  Future<AnalyticsStatusSnapshot> _handleDisableAndClear(
+    AnalyticsDisableAndClearRequest request, {
+    RpcContext? context,
+  }) {
+    if (_disposed) {
+      return Future.value(
+        const AnalyticsStatusSnapshot(
+          enabled: false,
+          eventCount: 0,
+        ),
+      );
+    }
+    return _storage.disableAndClear();
+  }
+
+  Future<AnalyticsAck> _handleShutdown(
+    AnalyticsShutdownRequest request, {
+    RpcContext? context,
+  }) async {
+    if (_disposed) {
+      return const AnalyticsAck(success: true, message: 'already disposed');
+    }
+
+    await _storage.dispose();
+    _disposed = true;
+    return const AnalyticsAck(success: true, message: 'shutdown');
+  }
+
+  @override
+  void dispose() {
+    if (!_disposed) {
+      // ignore: discarded_futures
+      _storage.dispose();
+      _disposed = true;
+    }
+    super.dispose();
+  }
+}
+
+final class AnalyticsStorageManager {
+  AnalyticsStorageManager._({
+    required DriftDataStorageAdapter storage,
+    required bool enabled,
+  })  : _storage = storage,
+        _enabled = enabled;
+
+  static Future<AnalyticsStorageManager> open({
+    required String databasePath,
+    required Uint8List encryptionKey,
+    required bool enabledByDefault,
+    required bool logSqlStatements,
+  }) async {
+    final file = File(databasePath);
+    file.parent.createSync(recursive: true);
+    final adapter = DriftDataStorageAdapter.file(
+      file,
+      logStatements: logSqlStatements,
+      sqlCipherKey: SqlCipherKey.fromBytes(
+        keyBytes: Uint8List.fromList(encryptionKey),
+      ),
+    );
+    await adapter.ensureReady();
+    final manager = AnalyticsStorageManager._(
+      storage: adapter,
+      enabled: enabledByDefault,
+    );
+    await manager._ensureSchema();
+    return manager;
+  }
+
+  final DriftDataStorageAdapter _storage;
+  bool _enabled;
+  bool _schemaReady = false;
+
+  Future<void> _ensureSchema() async {
+    if (_schemaReady) return;
+
+    await _storage.database.customStatement(
+      'CREATE TABLE IF NOT EXISTS analytics_events ('
+      'id INTEGER PRIMARY KEY AUTOINCREMENT,'
+      'event_name TEXT NOT NULL,'
+      'properties_json TEXT,'
+      'created_at_ms INTEGER NOT NULL'
+      ')',
+    );
+
+    await _storage.database.customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_analytics_events_created_at '
+      'ON analytics_events(created_at_ms)',
+    );
+
+    _schemaReady = true;
+  }
+
+  Future<bool> insertEvent(AnalyticsLogEventRequest request) async {
+    if (!_enabled) {
+      return false;
+    }
+
+    await _ensureSchema();
+    final payload = request.properties == null
+        ? null
+        : jsonEncode(request.properties);
+
+    await _storage.database.customStatement(
+      'INSERT INTO analytics_events (event_name, properties_json, created_at_ms) '
+      'VALUES (?, ?, ?)',
+      <Object?>[
+        request.eventName,
+        payload,
+        request.timestamp.toUtc().millisecondsSinceEpoch,
+      ],
+    );
+
+    return true;
+  }
+
+  Future<AnalyticsStatusSnapshot> setEnabled(bool enabled) async {
+    _enabled = enabled;
+    return snapshot();
+  }
+
+  Future<AnalyticsStatusSnapshot> clear() async {
+    await _ensureSchema();
+    await _storage.database.customStatement('DELETE FROM analytics_events');
+    return snapshot();
+  }
+
+  Future<AnalyticsStatusSnapshot> disableAndClear() async {
+    _enabled = false;
+    await _ensureSchema();
+    await _storage.database.customStatement('DELETE FROM analytics_events');
+    return snapshot();
+  }
+
+  Future<AnalyticsStatusSnapshot> snapshot() async {
+    await _ensureSchema();
+    final countRows = await _storage.database
+        .customSelect('SELECT COUNT(*) AS cnt FROM analytics_events')
+        .getSingle();
+    final count = countRows.read<int>('cnt');
+
+    DateTime? lastEventAt;
+    if (count > 0) {
+      final lastRow = await _storage.database
+          .customSelect(
+            'SELECT MAX(created_at_ms) AS last FROM analytics_events',
+          )
+          .getSingle();
+      final lastValue = lastRow.read<int?>('last');
+      if (lastValue != null) {
+        lastEventAt =
+            DateTime.fromMillisecondsSinceEpoch(lastValue, isUtc: true).toUtc();
+      }
+    }
+
+    return AnalyticsStatusSnapshot(
+      enabled: _enabled,
+      eventCount: count,
+      lastEventAt: lastEventAt,
+    );
+  }
+
+  Future<void> dispose() async {
+    await _storage.dispose();
+  }
+}

--- a/packages/rpc_dart_analytics/lib/src/analytics_worker.dart
+++ b/packages/rpc_dart_analytics/lib/src/analytics_worker.dart
@@ -23,6 +23,7 @@ void analyticsWorkerEntrypoint(
         publicKey: config.licenseKey,
         enabledByDefault: config.enabledByDefault,
         logSqlStatements: config.logSqlStatements,
+        diagnosticsOptions: config.diagnosticsOptions,
       );
 
       final endpoint = RpcResponderEndpoint(
@@ -47,6 +48,7 @@ class _WorkerBootstrapParams {
     required this.licenseKey,
     required this.enabledByDefault,
     required this.logSqlStatements,
+    required this.diagnosticsOptions,
   });
 
   factory _WorkerBootstrapParams.fromMap(Map<String, dynamic> raw) {
@@ -67,6 +69,9 @@ class _WorkerBootstrapParams {
       licenseKey: licenseKey,
       enabledByDefault: raw['enabled'] as bool? ?? true,
       logSqlStatements: raw['logStatements'] as bool? ?? false,
+      diagnosticsOptions: AnalyticsDiagnosticsOptions.fromMap(
+        raw['diagnostics'],
+      ),
     );
   }
 
@@ -74,6 +79,32 @@ class _WorkerBootstrapParams {
   final LicensifyPublicKey licenseKey;
   final bool enabledByDefault;
   final bool logSqlStatements;
+  final AnalyticsDiagnosticsOptions diagnosticsOptions;
+}
+
+@immutable
+class AnalyticsDiagnosticsOptions {
+  const AnalyticsDiagnosticsOptions({
+    required this.enabled,
+    required this.maxEvents,
+  });
+
+  factory AnalyticsDiagnosticsOptions.fromMap(dynamic raw) {
+    if (raw is! Map) {
+      return const AnalyticsDiagnosticsOptions(enabled: false, maxEvents: 200);
+    }
+
+    final map = Map<String, dynamic>.from(raw as Map);
+    final enabled = map['enabled'] as bool? ?? false;
+    final maxEvents = map['maxEvents'] as int? ?? 200;
+    return AnalyticsDiagnosticsOptions(
+      enabled: enabled,
+      maxEvents: maxEvents > 0 ? maxEvents : 200,
+    );
+  }
+
+  final bool enabled;
+  final int maxEvents;
 }
 
 final class AnalyticsResponder extends RpcResponderContract {
@@ -130,6 +161,13 @@ final class AnalyticsResponder extends RpcResponderContract {
       requestCodec: AnalyticsShutdownRequest.codec,
       responseCodec: AnalyticsAck.codec,
       handler: _handleShutdown,
+    );
+
+    addUnaryMethod<AnalyticsDiagnosticsRequest, AnalyticsDiagnosticsSnapshot>(
+      methodName: AnalyticsContract.methodDiagnostics,
+      requestCodec: AnalyticsDiagnosticsRequest.codec,
+      responseCodec: AnalyticsDiagnosticsSnapshot.codec,
+      handler: _handleDiagnostics,
     );
   }
 
@@ -218,6 +256,22 @@ final class AnalyticsResponder extends RpcResponderContract {
     }
     super.dispose();
   }
+
+  Future<AnalyticsDiagnosticsSnapshot> _handleDiagnostics(
+    AnalyticsDiagnosticsRequest request, {
+    RpcContext? context,
+  }) {
+    if (_disposed) {
+      return Future.value(
+        const AnalyticsDiagnosticsSnapshot(
+          diagnosticsEnabled: false,
+          recentEvents: <AnalyticsDiagnosticsEvent>[],
+          status: AnalyticsStatusSnapshot(enabled: false, eventCount: 0),
+        ),
+      );
+    }
+    return _storage.diagnosticsSnapshot();
+  }
 }
 
 final class AnalyticsStorageManager {
@@ -225,15 +279,18 @@ final class AnalyticsStorageManager {
     required DriftDataStorageAdapter storage,
     required LicensifyPublicKey publicKey,
     required bool enabled,
+    required AnalyticsDiagnosticsController diagnostics,
   })  : _storage = storage,
         _publicKey = publicKey,
-        _enabled = enabled;
+        _enabled = enabled,
+        _diagnostics = diagnostics;
 
   static Future<AnalyticsStorageManager> open({
     required String databasePath,
     required LicensifyPublicKey publicKey,
     required bool enabledByDefault,
     required bool logSqlStatements,
+    required AnalyticsDiagnosticsOptions diagnosticsOptions,
   }) async {
     final file = File(databasePath);
     file.parent.createSync(recursive: true);
@@ -242,10 +299,16 @@ final class AnalyticsStorageManager {
       logStatements: logSqlStatements,
     );
     await adapter.ensureReady();
+    final diagnostics = diagnosticsOptions.enabled
+        ? AnalyticsDiagnosticsController.enabled(
+            maxEvents: diagnosticsOptions.maxEvents,
+          )
+        : AnalyticsDiagnosticsController.disabled();
     final manager = AnalyticsStorageManager._(
       storage: adapter,
       publicKey: publicKey,
       enabled: enabledByDefault,
+      diagnostics: diagnostics,
     );
     await manager._ensureSchema();
     return manager;
@@ -255,6 +318,7 @@ final class AnalyticsStorageManager {
   final LicensifyPublicKey _publicKey;
   bool _enabled;
   bool _schemaReady = false;
+  final AnalyticsDiagnosticsController _diagnostics;
 
   Future<void> _ensureSchema() async {
     if (_schemaReady) return;
@@ -276,6 +340,15 @@ final class AnalyticsStorageManager {
     }
 
     await _ensureSchema();
+    final diagnosticsEvent = _diagnostics.enabled
+        ? AnalyticsDiagnosticsEvent(
+            eventName: request.eventName,
+            timestamp: request.timestamp.toUtc(),
+            properties: request.properties == null
+                ? null
+                : Map<String, dynamic>.from(request.properties!),
+          )
+        : null;
     final encryptedToken = await Licensify.encryptDataForPublicKey(
       data: <String, dynamic>{
         'event': request.eventName,
@@ -294,6 +367,10 @@ final class AnalyticsStorageManager {
       ],
     );
 
+    if (diagnosticsEvent != null) {
+      _diagnostics.record(diagnosticsEvent);
+    }
+
     return true;
   }
 
@@ -305,6 +382,7 @@ final class AnalyticsStorageManager {
   Future<AnalyticsStatusSnapshot> clear() async {
     await _ensureSchema();
     await _storage.database.customStatement('DELETE FROM analytics_events');
+    _diagnostics.clear();
     return snapshot();
   }
 
@@ -312,6 +390,7 @@ final class AnalyticsStorageManager {
     _enabled = false;
     await _ensureSchema();
     await _storage.database.customStatement('DELETE FROM analytics_events');
+    _diagnostics.clear();
     return snapshot();
   }
 
@@ -344,6 +423,52 @@ final class AnalyticsStorageManager {
   }
 
   Future<void> dispose() async {
+    _diagnostics.clear();
     await _storage.dispose();
+  }
+
+  Future<AnalyticsDiagnosticsSnapshot> diagnosticsSnapshot() async {
+    final status = await snapshot();
+    return AnalyticsDiagnosticsSnapshot(
+      diagnosticsEnabled: _diagnostics.enabled,
+      recentEvents: _diagnostics.snapshot(),
+      status: status,
+    );
+  }
+}
+
+final class AnalyticsDiagnosticsController {
+  AnalyticsDiagnosticsController.disabled()
+      : enabled = false,
+        maxEvents = 0,
+        _buffer = <AnalyticsDiagnosticsEvent>[];
+
+  AnalyticsDiagnosticsController.enabled({required this.maxEvents})
+      : enabled = true,
+        _buffer = <AnalyticsDiagnosticsEvent>[];
+
+  final bool enabled;
+  final int maxEvents;
+  final List<AnalyticsDiagnosticsEvent> _buffer;
+
+  void record(AnalyticsDiagnosticsEvent event) {
+    if (!enabled) {
+      return;
+    }
+    _buffer.add(event);
+    if (_buffer.length > maxEvents) {
+      _buffer.removeAt(0);
+    }
+  }
+
+  void clear() {
+    _buffer.clear();
+  }
+
+  List<AnalyticsDiagnosticsEvent> snapshot() {
+    if (!enabled) {
+      return const <AnalyticsDiagnosticsEvent>[];
+    }
+    return List<AnalyticsDiagnosticsEvent>.unmodifiable(_buffer);
   }
 }

--- a/packages/rpc_dart_analytics/lib/src/analytics_worker.dart
+++ b/packages/rpc_dart_analytics/lib/src/analytics_worker.dart
@@ -169,6 +169,20 @@ final class AnalyticsResponder extends RpcResponderContract {
       responseCodec: AnalyticsDiagnosticsSnapshot.codec,
       handler: _handleDiagnostics,
     );
+
+    addUnaryMethod<AnalyticsUploadFetchRequest, AnalyticsUploadBatch>(
+      methodName: AnalyticsContract.methodFetchForUpload,
+      requestCodec: AnalyticsUploadFetchRequest.codec,
+      responseCodec: AnalyticsUploadBatch.codec,
+      handler: _handleFetchForUpload,
+    );
+
+    addUnaryMethod<AnalyticsUploadAcknowledgeRequest, AnalyticsAck>(
+      methodName: AnalyticsContract.methodAcknowledgeUpload,
+      requestCodec: AnalyticsUploadAcknowledgeRequest.codec,
+      responseCodec: AnalyticsAck.codec,
+      handler: _handleAcknowledgeUpload,
+    );
   }
 
   Future<AnalyticsAck> _handleLogEvent(
@@ -271,6 +285,33 @@ final class AnalyticsResponder extends RpcResponderContract {
       );
     }
     return _storage.diagnosticsSnapshot();
+  }
+
+  Future<AnalyticsUploadBatch> _handleFetchForUpload(
+    AnalyticsUploadFetchRequest request, {
+    RpcContext? context,
+  }) {
+    if (_disposed) {
+      return Future.value(
+        const AnalyticsUploadBatch(
+          events: <AnalyticsUploadEnvelope>[],
+          hasMore: false,
+        ),
+      );
+    }
+    return _storage.fetchForUpload(limit: request.limit);
+  }
+
+  Future<AnalyticsAck> _handleAcknowledgeUpload(
+    AnalyticsUploadAcknowledgeRequest request, {
+    RpcContext? context,
+  }) async {
+    if (_disposed) {
+      return const AnalyticsAck(success: false, message: 'analytics storage disposed');
+    }
+
+    await _storage.acknowledgeUpload(request.eventIds);
+    return const AnalyticsAck(success: true, message: 'acknowledged');
   }
 }
 
@@ -433,6 +474,57 @@ final class AnalyticsStorageManager {
       diagnosticsEnabled: _diagnostics.enabled,
       recentEvents: _diagnostics.snapshot(),
       status: status,
+    );
+  }
+
+  Future<AnalyticsUploadBatch> fetchForUpload({required int limit}) async {
+    await _ensureSchema();
+    final rows = await _storage.database
+        .customSelect(
+          'SELECT id, created_at_ms, encrypted_token '
+          'FROM analytics_events ORDER BY id ASC LIMIT ?',
+          <Object?>[limit],
+        )
+        .get();
+
+    final events = rows
+        .map(
+          (row) => AnalyticsUploadEnvelope(
+            id: row.read<int>('id'),
+            createdAt: DateTime.fromMillisecondsSinceEpoch(
+              row.read<int>('created_at_ms'),
+              isUtc: true,
+            ).toUtc(),
+            encryptedToken: row.read<String>('encrypted_token'),
+          ),
+        )
+        .toList(growable: false);
+
+    var hasMore = false;
+    if (events.length == limit && events.isNotEmpty) {
+      final lastId = events.last.id;
+      final moreRow = await _storage.database
+          .customSelect(
+            'SELECT EXISTS(SELECT 1 FROM analytics_events WHERE id > ?) AS more',
+            <Object?>[lastId],
+          )
+          .getSingle();
+      hasMore = moreRow.read<int>('more') == 1;
+    }
+
+    return AnalyticsUploadBatch(events: events, hasMore: hasMore);
+  }
+
+  Future<void> acknowledgeUpload(List<int> eventIds) async {
+    if (eventIds.isEmpty) {
+      return;
+    }
+
+    await _ensureSchema();
+    final placeholders = List<String>.filled(eventIds.length, '?').join(',');
+    await _storage.database.customStatement(
+      'DELETE FROM analytics_events WHERE id IN ($placeholders)',
+      eventIds.cast<Object?>(),
     );
   }
 }

--- a/packages/rpc_dart_analytics/lib/src/analytics_worker.dart
+++ b/packages/rpc_dart_analytics/lib/src/analytics_worker.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
+import 'package:licensify/licensify.dart';
 import 'package:rpc_dart/rpc_dart.dart';
 import 'package:rpc_dart_data/rpc_dart_data.dart';
 
@@ -21,7 +20,7 @@ void analyticsWorkerEntrypoint(
       final config = _WorkerBootstrapParams.fromMap(customParams);
       final storage = await AnalyticsStorageManager.open(
         databasePath: config.databasePath,
-        encryptionKey: config.encryptionKey,
+        publicKey: config.licenseKey,
         enabledByDefault: config.enabledByDefault,
         logSqlStatements: config.logSqlStatements,
       );
@@ -45,21 +44,18 @@ void analyticsWorkerEntrypoint(
 class _WorkerBootstrapParams {
   const _WorkerBootstrapParams({
     required this.databasePath,
-    required this.encryptionKey,
+    required this.licenseKey,
     required this.enabledByDefault,
     required this.logSqlStatements,
   });
 
   factory _WorkerBootstrapParams.fromMap(Map<String, dynamic> raw) {
-    final keyData = raw['encryptionKey'];
-    late final Uint8List encryptionKey;
-    if (keyData is Uint8List) {
-      encryptionKey = Uint8List.fromList(keyData);
-    } else if (keyData is List<int>) {
-      encryptionKey = Uint8List.fromList(keyData);
-    } else {
-      throw ArgumentError('Invalid encryptionKey payload: ${keyData.runtimeType}');
+    final keyPaserk = raw['licenseKeyPaserk'];
+    if (keyPaserk is! String || keyPaserk.trim().isEmpty) {
+      throw ArgumentError('licenseKeyPaserk must be a non-empty string');
     }
+
+    final licenseKey = LicensifyPublicKey.fromPaserk(paserk: keyPaserk.trim());
 
     final databasePath = raw['databasePath'] as String?;
     if (databasePath == null || databasePath.isEmpty) {
@@ -68,14 +64,14 @@ class _WorkerBootstrapParams {
 
     return _WorkerBootstrapParams(
       databasePath: databasePath,
-      encryptionKey: encryptionKey,
+      licenseKey: licenseKey,
       enabledByDefault: raw['enabled'] as bool? ?? true,
       logSqlStatements: raw['logStatements'] as bool? ?? false,
     );
   }
 
   final String databasePath;
-  final Uint8List encryptionKey;
+  final LicensifyPublicKey licenseKey;
   final bool enabledByDefault;
   final bool logSqlStatements;
 }
@@ -227,13 +223,15 @@ final class AnalyticsResponder extends RpcResponderContract {
 final class AnalyticsStorageManager {
   AnalyticsStorageManager._({
     required DriftDataStorageAdapter storage,
+    required LicensifyPublicKey publicKey,
     required bool enabled,
   })  : _storage = storage,
+        _publicKey = publicKey,
         _enabled = enabled;
 
   static Future<AnalyticsStorageManager> open({
     required String databasePath,
-    required Uint8List encryptionKey,
+    required LicensifyPublicKey publicKey,
     required bool enabledByDefault,
     required bool logSqlStatements,
   }) async {
@@ -242,13 +240,11 @@ final class AnalyticsStorageManager {
     final adapter = DriftDataStorageAdapter.file(
       file,
       logStatements: logSqlStatements,
-      sqlCipherKey: SqlCipherKey.fromBytes(
-        keyBytes: Uint8List.fromList(encryptionKey),
-      ),
     );
     await adapter.ensureReady();
     final manager = AnalyticsStorageManager._(
       storage: adapter,
+      publicKey: publicKey,
       enabled: enabledByDefault,
     );
     await manager._ensureSchema();
@@ -256,6 +252,7 @@ final class AnalyticsStorageManager {
   }
 
   final DriftDataStorageAdapter _storage;
+  final LicensifyPublicKey _publicKey;
   bool _enabled;
   bool _schemaReady = false;
 
@@ -265,15 +262,9 @@ final class AnalyticsStorageManager {
     await _storage.database.customStatement(
       'CREATE TABLE IF NOT EXISTS analytics_events ('
       'id INTEGER PRIMARY KEY AUTOINCREMENT,'
-      'event_name TEXT NOT NULL,'
-      'properties_json TEXT,'
-      'created_at_ms INTEGER NOT NULL'
+      'created_at_ms INTEGER NOT NULL,'
+      'encrypted_token TEXT NOT NULL'
       ')',
-    );
-
-    await _storage.database.customStatement(
-      'CREATE INDEX IF NOT EXISTS idx_analytics_events_created_at '
-      'ON analytics_events(created_at_ms)',
     );
 
     _schemaReady = true;
@@ -285,17 +276,21 @@ final class AnalyticsStorageManager {
     }
 
     await _ensureSchema();
-    final payload = request.properties == null
-        ? null
-        : jsonEncode(request.properties);
+    final encryptedToken = await Licensify.encryptDataForPublicKey(
+      data: <String, dynamic>{
+        'event': request.eventName,
+        'timestamp': request.timestamp.toUtc().toIso8601String(),
+        if (request.properties != null) 'properties': request.properties!,
+      },
+      publicKey: _publicKey,
+    );
 
     await _storage.database.customStatement(
-      'INSERT INTO analytics_events (event_name, properties_json, created_at_ms) '
-      'VALUES (?, ?, ?)',
+      'INSERT INTO analytics_events (created_at_ms, encrypted_token) '
+      'VALUES (?, ?)',
       <Object?>[
-        request.eventName,
-        payload,
-        request.timestamp.toUtc().millisecondsSinceEpoch,
+        DateTime.now().toUtc().millisecondsSinceEpoch,
+        encryptedToken,
       ],
     );
 

--- a/packages/rpc_dart_analytics/lib/src/config.dart
+++ b/packages/rpc_dart_analytics/lib/src/config.dart
@@ -1,4 +1,3 @@
-import 'package:licensify/licensify.dart';
 import 'package:meta/meta.dart';
 
 /// Immutable runtime configuration for [RpcAnalytics].
@@ -6,14 +5,18 @@ import 'package:meta/meta.dart';
 class RpcAnalyticsConfig {
   /// Creates configuration for the analytics runtime.
   const RpcAnalyticsConfig({
-    required this.licenseKey,
+    required this.licenseKeyPaserk,
     required this.databasePath,
     this.enabledByDefault = true,
     this.logSqlStatements = false,
-  }) : assert(databasePath != '', 'databasePath must not be empty');
+  })  : assert(databasePath != '', 'databasePath must not be empty'),
+        assert(
+          licenseKeyPaserk.trim().startsWith('k4.public'),
+          'licenseKeyPaserk must be a PASERK k4.public string',
+        );
 
-  /// The application-level Licensify key required for the analytics runtime.
-  final LicensifyPublicKey licenseKey;
+  /// The PASERK `k4.public` string required for the analytics runtime.
+  final String licenseKeyPaserk;
 
   /// Absolute path to the encrypted SQLite database on the device.
   final String databasePath;

--- a/packages/rpc_dart_analytics/lib/src/config.dart
+++ b/packages/rpc_dart_analytics/lib/src/config.dart
@@ -1,0 +1,26 @@
+import 'package:licensify/licensify.dart';
+import 'package:meta/meta.dart';
+
+/// Immutable runtime configuration for [RpcAnalytics].
+@immutable
+class RpcAnalyticsConfig {
+  /// Creates configuration for the analytics runtime.
+  const RpcAnalyticsConfig({
+    required this.licenseKey,
+    required this.databasePath,
+    this.enabledByDefault = true,
+    this.logSqlStatements = false,
+  }) : assert(databasePath != '', 'databasePath must not be empty');
+
+  /// The application-level Licensify key required for the analytics runtime.
+  final LicensifyPublicKey licenseKey;
+
+  /// Absolute path to the encrypted SQLite database on the device.
+  final String databasePath;
+
+  /// Controls the initial enabled state when the worker spins up.
+  final bool enabledByDefault;
+
+  /// Enables verbose SQL logging on the worker side.
+  final bool logSqlStatements;
+}

--- a/packages/rpc_dart_analytics/lib/src/config.dart
+++ b/packages/rpc_dart_analytics/lib/src/config.dart
@@ -1,5 +1,33 @@
 import 'package:meta/meta.dart';
 
+/// Diagnostics settings that control developer tooling support.
+@immutable
+class RpcAnalyticsDiagnosticsOptions {
+  /// Creates options for enabling the developer diagnostics pipeline.
+  const RpcAnalyticsDiagnosticsOptions({
+    this.enabled = false,
+    this.maxEvents = 200,
+  }) : assert(maxEvents > 0, 'maxEvents must be greater than zero');
+
+  /// Convenience constructor that disables diagnostics entirely.
+  const RpcAnalyticsDiagnosticsOptions.disabled()
+      : enabled = false,
+        maxEvents = 200;
+
+  /// Whether diagnostics tooling is active.
+  final bool enabled;
+
+  /// Maximum number of recent events kept in memory for inspection.
+  final int maxEvents;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'enabled': enabled,
+      'maxEvents': maxEvents,
+    };
+  }
+}
+
 /// Immutable runtime configuration for [RpcAnalytics].
 @immutable
 class RpcAnalyticsConfig {
@@ -9,6 +37,7 @@ class RpcAnalyticsConfig {
     required this.databasePath,
     this.enabledByDefault = true,
     this.logSqlStatements = false,
+    this.diagnosticsOptions = const RpcAnalyticsDiagnosticsOptions.disabled(),
   })  : assert(databasePath != '', 'databasePath must not be empty'),
         assert(
           licenseKeyPaserk.trim().startsWith('k4.public'),
@@ -26,4 +55,7 @@ class RpcAnalyticsConfig {
 
   /// Enables verbose SQL logging on the worker side.
   final bool logSqlStatements;
+
+  /// Controls developer diagnostics buffers and APIs.
+  final RpcAnalyticsDiagnosticsOptions diagnosticsOptions;
 }

--- a/packages/rpc_dart_analytics/lib/src/messages.dart
+++ b/packages/rpc_dart_analytics/lib/src/messages.dart
@@ -13,6 +13,7 @@ final class AnalyticsContract {
   static const String methodDisableAndClear = 'disableAndClear';
   static const String methodGetStatus = 'getStatus';
   static const String methodShutdown = 'shutdown';
+  static const String methodDiagnostics = 'diagnostics';
 }
 
 /// Minimal acknowledgement envelope.
@@ -197,4 +198,105 @@ class AnalyticsShutdownRequest implements IRpcSerializable {
 
   @override
   Map<String, dynamic> toJson() => const <String, dynamic>{};
+}
+
+/// Request for retrieving diagnostics information.
+@immutable
+class AnalyticsDiagnosticsRequest implements IRpcSerializable {
+  const AnalyticsDiagnosticsRequest();
+
+  static const RpcCodec<AnalyticsDiagnosticsRequest> codec =
+      RpcCodec<AnalyticsDiagnosticsRequest>.withDecoder(
+    AnalyticsDiagnosticsRequest.fromJson,
+  );
+
+  static AnalyticsDiagnosticsRequest fromJson(Map<String, dynamic> json) {
+    return const AnalyticsDiagnosticsRequest();
+  }
+
+  @override
+  Map<String, dynamic> toJson() => const <String, dynamic>{};
+}
+
+/// In-memory analytics event kept only for diagnostics tooling.
+@immutable
+class AnalyticsDiagnosticsEvent implements IRpcSerializable {
+  const AnalyticsDiagnosticsEvent({
+    required this.eventName,
+    required this.timestamp,
+    this.properties,
+  });
+
+  final String eventName;
+  final DateTime timestamp;
+  final Map<String, dynamic>? properties;
+
+  static const RpcCodec<AnalyticsDiagnosticsEvent> codec =
+      RpcCodec<AnalyticsDiagnosticsEvent>.withDecoder(
+    AnalyticsDiagnosticsEvent.fromJson,
+  );
+
+  static AnalyticsDiagnosticsEvent fromJson(Map<String, dynamic> json) {
+    final rawProperties = json['properties'];
+    return AnalyticsDiagnosticsEvent(
+      eventName: json['eventName'] as String? ?? '',
+      timestamp: DateTime.parse(json['timestamp'] as String).toUtc(),
+      properties: rawProperties == null
+          ? null
+          : Map<String, dynamic>.from(rawProperties as Map),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'eventName': eventName,
+      'timestamp': timestamp.toUtc().toIso8601String(),
+      if (properties != null) 'properties': properties,
+    };
+  }
+}
+
+/// Snapshot with recent diagnostics data for development tooling.
+@immutable
+class AnalyticsDiagnosticsSnapshot implements IRpcSerializable {
+  const AnalyticsDiagnosticsSnapshot({
+    required this.diagnosticsEnabled,
+    required this.recentEvents,
+    required this.status,
+  });
+
+  final bool diagnosticsEnabled;
+  final List<AnalyticsDiagnosticsEvent> recentEvents;
+  final AnalyticsStatusSnapshot status;
+
+  static const RpcCodec<AnalyticsDiagnosticsSnapshot> codec =
+      RpcCodec<AnalyticsDiagnosticsSnapshot>.withDecoder(
+    AnalyticsDiagnosticsSnapshot.fromJson,
+  );
+
+  static AnalyticsDiagnosticsSnapshot fromJson(Map<String, dynamic> json) {
+    final events = json['recentEvents'] as List<dynamic>?;
+    return AnalyticsDiagnosticsSnapshot(
+      diagnosticsEnabled: json['diagnosticsEnabled'] as bool? ?? false,
+      recentEvents: events == null
+          ? const <AnalyticsDiagnosticsEvent>[]
+          : events
+              .map((dynamic raw) =>
+                  AnalyticsDiagnosticsEvent.fromJson(Map<String, dynamic>.from(raw as Map)))
+              .toList(growable: false),
+      status: AnalyticsStatusSnapshot.fromJson(
+        Map<String, dynamic>.from(json['status'] as Map),
+      ),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'diagnosticsEnabled': diagnosticsEnabled,
+      'recentEvents': recentEvents.map((e) => e.toJson()).toList(growable: false),
+      'status': status.toJson(),
+    };
+  }
 }

--- a/packages/rpc_dart_analytics/lib/src/messages.dart
+++ b/packages/rpc_dart_analytics/lib/src/messages.dart
@@ -1,0 +1,200 @@
+import 'package:meta/meta.dart';
+import 'package:rpc_dart/rpc_dart.dart';
+
+/// RPC contract identifiers shared between the analytics caller and responder.
+@immutable
+final class AnalyticsContract {
+  const AnalyticsContract._();
+
+  static const String serviceName = 'rpc.dart.analytics';
+  static const String methodLogEvent = 'logEvent';
+  static const String methodSetEnabled = 'setEnabled';
+  static const String methodClear = 'clear';
+  static const String methodDisableAndClear = 'disableAndClear';
+  static const String methodGetStatus = 'getStatus';
+  static const String methodShutdown = 'shutdown';
+}
+
+/// Minimal acknowledgement envelope.
+@immutable
+class AnalyticsAck implements IRpcSerializable {
+  const AnalyticsAck({
+    required this.success,
+    this.message,
+  });
+
+  final bool success;
+  final String? message;
+
+  static const RpcCodec<AnalyticsAck> codec =
+      RpcCodec<AnalyticsAck>.withDecoder(AnalyticsAck.fromJson);
+
+  static AnalyticsAck fromJson(Map<String, dynamic> json) {
+    return AnalyticsAck(
+      success: json['success'] as bool? ?? false,
+      message: json['message'] as String?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'success': success,
+      if (message != null) 'message': message,
+    };
+  }
+}
+
+/// Request payload for writing an analytics event.
+@immutable
+class AnalyticsLogEventRequest implements IRpcSerializable {
+  const AnalyticsLogEventRequest({
+    required this.eventName,
+    this.properties,
+    required this.timestamp,
+  });
+
+  final String eventName;
+  final Map<String, dynamic>? properties;
+  final DateTime timestamp;
+
+  static const RpcCodec<AnalyticsLogEventRequest> codec =
+      RpcCodec<AnalyticsLogEventRequest>.withDecoder(
+    AnalyticsLogEventRequest.fromJson,
+  );
+
+  static AnalyticsLogEventRequest fromJson(Map<String, dynamic> json) {
+    final rawProperties = json['properties'];
+    return AnalyticsLogEventRequest(
+      eventName: json['eventName'] as String? ?? '',
+      properties: rawProperties == null
+          ? null
+          : Map<String, dynamic>.from(rawProperties as Map),
+      timestamp: DateTime.parse(json['timestamp'] as String),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'eventName': eventName,
+      if (properties != null) 'properties': properties,
+      'timestamp': timestamp.toUtc().toIso8601String(),
+    };
+  }
+}
+
+/// Request that toggles the analytics enabled state.
+@immutable
+class AnalyticsSetEnabledRequest implements IRpcSerializable {
+  const AnalyticsSetEnabledRequest(this.enabled);
+
+  final bool enabled;
+
+  static const RpcCodec<AnalyticsSetEnabledRequest> codec =
+      RpcCodec<AnalyticsSetEnabledRequest>.withDecoder(
+    AnalyticsSetEnabledRequest.fromJson,
+  );
+
+  static AnalyticsSetEnabledRequest fromJson(Map<String, dynamic> json) {
+    return AnalyticsSetEnabledRequest(json['enabled'] as bool? ?? true);
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{'enabled': enabled};
+  }
+}
+
+/// Snapshot returned back to the Flutter isolate with storage metadata.
+@immutable
+class AnalyticsStatusSnapshot implements IRpcSerializable {
+  const AnalyticsStatusSnapshot({
+    required this.enabled,
+    required this.eventCount,
+    this.lastEventAt,
+  });
+
+  final bool enabled;
+  final int eventCount;
+  final DateTime? lastEventAt;
+
+  static const RpcCodec<AnalyticsStatusSnapshot> codec =
+      RpcCodec<AnalyticsStatusSnapshot>.withDecoder(
+    AnalyticsStatusSnapshot.fromJson,
+  );
+
+  static AnalyticsStatusSnapshot fromJson(Map<String, dynamic> json) {
+    final lastTimestamp = json['lastEventAt'] as String?;
+    return AnalyticsStatusSnapshot(
+      enabled: json['enabled'] as bool? ?? false,
+      eventCount: json['eventCount'] as int? ?? 0,
+      lastEventAt:
+          lastTimestamp == null ? null : DateTime.parse(lastTimestamp).toUtc(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'enabled': enabled,
+      'eventCount': eventCount,
+      if (lastEventAt != null)
+        'lastEventAt': lastEventAt!.toUtc().toIso8601String(),
+    };
+  }
+}
+
+/// Command that clears all stored analytics events.
+@immutable
+class AnalyticsClearRequest implements IRpcSerializable {
+  const AnalyticsClearRequest();
+
+  static const RpcCodec<AnalyticsClearRequest> codec =
+      RpcCodec<AnalyticsClearRequest>.withDecoder(
+    AnalyticsClearRequest.fromJson,
+  );
+
+  static AnalyticsClearRequest fromJson(Map<String, dynamic> json) {
+    return const AnalyticsClearRequest();
+  }
+
+  @override
+  Map<String, dynamic> toJson() => const <String, dynamic>{};
+}
+
+/// Combined disable + clear command envelope.
+@immutable
+class AnalyticsDisableAndClearRequest implements IRpcSerializable {
+  const AnalyticsDisableAndClearRequest();
+
+  static const RpcCodec<AnalyticsDisableAndClearRequest> codec =
+      RpcCodec<AnalyticsDisableAndClearRequest>.withDecoder(
+    AnalyticsDisableAndClearRequest.fromJson,
+  );
+
+  static AnalyticsDisableAndClearRequest fromJson(Map<String, dynamic> json) {
+    return const AnalyticsDisableAndClearRequest();
+  }
+
+  @override
+  Map<String, dynamic> toJson() => const <String, dynamic>{};
+}
+
+/// Final shutdown command that tells the worker to release resources.
+@immutable
+class AnalyticsShutdownRequest implements IRpcSerializable {
+  const AnalyticsShutdownRequest();
+
+  static const RpcCodec<AnalyticsShutdownRequest> codec =
+      RpcCodec<AnalyticsShutdownRequest>.withDecoder(
+    AnalyticsShutdownRequest.fromJson,
+  );
+
+  static AnalyticsShutdownRequest fromJson(Map<String, dynamic> json) {
+    return const AnalyticsShutdownRequest();
+  }
+
+  @override
+  Map<String, dynamic> toJson() => const <String, dynamic>{};
+}

--- a/packages/rpc_dart_analytics/lib/src/messages.dart
+++ b/packages/rpc_dart_analytics/lib/src/messages.dart
@@ -54,11 +54,13 @@ class AnalyticsLogEventRequest implements IRpcSerializable {
   const AnalyticsLogEventRequest({
     required this.eventName,
     this.properties,
+    this.deliveryHints,
     required this.timestamp,
   });
 
   final String eventName;
   final Map<String, dynamic>? properties;
+  final Map<String, dynamic>? deliveryHints;
   final DateTime timestamp;
 
   static const RpcCodec<AnalyticsLogEventRequest> codec =
@@ -68,11 +70,15 @@ class AnalyticsLogEventRequest implements IRpcSerializable {
 
   static AnalyticsLogEventRequest fromJson(Map<String, dynamic> json) {
     final rawProperties = json['properties'];
+    final rawHints = json['deliveryHints'];
     return AnalyticsLogEventRequest(
       eventName: json['eventName'] as String? ?? '',
       properties: rawProperties == null
           ? null
           : Map<String, dynamic>.from(rawProperties as Map),
+      deliveryHints: rawHints == null
+          ? null
+          : Map<String, dynamic>.from(rawHints as Map),
       timestamp: DateTime.parse(json['timestamp'] as String),
     );
   }
@@ -82,6 +88,7 @@ class AnalyticsLogEventRequest implements IRpcSerializable {
     return <String, dynamic>{
       'eventName': eventName,
       if (properties != null) 'properties': properties,
+      if (deliveryHints != null) 'deliveryHints': deliveryHints,
       'timestamp': timestamp.toUtc().toIso8601String(),
     };
   }
@@ -227,11 +234,13 @@ class AnalyticsDiagnosticsEvent implements IRpcSerializable {
     required this.eventName,
     required this.timestamp,
     this.properties,
+    this.deliveryHints,
   });
 
   final String eventName;
   final DateTime timestamp;
   final Map<String, dynamic>? properties;
+  final Map<String, dynamic>? deliveryHints;
 
   static const RpcCodec<AnalyticsDiagnosticsEvent> codec =
       RpcCodec<AnalyticsDiagnosticsEvent>.withDecoder(
@@ -240,12 +249,16 @@ class AnalyticsDiagnosticsEvent implements IRpcSerializable {
 
   static AnalyticsDiagnosticsEvent fromJson(Map<String, dynamic> json) {
     final rawProperties = json['properties'];
+    final rawHints = json['deliveryHints'];
     return AnalyticsDiagnosticsEvent(
       eventName: json['eventName'] as String? ?? '',
       timestamp: DateTime.parse(json['timestamp'] as String).toUtc(),
       properties: rawProperties == null
           ? null
           : Map<String, dynamic>.from(rawProperties as Map),
+      deliveryHints: rawHints == null
+          ? null
+          : Map<String, dynamic>.from(rawHints as Map),
     );
   }
 
@@ -255,6 +268,7 @@ class AnalyticsDiagnosticsEvent implements IRpcSerializable {
       'eventName': eventName,
       'timestamp': timestamp.toUtc().toIso8601String(),
       if (properties != null) 'properties': properties,
+      if (deliveryHints != null) 'deliveryHints': deliveryHints,
     };
   }
 }
@@ -336,6 +350,7 @@ class AnalyticsUploadEnvelope implements IRpcSerializable {
     required this.id,
     required this.createdAt,
     required this.encryptedToken,
+    this.deliveryHints,
   });
 
   /// Local database identifier, used for acknowledging uploads.
@@ -347,6 +362,9 @@ class AnalyticsUploadEnvelope implements IRpcSerializable {
   /// Licensify-sealed payload to forward to backend storage.
   final String encryptedToken;
 
+  /// Optional routing metadata that stays on-device in plaintext.
+  final Map<String, dynamic>? deliveryHints;
+
   static const RpcCodec<AnalyticsUploadEnvelope> codec =
       RpcCodec<AnalyticsUploadEnvelope>.withDecoder(
     AnalyticsUploadEnvelope.fromJson,
@@ -357,6 +375,9 @@ class AnalyticsUploadEnvelope implements IRpcSerializable {
       id: json['id'] as int? ?? -1,
       createdAt: DateTime.parse(json['createdAt'] as String).toUtc(),
       encryptedToken: json['encryptedToken'] as String? ?? '',
+      deliveryHints: json['deliveryHints'] == null
+          ? null
+          : Map<String, dynamic>.from(json['deliveryHints'] as Map),
     );
   }
 
@@ -366,6 +387,7 @@ class AnalyticsUploadEnvelope implements IRpcSerializable {
       'id': id,
       'createdAt': createdAt.toUtc().toIso8601String(),
       'encryptedToken': encryptedToken,
+      if (deliveryHints != null) 'deliveryHints': deliveryHints,
     };
   }
 }

--- a/packages/rpc_dart_analytics/lib/src/messages.dart
+++ b/packages/rpc_dart_analytics/lib/src/messages.dart
@@ -14,6 +14,8 @@ final class AnalyticsContract {
   static const String methodGetStatus = 'getStatus';
   static const String methodShutdown = 'shutdown';
   static const String methodDiagnostics = 'diagnostics';
+  static const String methodFetchForUpload = 'fetchForUpload';
+  static const String methodAcknowledgeUpload = 'acknowledgeUpload';
 }
 
 /// Minimal acknowledgement envelope.
@@ -297,6 +299,151 @@ class AnalyticsDiagnosticsSnapshot implements IRpcSerializable {
       'diagnosticsEnabled': diagnosticsEnabled,
       'recentEvents': recentEvents.map((e) => e.toJson()).toList(growable: false),
       'status': status.toJson(),
+    };
+  }
+}
+
+/// Request payload for fetching encrypted analytics tokens.
+@immutable
+class AnalyticsUploadFetchRequest implements IRpcSerializable {
+  const AnalyticsUploadFetchRequest({this.limit = 50}) : assert(limit > 0);
+
+  /// Maximum number of events to include in the batch.
+  final int limit;
+
+  static const RpcCodec<AnalyticsUploadFetchRequest> codec =
+      RpcCodec<AnalyticsUploadFetchRequest>.withDecoder(
+    AnalyticsUploadFetchRequest.fromJson,
+  );
+
+  static AnalyticsUploadFetchRequest fromJson(Map<String, dynamic> json) {
+    final limit = json['limit'] as int? ?? 50;
+    return AnalyticsUploadFetchRequest(limit: limit > 0 ? limit : 50);
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'limit': limit,
+    };
+  }
+}
+
+/// A single encrypted analytics event ready for backend upload.
+@immutable
+class AnalyticsUploadEnvelope implements IRpcSerializable {
+  const AnalyticsUploadEnvelope({
+    required this.id,
+    required this.createdAt,
+    required this.encryptedToken,
+  });
+
+  /// Local database identifier, used for acknowledging uploads.
+  final int id;
+
+  /// Timestamp when the event was persisted on-device.
+  final DateTime createdAt;
+
+  /// Licensify-sealed payload to forward to backend storage.
+  final String encryptedToken;
+
+  static const RpcCodec<AnalyticsUploadEnvelope> codec =
+      RpcCodec<AnalyticsUploadEnvelope>.withDecoder(
+    AnalyticsUploadEnvelope.fromJson,
+  );
+
+  static AnalyticsUploadEnvelope fromJson(Map<String, dynamic> json) {
+    return AnalyticsUploadEnvelope(
+      id: json['id'] as int? ?? -1,
+      createdAt: DateTime.parse(json['createdAt'] as String).toUtc(),
+      encryptedToken: json['encryptedToken'] as String? ?? '',
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'createdAt': createdAt.toUtc().toIso8601String(),
+      'encryptedToken': encryptedToken,
+    };
+  }
+}
+
+/// Batch of encrypted analytics events.
+@immutable
+class AnalyticsUploadBatch implements IRpcSerializable {
+  const AnalyticsUploadBatch({
+    required this.events,
+    required this.hasMore,
+  });
+
+  /// Events returned for the current batch.
+  final List<AnalyticsUploadEnvelope> events;
+
+  /// Indicates whether more events remain in the store.
+  final bool hasMore;
+
+  static const RpcCodec<AnalyticsUploadBatch> codec =
+      RpcCodec<AnalyticsUploadBatch>.withDecoder(
+    AnalyticsUploadBatch.fromJson,
+  );
+
+  static AnalyticsUploadBatch fromJson(Map<String, dynamic> json) {
+    final events = json['events'] as List<dynamic>?;
+    return AnalyticsUploadBatch(
+      events: events == null
+          ? const <AnalyticsUploadEnvelope>[]
+          : events
+              .map((dynamic raw) => AnalyticsUploadEnvelope.fromJson(
+                    Map<String, dynamic>.from(raw as Map),
+                  ))
+              .toList(growable: false),
+      hasMore: json['hasMore'] as bool? ?? false,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'events': events.map((e) => e.toJson()).toList(growable: false),
+      'hasMore': hasMore,
+    };
+  }
+}
+
+/// Request payload used to delete uploaded events from local storage.
+@immutable
+class AnalyticsUploadAcknowledgeRequest implements IRpcSerializable {
+  const AnalyticsUploadAcknowledgeRequest({required this.eventIds})
+      : assert(eventIds.length == eventIds.toSet().length,
+            'eventIds should be unique');
+
+  /// Identifiers of events that have been uploaded successfully.
+  final List<int> eventIds;
+
+  static const RpcCodec<AnalyticsUploadAcknowledgeRequest> codec =
+      RpcCodec<AnalyticsUploadAcknowledgeRequest>.withDecoder(
+    AnalyticsUploadAcknowledgeRequest.fromJson,
+  );
+
+  static AnalyticsUploadAcknowledgeRequest fromJson(
+    Map<String, dynamic> json,
+  ) {
+    final rawIds = json['eventIds'];
+    final ids = rawIds is List
+        ? rawIds
+            .whereType<num>()
+            .map((num value) => value.toInt())
+            .toList(growable: false)
+        : const <int>[];
+    return AnalyticsUploadAcknowledgeRequest(eventIds: ids);
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'eventIds': eventIds,
     };
   }
 }

--- a/packages/rpc_dart_analytics/pubspec.yaml
+++ b/packages/rpc_dart_analytics/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rpc_dart_analytics
 description: Privacy-first offline analytics service for Flutter apps built on rpc_dart.
-version: 0.3.0
+version: 0.4.0
 publish_to: none
 
 environment:

--- a/packages/rpc_dart_analytics/pubspec.yaml
+++ b/packages/rpc_dart_analytics/pubspec.yaml
@@ -1,0 +1,31 @@
+name: rpc_dart_analytics
+description: Privacy-first offline analytics service for Flutter apps built on rpc_dart.
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.22.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  rpc_dart: ^2.3.1
+  rpc_dart_data: ^1.1.0
+  rpc_dart_transports: ^1.4.0
+  licensify: ^4.2.0
+  drift: ^2.28.2
+  collection: ^1.19.1
+  meta: ^1.16.0
+  crypto: ^3.0.3
+  path: ^1.9.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  lints: ^5.1.1
+
+flutter:
+  # This is a pure Dart package that depends on Flutter runtime APIs.
+  # The empty section keeps Flutter tooling aware of the package type.
+

--- a/packages/rpc_dart_analytics/pubspec.yaml
+++ b/packages/rpc_dart_analytics/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rpc_dart_analytics
 description: Privacy-first offline analytics service for Flutter apps built on rpc_dart.
-version: 0.2.0
+version: 0.3.0
 publish_to: none
 
 environment:

--- a/packages/rpc_dart_analytics/pubspec.yaml
+++ b/packages/rpc_dart_analytics/pubspec.yaml
@@ -15,10 +15,7 @@ dependencies:
   rpc_dart_transports: ^1.4.0
   licensify: ^4.2.0
   drift: ^2.28.2
-  collection: ^1.19.1
   meta: ^1.16.0
-  crypto: ^3.0.3
-  path: ^1.9.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/rpc_dart_analytics/pubspec.yaml
+++ b/packages/rpc_dart_analytics/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rpc_dart_analytics
 description: Privacy-first offline analytics service for Flutter apps built on rpc_dart.
-version: 0.1.0
+version: 0.2.0
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Summary
- add the new `rpc_dart_analytics` Flutter package with documentation and lint configuration
- implement an isolate-backed analytics worker that stores encrypted events through `rpc_dart_data`
- expose a client API that requires a `LicensifyPublicKey`, allows toggling analytics, and can wipe all stored data

## Testing
- Not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f7b5d7c678833395b316b7033bfd46